### PR TITLE
Fast structured sexual

### DIFF
--- a/tests/devtest_faststructuredsexual.py
+++ b/tests/devtest_faststructuredsexual.py
@@ -1,0 +1,32 @@
+"""
+Compare performance and results of regular & fast StructuredSexual.
+
+Timings:
+      10k  20k
+rand  0.5  0.6
+slow 14.8 94.3
+fast  0.7  1.1
+"""
+
+import sciris as sc
+import starsim as ss
+import stisim as sti
+
+kw = dict(n_agents=20e3)
+
+s0 = ss.Sim(diseases='sis', networks='random', **kw)
+s1 = ss.Sim(diseases='sis', networks=sti.StructuredSexual(), **kw)
+s2 = ss.Sim(diseases='sis', networks=sti.FastStructuredSexual(), **kw)
+
+with sc.timer('random'):
+    s0.run()
+    
+with sc.timer('StructuredSexual'):
+    s1.run()
+    
+with sc.timer('FastStructuredSexual'):
+    s2.run()
+    
+    
+for sim in [s0, s1, s2]:
+    sim.plot()


### PR DESCRIPTION
Adds a fast version of `StructuredSexual` that's about 20x faster for 10k agents and nearly 100x faster for 20k agents. Results are similar but not identical, and are **not** CRN-safe:
![image](https://github.com/starsimhub/stisim/assets/3239256/4528cb6c-ffae-41f6-9529-dcea7770ac93)

```py
"""
Compare performance and results of regular & fast StructuredSexual.

Timings:
      10k  20k
rand  0.5  0.6
slow 14.8 94.3
fast  0.7  1.1
"""

import sciris as sc
import starsim as ss
import stisim as sti

kw = dict(n_agents=20e3)

s0 = ss.Sim(diseases='sis', networks='random', **kw)
s1 = ss.Sim(diseases='sis', networks=sti.StructuredSexual(), **kw)
s2 = ss.Sim(diseases='sis', networks=sti.FastStructuredSexual(), **kw)

with sc.timer('random'):
    s0.run()
    
with sc.timer('StructuredSexual'):
    s1.run()
    
with sc.timer('FastStructuredSexual'):
    s2.run()
    
    
for sim in [s0, s1, s2]:
    sim.plot()
```