### PR TITLE
Partner states

### DIFF
--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -409,28 +409,6 @@ class StructuredSexual(ss.SexualNetwork):
             getattr(self, f'{key}_partners')[p1_edges] += p1_counts
             getattr(self, f'{key}_partners')[p2_edges] += p2_counts
 
-        #
-        #
-        # onetime = dur < 1 & ~sw
-        # onetime_p1, onetime_counts_p1 = np.unique(p1[onetime], return_counts=True)
-        # onetime_p2, onetime_counts_p2 = np.unique(p2[onetime], return_counts=True)
-        # self.onetime_partners[onetime_p1] += onetime_counts_p1
-        # self.onetime_partners[onetime_p2] += onetime_counts_p2
-        #
-        #
-        # # stable_p1, stable_counts_p1 = np.unique(p1[stable & ~onetime], return_counts=True)
-        # # stable_p2, stable_counts_p2 = np.unique(p2[stable & ~onetime], return_counts=True)
-        #
-        # stable_p1, stable_counts_p1 = np.unique(p1[edge_types==self.edge_types['stable']], return_counts=True)
-        # stable_p2, stable_counts_p2 = np.unique(p2[edge_types==self.edge_types['stable']], return_counts=True)
-        #
-        # self.stable_partners[stable_p1] += stable_counts_p1
-        # self.stable_partners[stable_p2] += stable_counts_p2
-        #
-        # casual_p1, casual_counts_p1 = np.unique(p1[casual & ~onetime], return_counts=True)
-        # casual_p2, casual_counts_p2 = np.unique(p2[casual & ~onetime], return_counts=True)
-        # self.casual_partners[casual_p1] += casual_counts_p1
-        # self.casual_partners[casual_p2] += casual_counts_p2
 
         # Add partner counts, not including SW partners
         unique_p1, counts_p1 = np.unique(p1_gp, return_counts=True)
@@ -529,21 +507,6 @@ class StructuredSexual(ss.SexualNetwork):
         self.casual_partners[p2_edges][casuals] -= 1
         self.stable_partners[p1_edges][stables] -= 1
         self.stable_partners[p2_edges][stables] -= 1
-
-        # casual_partners = self.casual_partners[self.casual_partners > 0]
-        # stable_partners = self.stable_partners[self.stable_partners > 0]
-        # p1_onetime = np.intersect1d(p1_edges, onetime_partners)
-        # p2_onetime = np.intersect1d(p2_edges, onetime_partners)
-
-
-
-        # decrement the stable, casual, and onetime partner counts too
-        # self.onetime_partners[ss.uids(self.edges.p1[inactive_gp])] -= 1
-        # self.onetime_partners[ss.uids(self.edges.p2[inactive_gp])] -= 1
-        # self.casual_partners[ss.uids(self.edges.p1[inactive_gp])] -= 1
-        # self.casual_partners[ss.uids(self.edges.p2[inactive_gp])] -= 1
-        # self.stable_partners[ss.uids(self.edges.p1[inactive_gp])] -= 1
-        # self.stable_partners[ss.uids(self.edges.p2[inactive_gp])] -= 1
 
         # For all contacts that are due to expire, remove them from the contacts list
         if len(active) > 0:

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -497,16 +497,20 @@ class StructuredSexual(ss.SexualNetwork):
         onetimes = edge_types == self.edge_types['onetime']
         casuals  = edge_types == self.edge_types['casual']
         stables  = edge_types == self.edge_types['stable']
+        sw = edge_types == self.edge_types['sw']
 
         self.partners[p1_edges] -= 1
         self.partners[p2_edges] -= 1
 
-        self.onetime_partners[p1_edges][onetimes] -= 1
-        self.onetime_partners[p2_edges][onetimes] -= 1
-        self.casual_partners[p1_edges][casuals] -= 1
-        self.casual_partners[p2_edges][casuals] -= 1
-        self.stable_partners[p1_edges][stables] -= 1
-        self.stable_partners[p2_edges][stables] -= 1
+        self.onetime_partners[p1_edges[onetimes]] -= 1
+        self.onetime_partners[p2_edges[onetimes]] -= 1
+        self.casual_partners[p1_edges[casuals]] -= 1
+        self.casual_partners[p2_edges[casuals]] -= 1
+        self.stable_partners[p1_edges[stables]] -= 1
+        self.stable_partners[p2_edges[stables]] -= 1
+        self.sw_partners[p1_edges[sw]] -= 1
+        self.sw_partners[p2_edges[sw]] -= 1
+
 
         # For all contacts that are due to expire, remove them from the contacts list
         if len(active) > 0:

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -161,6 +161,10 @@ class StructuredSexual(ss.SexualNetwork):
             ss.FloatArr('stable_partners', default=0),
             ss.FloatArr('onetime_partners', default=0),
             ss.FloatArr('sw_partners', default=0),
+            ss.FloatArr('lifetime_casual_partners', default=0),
+            ss.FloatArr('lifetime_stable_partners', default=0),
+            ss.FloatArr('lifetime_onetime_partners', default=0),
+            ss.FloatArr('lifetime_sw_partners', default=0),
             ss.FloatArr('sw_intensity'),  # Intensity of sex work
         )
 
@@ -406,8 +410,12 @@ class StructuredSexual(ss.SexualNetwork):
             p1_edges, p1_counts = np.unique(p1[edge_types==edge_type], return_counts=True)
             p2_edges, p2_counts = np.unique(p2[edge_types==edge_type], return_counts=True)
 
+            # update partner counts
             getattr(self, f'{key}_partners')[p1_edges] += p1_counts
             getattr(self, f'{key}_partners')[p2_edges] += p2_counts
+            getattr(self, f'lifetime_{key}_partners')[p1_edges] += p1_counts
+            getattr(self, f'lifetime_{key}_partners')[p2_edges] += p2_counts
+
 
 
         # Add partner counts, not including SW partners


### PR DESCRIPTION
Added an edge_type parameter to the `StructuredSexual` network to track whether an edge is a stable, casual, onetime, or sw connection, and added states that track the number of connections of each type for each agent. The edge_types are currently defined as a dictionary, but could be changed to an enum. Closes #99.