### PR TITLE
Ensure TimePar parameters are converted to dt when assigning to arr

### DIFF
--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -516,8 +516,8 @@ class SEIS(BaseSTI):
         elif len(par[0]) > 1:
             arr = np.full((len(uids), 2), np.nan)
             for idx in range(2):
-                arr[self.sim.people.female[uids], idx] = par[0][idx]
-                arr[self.sim.people.male[uids], idx] = par[1][idx]
+                arr[self.sim.people.female[uids], idx] = par[0][idx].to(self.dt) if isinstance(par[0][idx], ss.TimePar) else par[0][idx]
+                arr[self.sim.people.male[uids], idx] = par[1][idx].to(self.dt) if isinstance(par[1][idx], ss.TimePar) else par[1][idx]
         return arr
 
     def set_symptoms(self, p, uids):


### PR DESCRIPTION
Previously, TimePar values were assigned directly as bare numbers, without a conversion to the sim's time step. 

For example, the presymptomatic period is specified in weeks. 
```python
self.dur_presymp = [  # For those who develop symptoms, how long before symptoms appear
    [ss.weeks(1), ss.weeks(10)],  # Women
    [ss.weeks(0.25), ss.weeks(1)],  # Men: symptoms should appear within days
]
``` 
Previously, `set_pars()` would assign the raw numbers in `ss.weeks()`, so if the simulation's timestep was monthly, a presymptomatic period of 2 weeks would incorrectly come out as 2 months.

This PR ensures that any `ss.TimePar` instances are converted to the correct simulation time step before being assigned to `arr` (and then passed to the distribution).