### PR TITLE
Guard pregnancy/maternalnet access in HIV and syphilis interventions

### DIFF
--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -125,11 +125,12 @@ class ART(ss.Intervention):
         # Apply correction to match ART coverage data:
         self.art_coverage_correction(sim, target_coverage=n_to_treat)
 
-        # Adjust rel_sus for protected unborn agents
-        if hiv.on_art[sim.people.pregnancy.pregnant].any():
-            mother_uids = (hiv.on_art & sim.people.pregnancy.pregnant).uids
-            infants = sim.networks.maternalnet.find_contacts(mother_uids)
-            hiv.rel_sus[ss.uids(infants)] = 0
+        # Adjust rel_sus for protected unborn agents (only if pregnancy is modeled)
+        if hasattr(sim.people, 'pregnancy') and hasattr(sim.networks, 'maternalnet'):
+            if hiv.on_art[sim.people.pregnancy.pregnant].any():
+                mother_uids = (hiv.on_art & sim.people.pregnancy.pregnant).uids
+                infants = sim.networks.maternalnet.find_contacts(mother_uids)
+                hiv.rel_sus[ss.uids(infants)] = 0
 
         return
 

--- a/stisim/interventions/syphilis_interventions.py
+++ b/stisim/interventions/syphilis_interventions.py
@@ -108,13 +108,13 @@ class SyphTx(STITreatment):
         """
         sim = self.sim
         treat_uids = super().step()
-        # Treat unborn babies of successfully treated mothers
-        treat_pregnant_uids = sim.people.pregnancy.pregnant.uids & self.outcomes['successful']
-        overtreat_pregnant_uids = sim.people.pregnancy.pregnant.uids & self.outcomes['unnecessary']
-        # Store results - Unnecessary
-        sim.diseases.syph.results['new_treated_unnecessary_pregnant'][self.ti] += len(overtreat_pregnant_uids)
-        if len(treat_pregnant_uids):
-            self.treat_fetus(sim, mother_uids=treat_pregnant_uids)
+        # Treat unborn babies of successfully treated mothers (only if pregnancy is modeled)
+        if hasattr(sim.people, 'pregnancy'):
+            treat_pregnant_uids = sim.people.pregnancy.pregnant.uids & self.outcomes['successful']
+            overtreat_pregnant_uids = sim.people.pregnancy.pregnant.uids & self.outcomes['unnecessary']
+            sim.diseases.syph.results['new_treated_unnecessary_pregnant'][self.ti] += len(overtreat_pregnant_uids)
+            if len(treat_pregnant_uids):
+                self.treat_fetus(sim, mother_uids=treat_pregnant_uids)
         return treat_uids
 
 
@@ -234,7 +234,7 @@ class SyphTest(STITest):
 
         if (after_start & before_stop):
             # Schedule newborn tests if the mother is positive
-            if self.newborn_test is not None:
+            if self.newborn_test is not None and hasattr(sim.networks, 'maternalnet') and hasattr(sim.people, 'pregnancy'):
                 new_pos = self.ti_positive == self.ti
                 if new_pos.any():
                     pos_mother_inds = np.in1d(sim.networks.maternalnet.p1, new_pos.uids)


### PR DESCRIPTION
Skip unborn agent rel_sus update in ART if pregnancy is not in the sim. Guard syphilis treatment fetus logic and ANC newborn test scheduling with the same checks. Fixes #313.