### PR TITLE
Relationship durations

### DIFF
--- a/stisim/analyzers.py
+++ b/stisim/analyzers.py
@@ -233,7 +233,7 @@ class RelationshipDurations(ss.Analyzer):
         pl.show()
 
 
-    def get_relationship_durations(self, include_current=True):
+    def get_relationship_durations(self):
         """
         Returns the durations of all relationships, separated by sex.
 
@@ -249,12 +249,6 @@ class RelationshipDurations(ss.Analyzer):
         female_durations = []
         for pair, relationships in self.sim.networks.structuredsexual.relationship_durs.items():
             durs = [relationship['dur'] for relationship in relationships]
-
-            if include_current and durs[-1] is None:
-                durs[-1] = self.ti - relationships[-1]['start']
-            else:
-                # if we are only concerned with relationships that have concluded, remove the last entry when it is None
-                durs = durs[:-1]
 
             # assign the durations to male and female lists
             for uid in pair:

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -409,28 +409,6 @@ class StructuredSexual(ss.SexualNetwork):
             getattr(self, f'{key}_partners')[p1_edges] += p1_counts
             getattr(self, f'{key}_partners')[p2_edges] += p2_counts
 
-        #
-        #
-        # onetime = dur < 1 & ~sw
-        # onetime_p1, onetime_counts_p1 = np.unique(p1[onetime], return_counts=True)
-        # onetime_p2, onetime_counts_p2 = np.unique(p2[onetime], return_counts=True)
-        # self.onetime_partners[onetime_p1] += onetime_counts_p1
-        # self.onetime_partners[onetime_p2] += onetime_counts_p2
-        #
-        #
-        # # stable_p1, stable_counts_p1 = np.unique(p1[stable & ~onetime], return_counts=True)
-        # # stable_p2, stable_counts_p2 = np.unique(p2[stable & ~onetime], return_counts=True)
-        #
-        # stable_p1, stable_counts_p1 = np.unique(p1[edge_types==self.edge_types['stable']], return_counts=True)
-        # stable_p2, stable_counts_p2 = np.unique(p2[edge_types==self.edge_types['stable']], return_counts=True)
-        #
-        # self.stable_partners[stable_p1] += stable_counts_p1
-        # self.stable_partners[stable_p2] += stable_counts_p2
-        #
-        # casual_p1, casual_counts_p1 = np.unique(p1[casual & ~onetime], return_counts=True)
-        # casual_p2, casual_counts_p2 = np.unique(p2[casual & ~onetime], return_counts=True)
-        # self.casual_partners[casual_p1] += casual_counts_p1
-        # self.casual_partners[casual_p2] += casual_counts_p2
 
         # Add partner counts, not including SW partners
         unique_p1, counts_p1 = np.unique(p1_gp, return_counts=True)
@@ -529,21 +507,6 @@ class StructuredSexual(ss.SexualNetwork):
         self.casual_partners[p2_edges][casuals] -= 1
         self.stable_partners[p1_edges][stables] -= 1
         self.stable_partners[p2_edges][stables] -= 1
-
-        # casual_partners = self.casual_partners[self.casual_partners > 0]
-        # stable_partners = self.stable_partners[self.stable_partners > 0]
-        # p1_onetime = np.intersect1d(p1_edges, onetime_partners)
-        # p2_onetime = np.intersect1d(p2_edges, onetime_partners)
-
-
-
-        # decrement the stable, casual, and onetime partner counts too
-        # self.onetime_partners[ss.uids(self.edges.p1[inactive_gp])] -= 1
-        # self.onetime_partners[ss.uids(self.edges.p2[inactive_gp])] -= 1
-        # self.casual_partners[ss.uids(self.edges.p1[inactive_gp])] -= 1
-        # self.casual_partners[ss.uids(self.edges.p2[inactive_gp])] -= 1
-        # self.stable_partners[ss.uids(self.edges.p1[inactive_gp])] -= 1
-        # self.stable_partners[ss.uids(self.edges.p2[inactive_gp])] -= 1
 
         # For all contacts that are due to expire, remove them from the contacts list
         if len(active) > 0:

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -397,11 +397,11 @@ class StructuredSexual(ss.SexualNetwork):
         edge_types[any_match & (dur < 1)] = self.edge_types['onetime']
 
         relationships = (edge_types == self.edge_types['stable']) | (edge_types == self.edge_types['casual'])
-        for (a,b) in zip(p1[relationships], p2[relationships]):
+        for (a, b, reldur) in zip(p1[relationships], p2[relationships], dur[relationships]):
             pair = (min(a,b), max(a,b))
             if not pair in self.relationship_durs:
                 self.relationship_durs[pair] = []
-            self.relationship_durs[pair].append({'start': self.ti, 'dur': None})
+            self.relationship_durs[pair].append({'start': self.ti, 'dur': reldur}) # set dur to intended duration. When the relationship actually ends, this will be updated
 
 
         self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, sw=sw, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -168,6 +168,8 @@ class StructuredSexual(ss.SexualNetwork):
             ss.FloatArr('sw_intensity'),  # Intensity of sex work
         )
 
+        self.relationship_durs = dict()
+
         return
 
     @staticmethod
@@ -394,6 +396,14 @@ class StructuredSexual(ss.SexualNetwork):
 
         edge_types[any_match & (dur < 1)] = self.edge_types['onetime']
 
+        relationships = (edge_types == self.edge_types['stable']) | (edge_types == self.edge_types['casual'])
+        for (a,b) in zip(p1[relationships], p2[relationships]):
+            pair = (min(a,b), max(a,b))
+            if not pair in self.relationship_durs:
+                self.relationship_durs[pair] = []
+            self.relationship_durs[pair].append({'start': self.ti, 'dur': None})
+
+
         self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, sw=sw, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
 
         # Checks
@@ -518,7 +528,9 @@ class StructuredSexual(ss.SexualNetwork):
         self.stable_partners[p2_edges[stables]] -= 1
         self.sw_partners[p1_edges[sw]] -= 1
         self.sw_partners[p2_edges[sw]] -= 1
-
+        for a, b in zip(p1_edges[(casuals + stables)], p2_edges[(casuals + stables)]):
+            pair = (min(a,b), max(a,b))
+            self.relationship_durs[pair][-1]['dur'] = self.ti - self.relationship_durs[pair][-1]['start']
 
         # For all contacts that are due to expire, remove them from the contacts list
         if len(active) > 0:

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -497,16 +497,20 @@ class StructuredSexual(ss.SexualNetwork):
         onetimes = edge_types == self.edge_types['onetime']
         casuals  = edge_types == self.edge_types['casual']
         stables  = edge_types == self.edge_types['stable']
+        sw = edge_types == self.edge_types['sw']
 
         self.partners[p1_edges] -= 1
         self.partners[p2_edges] -= 1
 
-        self.onetime_partners[p1_edges][onetimes] -= 1
-        self.onetime_partners[p2_edges][onetimes] -= 1
-        self.casual_partners[p1_edges][casuals] -= 1
-        self.casual_partners[p2_edges][casuals] -= 1
-        self.stable_partners[p1_edges][stables] -= 1
-        self.stable_partners[p2_edges][stables] -= 1
+        self.onetime_partners[p1_edges[onetimes]] -= 1
+        self.onetime_partners[p2_edges[onetimes]] -= 1
+        self.casual_partners[p1_edges[casuals]] -= 1
+        self.casual_partners[p2_edges[casuals]] -= 1
+        self.stable_partners[p1_edges[stables]] -= 1
+        self.stable_partners[p2_edges[stables]] -= 1
+        self.sw_partners[p1_edges[sw]] -= 1
+        self.sw_partners[p2_edges[sw]] -= 1
+
 
         # For all contacts that are due to expire, remove them from the contacts list
         if len(active) > 0:

--- a/stisim/networks.py
+++ b/stisim/networks.py
@@ -161,6 +161,10 @@ class StructuredSexual(ss.SexualNetwork):
             ss.FloatArr('stable_partners', default=0),
             ss.FloatArr('onetime_partners', default=0),
             ss.FloatArr('sw_partners', default=0),
+            ss.FloatArr('lifetime_casual_partners', default=0),
+            ss.FloatArr('lifetime_stable_partners', default=0),
+            ss.FloatArr('lifetime_onetime_partners', default=0),
+            ss.FloatArr('lifetime_sw_partners', default=0),
             ss.FloatArr('sw_intensity'),  # Intensity of sex work
         )
 
@@ -406,8 +410,12 @@ class StructuredSexual(ss.SexualNetwork):
             p1_edges, p1_counts = np.unique(p1[edge_types==edge_type], return_counts=True)
             p2_edges, p2_counts = np.unique(p2[edge_types==edge_type], return_counts=True)
 
+            # update partner counts
             getattr(self, f'{key}_partners')[p1_edges] += p1_counts
             getattr(self, f'{key}_partners')[p2_edges] += p2_counts
+            getattr(self, f'lifetime_{key}_partners')[p1_edges] += p1_counts
+            getattr(self, f'lifetime_{key}_partners')[p2_edges] += p2_counts
+
 
 
         # Add partner counts, not including SW partners


### PR DESCRIPTION
For #97. This PR adds a dictionary to `StructuredSexual` that tracks all relationship durations. The dictionary key is a tuple of the 2 uids in each relationship, and the value is a list of that pair's relationships start time and duration. I also added an analyzer which tracks stats (currently mean and median duration) of the relationships at each timestep and plots a histogram of all relationship durations, as well as sex-specific histograms.