### PR TITLE
update diseases to require 'structuredsexual' name

### DIFF
--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -15,7 +15,7 @@ class HIV(ss.Infection):
 
     def __init__(self, pars=None, init_prev_data=None, **kwargs):
         super().__init__()
-        self.requires = sti.StructuredSexual
+        self.requires = 'structuredsexual'
 
         # Parameters
         self.default_pars(

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -71,7 +71,7 @@ class Syphilis(ss.Infection):
 
     def __init__(self, pars=None, init_prev_data=None, init_prev_latent_data=None, **kwargs):
         super().__init__()
-        self.requires = sti.StructuredSexual
+        self.requires = 'structuredsexual'
 
         self.default_pars(
             # Adult syphilis natural history, all specified in years


### PR DESCRIPTION
By naming it 'structuredsexual', the user can use any structured sexual network (in our case `FastStructuredSexual`
We might want to revisit this in the future, but this works with the new starsim version (1.0.0)