### PR TITLE
Fix docs GitHub Action

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -29,8 +29,7 @@ jobs:
           key: mkdocs-material-${{ runner.os }}-${{ hashFiles('**/requirements.txt', '**/pyproject.toml', '**/mkdocs.yml') }}
           path: ~/.cache/pip
 
-      - run: pip install -r docs/requirements.txt
-
+      - run: pip install -e .[dev]
       - run: mkdocs build
 
       - uses: actions/upload-pages-artifact@v3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-mkdocs
-mkdocs-material
-mkdocstrings[python]
-mkdocs-include-markdown-plugin
-mkdocs-jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "stisim"
 dynamic = ["version"]
 description = "STI modelling toolbox built on the Starsim platform"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["agent-based model", "simulation", "disease", "epidemiology", "sexually transmitted infections", "STIs", "STDs"]
 
@@ -24,20 +24,30 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Development Status :: 5 - Production/Stable",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14"
 ]
 
 dependencies = [
     "starsim>=3.0.1",
     "optuna",
     "requests",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-cov",
+    "pytest-env", 
+    "pytest-xdist",
+    "quartodoc",
+    "jupyter",
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocstrings[python]",
+    "mkdocs-include-markdown-plugin",
+    "mkdocs-jupyter"
 ]
 
 [project.urls]


### PR DESCRIPTION
Replaces `docs/requirements.txt` with `pip install -e .[dev]` in `pyproject.toml`, so docs should build correctly on GitHub Actions now.