### PR TITLE
Refactor HIV interventions: flexible coverage, documentation, tests

### DIFF
--- a/docs/tutorials/tut_interventions.ipynb
+++ b/docs/tutorials/tut_interventions.ipynb
@@ -1,13 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "source": "# Format 1: No coverage — treat all who are diagnosed (simplest)\nart_simple = sti.ART()\n\n# Format 2: Constant proportion of infected\nart_const = sti.ART(coverage=0.8)\n\n# Format 3: Time-varying dict\nart_dict = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})\n\n# Format 4: DataFrame with proportion column\nart_df = sti.ART(coverage=pd.DataFrame(\n    index=np.arange(2000, 2026),\n    data={'p_art': np.linspace(0, 0.9, 26)},\n))\n\n# Format 5: DataFrame with absolute numbers\nart_n = sti.ART(coverage=pd.DataFrame(\n    index=np.arange(2000, 2026),\n    data={'n_art': np.linspace(0, 500000, 26)},\n))\n\n# Compare two formats\ntest = sti.HIVTest(test_prob_data=0.3, name='hiv_test')\n\nsim1 = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim1.pars.interventions = [test, art_const]\nsim1.run(verbose=0)\n\nsim2 = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim2.pars.interventions = [sti.HIVTest(test_prob_data=0.3, name='hiv_test'), art_dict]\nsim2.run(verbose=0)\n\nfig, ax = plt.subplots()\nax.plot(sim1.timevec, sim1.results.hiv.n_on_art, label='Constant 80%')\nax.plot(sim2.timevec, sim2.results.hiv.n_on_art, label='Ramping 0→90%')\nax.set_xlabel('Year')\nax.set_ylabel('Number on ART')\nax.legend()\nax.set_title('ART coverage formats comparison')\nfig",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -68,23 +61,24 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "## Exercises\n\n1. Add VMMC to the HIV sim using `sti.VMMC(coverage=0.3)`. How does it affect new infections compared to ART alone?\n2. Try running `sti.ART()` without any `HIVTest` — what happens? (Hint: check for a warning.)\n3. Compare `sti.ART(coverage=0.5)` vs `sti.ART(coverage=0.9)` — how does the number on ART differ?\n4. Create a sim with both gonorrhea and chlamydia, and use a single `STITreatment(diseases=['ng', 'ct'])` to treat both. Compare prevalence with and without treatment."
+   "source": "# Higher testing rate for FSWs\nfsw_test = sti.HIVTest(\n    test_prob_data=0.3,\n    start=2000,\n    name='fsw_test',\n    eligibility=lambda sim: sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.diagnosed,\n)\n\n# Lower testing rate for the general population\ngp_test = sti.HIVTest(\n    test_prob_data=0.05,\n    start=2000,\n    name='gp_test',\n    eligibility=lambda sim: ~sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.diagnosed,\n)\n\nart2 = sti.ART(coverage=0.8)\n\nsim = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim.pars.interventions = [fsw_test, gp_test, art2]\nsim.run(verbose=0)\nsim.plot(key=['hiv.prevalence_15_49', 'hiv.new_infections', 'hiv.n_on_art'])"
   },
   {
    "cell_type": "markdown",
-   "source": "## ART coverage formats\n\nART accepts coverage data in several formats. Here are the main options:",
+   "source": "## ART coverage formats and monitoring\n\nART accepts coverage data in several formats. You can also use the `art_coverage` analyzer to track coverage by age and sex, and verify that the model matches your targets.",
    "metadata": {}
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "source": "# Different coverage formats\nart_const = sti.ART(coverage=0.8)                                                     # Constant proportion\nart_dict  = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})   # Time-varying\nart_none  = sti.ART()                                                                  # No target: treat all diagnosed\n\n# Run with the art_coverage analyzer to monitor coverage by age/sex\nsim = hivsim.demo('simple', run=False, plot=False, n_agents=5000)\nsim.pars.interventions = [sti.HIVTest(test_prob_data=0.3, name='hiv_test'), art_dict]\nsim.pars.analyzers = [sti.art_coverage(age_bins=[15, 25, 35, 45, 65])]\nsim.run(verbose=0)\n\n# Three ways to inspect the results:\n\n# 1. Use the built-in plot method\nsim.analyzers.art_coverage.plot()\n\n# 2. Access results directly\nac = sim.results.art_coverage\nprint(f'Final overall ART coverage: {ac.p_art[-1]:.1%}')\nprint(f'Final coverage, women 25-35: {ac.p_art_f_25_35[-1]:.1%}')\nprint(f'Final coverage, men 25-35:   {ac.p_art_m_25_35[-1]:.1%}')\n\n# 3. Export to a DataFrame for further analysis\ndf = sim.results.art_coverage.to_df()\nprint(f'\\nDataFrame shape: {df.shape}')\ndf.head()",
    "metadata": {},
-   "source": [
-    "## Exercises\n",
-    "\n",
-    "1. Add VMMC to the HIV sim using `sti.VMMC()`. How does it affect new infections compared to ART alone?\n",
-    "2. Modify the gonorrhea example to use a higher treatment efficacy (`treat_eff=0.99`). How much does prevalence change?\n",
-    "3. Create a sim with both gonorrhea and chlamydia, and use a single `STITreatment(diseases=['ng', 'ct'])` to treat both. Compare prevalence with and without treatment."
-   ]
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Exercises\n\n1. Add VMMC to the HIV sim using `sti.VMMC(coverage=0.3)`. How does it affect new infections compared to ART alone?\n2. Try running `sti.ART()` without any `HIVTest` — what happens? (Hint: check for a warning.)\n3. Compare `sti.ART(coverage=0.5)` vs `sti.ART(coverage=0.9)` — how does the number on ART differ? Use `sti.art_coverage()` to plot the results.\n4. Create a sim with both gonorrhea and chlamydia, and use a single `STITreatment(diseases=['ng', 'ct'])` to treat both. Compare prevalence with and without treatment.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/docs/tutorials/tut_interventions.ipynb
+++ b/docs/tutorials/tut_interventions.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "source": "# Format 1: No coverage — treat all who are diagnosed (simplest)\nart_simple = sti.ART()\n\n# Format 2: Constant proportion of infected\nart_const = sti.ART(coverage=0.8)\n\n# Format 3: Time-varying dict\nart_dict = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})\n\n# Format 4: DataFrame with proportion column\nart_df = sti.ART(coverage=pd.DataFrame(\n    index=np.arange(2000, 2026),\n    data={'p_art': np.linspace(0, 0.9, 26)},\n))\n\n# Format 5: DataFrame with absolute numbers\nart_n = sti.ART(coverage=pd.DataFrame(\n    index=np.arange(2000, 2026),\n    data={'n_art': np.linspace(0, 500000, 26)},\n))\n\n# Compare two formats\ntest = sti.HIVTest(test_prob_data=0.3, name='hiv_test')\n\nsim1 = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim1.pars.interventions = [test, art_const]\nsim1.run(verbose=0)\n\nsim2 = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim2.pars.interventions = [sti.HIVTest(test_prob_data=0.3, name='hiv_test'), art_dict]\nsim2.run(verbose=0)\n\nfig, ax = plt.subplots()\nax.plot(sim1.timevec, sim1.results.hiv.n_on_art, label='Constant 80%')\nax.plot(sim2.timevec, sim2.results.hiv.n_on_art, label='Ramping 0→90%')\nax.set_xlabel('Year')\nax.set_ylabel('Number on ART')\nax.legend()\nax.set_title('ART coverage formats comparison')\nfig",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,37 +38,21 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## HIV testing and ART\n\nHIV interventions use HIV-specific classes. `HIVTest` tests undiagnosed agents, and `ART` puts diagnosed agents on treatment with coverage targets over time.\n\nNote: ART includes logic to protect infants of treated mothers, so we need to include demographics (pregnancy and deaths) in the sim."
+   "source": "## HIV testing and ART\n\nHIV interventions follow a specific pipeline: **testing → diagnosis → ART initiation**. Agents must be diagnosed by `HIVTest` before they can start ART.\n\nKey things to know:\n- `test_prob_data` is a **per-year** probability, automatically scaled by timestep. With monthly dt, `test_prob_data=0.1` means ~0.83% per month (~10% per year).\n- `ART(coverage=0.8)` will force-fit 80% of infected onto ART. `ART()` with no coverage treats everyone who is diagnosed.\n- `art_initiation` (default 90%) controls how many newly diagnosed agents are willing to start ART."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Create HIV testing: 10% annual probability, starting in 2000\nhiv_test = sti.HIVTest(test_prob_data=0.1, start=2000, name='hiv_test')\n\n# Create ART: coverage ramps from 0% to 90% over time\nart_data = pd.DataFrame(\n    index=np.arange(2000, 2031),\n    data={'p_art': np.clip(np.linspace(0, 0.9, 31), 0, 1)}\n)\nart = sti.ART(coverage_data=art_data)\n\n# Demographics needed for ART (pregnancy protection)\ndemographics = [sti.Pregnancy(fertility_rate=20), ss.Deaths(death_rate=10)]\n\n# Run with and without interventions\nsim_base = sti.Sim(diseases='hiv', demographics=[sti.Pregnancy(fertility_rate=20), ss.Deaths(death_rate=10)],\n                   n_agents=3000, start=2000, stop=2030)\nsim_intv = sti.Sim(diseases='hiv', demographics=demographics, interventions=[hiv_test, art],\n                   n_agents=3000, start=2000, stop=2030)\n\nsim_base.run(verbose=0)\nsim_intv.run(verbose=0)"
+   "source": "import hivsim\n\n# Simplest approach: use hivsim.demo which includes testing + ART by default\nsim_default = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim_default.run(verbose=0)\n\n# Custom: specify coverage explicitly\nhiv_test = sti.HIVTest(test_prob_data=0.2, start=2000, name='hiv_test')\n\n# ART with time-varying coverage (proportion of infected)\nart = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})\n\n# Without any interventions for comparison\nsim_base = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim_base.pars.interventions = []\nsim_base.run(verbose=0)\n\n# With custom testing + ART\nsim_intv = hivsim.demo('simple', run=False, plot=False, n_agents=3000)\nsim_intv.pars.interventions = [hiv_test, art]\nsim_intv.run(verbose=0)"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "fig, axes = plt.subplots(1, 2, figsize=(10, 4))\n",
-    "\n",
-    "axes[0].plot(sim_base.timevec, sim_base.results.hiv.new_infections, label='No ART', alpha=0.7)\n",
-    "axes[0].plot(sim_intv.timevec, sim_intv.results.hiv.new_infections, label='Testing + ART', alpha=0.7)\n",
-    "axes[0].set_xlabel('Year')\n",
-    "axes[0].set_ylabel('New HIV infections')\n",
-    "axes[0].legend()\n",
-    "\n",
-    "axes[1].plot(sim_intv.timevec, sim_intv.results.hiv.p_on_art)\n",
-    "axes[1].set_xlabel('Year')\n",
-    "axes[1].set_ylabel('Proportion on ART')\n",
-    "axes[1].set_title('ART coverage')\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "fig"
-   ]
+   "source": "fig, axes = plt.subplots(1, 3, figsize=(14, 4))\n\naxes[0].plot(sim_base.timevec, sim_base.results.hiv.prevalence_15_49, label='No interventions', alpha=0.7)\naxes[0].plot(sim_intv.timevec, sim_intv.results.hiv.prevalence_15_49, label='Testing + ART', alpha=0.7)\naxes[0].set_xlabel('Year')\naxes[0].set_ylabel('HIV prevalence (15-49)')\naxes[0].legend()\n\naxes[1].plot(sim_intv.timevec, sim_intv.results.hiv.new_infections, alpha=0.7)\naxes[1].set_xlabel('Year')\naxes[1].set_ylabel('New HIV infections')\naxes[1].set_title('Infections with ART')\n\naxes[2].plot(sim_intv.timevec, sim_intv.results.hiv.n_on_art)\naxes[2].set_xlabel('Year')\naxes[2].set_ylabel('Number on ART')\naxes[2].set_title('ART uptake')\n\nplt.tight_layout()\nfig"
   },
   {
    "cell_type": "markdown",
@@ -77,7 +68,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Higher testing rate for FSWs\nfsw_test = sti.HIVTest(\n    test_prob_data=0.3,\n    start=2000,\n    name='fsw_test',\n    eligibility=lambda sim: sim.networks.structuredsexual.fsw,\n)\n\n# Lower testing rate for the general population\ngp_test = sti.HIVTest(\n    test_prob_data=0.05,\n    start=2000,\n    name='gp_test',\n    eligibility=lambda sim: ~sim.networks.structuredsexual.fsw,\n)\n\nart2 = sti.ART(coverage_data=art_data)\n\nsim = sti.Sim(\n    diseases='hiv',\n    demographics=[sti.Pregnancy(fertility_rate=20), ss.Deaths(death_rate=10)],\n    interventions=[fsw_test, gp_test, art2],\n    n_agents=3000,\n    start=2000,\n    stop=2030,\n)\nsim.run(verbose=0)\nsim.plot(key=['hiv.prevalence', 'hiv.new_infections', 'hiv.p_on_art'])"
+   "source": "## Exercises\n\n1. Add VMMC to the HIV sim using `sti.VMMC(coverage=0.3)`. How does it affect new infections compared to ART alone?\n2. Try running `sti.ART()` without any `HIVTest` — what happens? (Hint: check for a warning.)\n3. Compare `sti.ART(coverage=0.5)` vs `sti.ART(coverage=0.9)` — how does the number on ART differ?\n4. Create a sim with both gonorrhea and chlamydia, and use a single `STITreatment(diseases=['ng', 'ct'])` to treat both. Compare prevalence with and without treatment."
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## ART coverage formats\n\nART accepts coverage data in several formats. Here are the main options:",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -179,7 +179,7 @@ art = sti.ART(coverage=stratified_df)
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `coverage` | None (no target; treat all who initiate) | Coverage target: scalar, dict, DataFrame, or stratified DataFrame. Dict values are linearly interpolated between years. DataFrame requires index=years and a column named `n_art` (absolute numbers) or `p_art` (proportion of infected). Stratified DataFrames need columns Year, Gender/Sex, AgeBin `[lo,hi)`, and a numeric value column. |
+| `coverage` | None (no target; treat all who initiate) | Coverage target: scalar, dict, DataFrame, or stratified DataFrame. Dict values are linearly interpolated between years. DataFrame requires index=years and a column named `n_art` (absolute numbers) or `p_art` (proportion of infected). Stratified DataFrames need columns Year, Gender/Sex, AgeBin `[lo,hi)`, and a numeric value column. Gender accepts: 0/f/female (female), 1/m/male (male). |
 | `art_initiation` | bernoulli(0.9) | Probability a newly diagnosed person initiates ART. Set to 1 to treat all diagnosed. |
 
 ### VMMC

--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -157,8 +157,11 @@ fsw_test = sti.HIVTest(
 ART accepts coverage in multiple formats:
 
 ```python
-# No coverage target — treat all who are diagnosed
+# No coverage target — 90% of newly diagnosed initiate ART (default)
 art = sti.ART()
+
+# Treat ALL diagnosed, no coverage constraint
+art = sti.ART(art_initiation=1)
 
 # Constant proportion of infected
 art = sti.ART(coverage=0.8)

--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -28,7 +28,7 @@ The base testing class. Controls who gets tested, how often, and with what diagn
 ```python
 test = sti.STITest(
     product=my_diagnostic,      # Diagnostic product (required)
-    test_prob_data=0.1,         # Per-timestep probability of testing
+    test_prob_data=0.1,         # Annual testing rate (10% per year)
     eligibility=lambda sim: sim.people.female,  # Who is eligible
     start=2015,                 # When testing begins
 )
@@ -39,10 +39,10 @@ Key parameters:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `product` | (required) | Diagnostic product (e.g., `STIDx`, `HIVDx`) |
-| `test_prob_data` | 1.0 | Testing probability -- scalar, array, or time-varying |
+| `test_prob_data` | 1.0 | Annual testing rate (scalar or array over years). Automatically scaled by dt when `dt_scale=True`. |
 | `eligibility` | all agents | Function `f(sim) -> UIDs` defining who can be tested |
 | `start` / `stop` | sim start/end | Active period for the intervention |
-| `dt_scale` | True | Scale probability by timestep length |
+| `dt_scale` | True | If True, interpret `test_prob_data` as an annual rate and multiply by dt. Set to False to use as a per-timestep probability. |
 
 ### HIVTest
 
@@ -127,7 +127,7 @@ hiv.ti_diagnosed = ti         │
 **Key points:**
 
 - Agents must be **diagnosed** before they can go on ART. If you add ART without HIVTest, a warning is raised and no agents will be treated.
-- `test_prob_data` is a **per-year rate**, automatically scaled by dt. With monthly timesteps (dt=1/12), `test_prob_data=0.1` means ~0.83% per month, not 10% per month. To test everyone in one timestep, use `test_prob_data=1/dt` (e.g. 12 for monthly).
+- `test_prob_data` is an **annual testing rate** by default (`dt_scale=True`). With monthly timesteps (dt=1/12), `test_prob_data=0.1` means ~0.83% per month, or ~10% per year. To use a per-timestep probability directly, set `dt_scale=False`.
 - ART `art_initiation` (default 0.9) controls what fraction of newly diagnosed agents are willing to start treatment.
 - If `coverage` is provided, ART force-fits the number on treatment to match the target by adding/removing agents based on CD4 and care-seeking.
 - If no `coverage` is provided (the default), ART simply treats everyone who initiates, with no capacity constraint.
@@ -148,7 +148,7 @@ fsw_test = sti.HIVTest(
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `test_prob_data` | 1.0 | Per-year testing probability (scaled by dt) |
+| `test_prob_data` | 1.0 | Annual testing rate (scaled by dt when `dt_scale=True`) |
 | `eligibility` | undiagnosed | Function `f(sim) -> BoolArr` defining who can be tested |
 | `start` | sim start | Year testing begins |
 

--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -38,11 +38,11 @@ Key parameters:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `product` | (required) | Diagnostic product (e.g., `STIDx`, `HIVDx`) |
-| `test_prob_data` | 1.0 | Annual testing rate (scalar or array over years). Automatically scaled by dt when `dt_scale=True`. |
-| `eligibility` | all agents | Function `f(sim) -> UIDs` defining who can be tested |
-| `start` / `stop` | sim start/end | Active period for the intervention |
-| `dt_scale` | True | If True, interpret `test_prob_data` as an annual rate and multiply by dt. Set to False to use as a per-timestep probability. |
+| `product` | (required for STITest; HIVTest auto-creates a perfect HIVDx) | Diagnostic product (e.g., `STIDx`, `HIVDx`) |
+| `test_prob_data` | 1.0 | Annual testing probability (scalar or array over years). Converted to per-timestep probability via `ss.probperyear` when `dt_scale=True`. |
+| `eligibility` | all agents (HIVTest: undiagnosed only) | Function `f(sim) -> BoolArr` defining who can be tested, e.g. `lambda sim: sim.people.female & (sim.people.age >= 15)` |
+| `start` / `stop` | first/last sim year | Calendar year (inclusive) when the intervention activates/deactivates |
+| `dt_scale` | True | If True (default), interpret `test_prob_data` as an annual probability. Set to False to interpret as a per-timestep probability. |
 
 ### HIVTest
 
@@ -126,10 +126,11 @@ hiv.ti_diagnosed = ti         │
 
 **Key points:**
 
+- **Intervention order matters**: interventions run in the order they appear in the list. HIVTest must come before ART so that agents diagnosed this timestep can initiate ART in the same step.
 - Agents must be **diagnosed** before they can go on ART. If you add ART without HIVTest, a warning is raised and no agents will be treated.
-- `test_prob_data` is an **annual testing rate** by default (`dt_scale=True`). With monthly timesteps (dt=1/12), `test_prob_data=0.1` means ~0.83% per month, or ~10% per year. To use a per-timestep probability directly, set `dt_scale=False`.
+- `test_prob_data` is an **annual testing probability** by default (`dt_scale=True`). It is converted to a per-timestep probability via `ss.probperyear`. With monthly timesteps, `test_prob_data=0.1` means ~0.88% per month, correctly recovering ~10% per year. To use a per-timestep probability directly, set `dt_scale=False`.
 - ART `art_initiation` (default 0.9) controls what fraction of newly diagnosed agents are willing to start treatment.
-- If `coverage` is provided, ART force-fits the number on treatment to match the target by adding/removing agents based on CD4 and care-seeking.
+- If `coverage` is provided, ART force-fits the number on treatment to match the target each timestep. Agents are added or removed immediately (not gradually) to hit the target, prioritized by CD4 count and care-seeking propensity.
 - If no `coverage` is provided (the default), ART simply treats everyone who initiates, with no capacity constraint.
 
 ### HIVTest
@@ -148,7 +149,7 @@ fsw_test = sti.HIVTest(
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `test_prob_data` | 1.0 | Annual testing rate (scaled by dt when `dt_scale=True`) |
+| `test_prob_data` | 1.0 | Annual testing probability (converted via `ss.probperyear` when `dt_scale=True`) |
 | `eligibility` | undiagnosed | Function `f(sim) -> BoolArr` defining who can be tested |
 | `start` | sim start | Year testing begins |
 
@@ -178,12 +179,12 @@ art = sti.ART(coverage=stratified_df)
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `coverage` | None | Coverage target: scalar, dict, DataFrame, or stratified DataFrame |
-| `art_initiation` | bernoulli(0.9) | Probability a newly diagnosed person initiates ART |
+| `coverage` | None (no target; treat all who initiate) | Coverage target: scalar, dict, DataFrame, or stratified DataFrame. Dict values are linearly interpolated between years. DataFrame requires index=years and a column named `n_art` (absolute numbers) or `p_art` (proportion of infected). Stratified DataFrames need columns Year, Gender/Sex, AgeBin `[lo,hi)`, and a numeric value column. |
+| `art_initiation` | bernoulli(0.9) | Probability a newly diagnosed person initiates ART. Set to 1 to treat all diagnosed. |
 
 ### VMMC
 
-Voluntary medical male circumcision. Reduces male susceptibility to HIV by 60%.
+Voluntary medical male circumcision. Targets all males by default; reduces susceptibility to HIV acquisition by 60%.
 
 ```python
 vmmc = sti.VMMC(coverage=0.3)
@@ -192,12 +193,13 @@ vmmc = sti.VMMC(coverage={'year': [2010, 2025], 'value': [0, 0.4]})
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `coverage` | None | Coverage target (same formats as ART) |
+| `coverage` | None (does nothing without coverage data) | Coverage target (same formats as ART). Required for VMMC to have any effect. |
 | `eff_circ` | 0.6 | Efficacy (60% reduction in HIV acquisition risk) |
+| `eligibility` | all males | Optional function to further restrict who is eligible |
 
 ### PrEP
 
-Pre-exposure prophylaxis targeting FSWs. Reduces susceptibility by 80%.
+Pre-exposure prophylaxis. By default targets HIV-negative FSWs (female sex workers) who are not already on PrEP. Use the `eligibility` parameter to target a different population.
 
 ```python
 prep = sti.Prep(coverage=[0, 0.5], years=[2020, 2025])
@@ -205,9 +207,10 @@ prep = sti.Prep(coverage=[0, 0.5], years=[2020, 2025])
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `coverage` | ramps to 80% | Coverage at each year |
-| `years` | [2004, 2005, 2015, 2025] | Corresponding years |
-| `eff_prep` | 0.8 | Efficacy (80% reduction) |
+| `coverage` | [0, 0.01, 0.5, 0.8] | Coverage values at each year (linearly interpolated between years) |
+| `years` | [2004, 2005, 2015, 2025] | Calendar years corresponding to coverage values |
+| `eff_prep` | 0.8 | Efficacy (80% reduction in HIV acquisition risk) |
+| `eligibility` | HIV-negative FSWs not on PrEP | Optional function to override default targeting |
 
 ## Combining interventions
 

--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -100,33 +100,111 @@ Treatment outcomes are tracked as successful (infection cleared), failed (infect
 | `sti.SyphTx` | Syphilis | Treats pregnant mothers and fetuses; stage-specific |
 | `sti.treat_BV` | BV | CST-based treatment with durable post-treatment effects |
 
-## HIV-specific interventions
+## HIV treatment pipeline
+
+HIV treatment in STIsim follows a specific pipeline. Understanding this flow is essential for setting up HIV interventions correctly:
+
+```
+HIVTest                          ART
+  │                               │
+  │ test eligible agents          │ check newly diagnosed
+  │ (per-year probability)        │ (ti_diagnosed == this step)
+  │                               │
+  ▼                               ▼
+hiv.diagnosed = True    ──►   art_initiation filter (90% default)
+hiv.ti_diagnosed = ti         │
+                              ▼
+                         If coverage specified:
+                           prioritize by CD4, match target
+                         If no coverage:
+                           treat all who initiate
+                              │
+                              ▼
+                         hiv.on_art = True
+                         (reduces transmissibility, reconstitutes CD4)
+```
+
+**Key points:**
+
+- Agents must be **diagnosed** before they can go on ART. If you add ART without HIVTest, a warning is raised and no agents will be treated.
+- `test_prob_data` is a **per-year rate**, automatically scaled by dt. With monthly timesteps (dt=1/12), `test_prob_data=0.1` means ~0.83% per month, not 10% per month. To test everyone in one timestep, use `test_prob_data=1/dt` (e.g. 12 for monthly).
+- ART `art_initiation` (default 0.9) controls what fraction of newly diagnosed agents are willing to start treatment.
+- If `coverage` is provided, ART force-fits the number on treatment to match the target by adding/removing agents based on CD4 and care-seeking.
+- If no `coverage` is provided (the default), ART simply treats everyone who initiates, with no capacity constraint.
+
+### HIVTest
+
+```python
+# Test 20% of undiagnosed agents per year
+hiv_test = sti.HIVTest(test_prob_data=0.2, start=2000, name='hiv_test')
+
+# Higher rate for FSWs
+fsw_test = sti.HIVTest(
+    test_prob_data=0.5,
+    name='fsw_test',
+    eligibility=lambda sim: sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.diagnosed,
+)
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `test_prob_data` | 1.0 | Per-year testing probability (scaled by dt) |
+| `eligibility` | undiagnosed | Function `f(sim) -> BoolArr` defining who can be tested |
+| `start` | sim start | Year testing begins |
 
 ### ART
 
-Antiretroviral therapy with CD4-based prioritization and coverage targets.
+ART accepts coverage in multiple formats:
 
 ```python
-art = sti.ART(coverage_data=art_df)  # DataFrame with year index and n_art or p_art column
+# No coverage target — treat all who are diagnosed
+art = sti.ART()
+
+# Constant proportion of infected
+art = sti.ART(coverage=0.8)
+
+# Time-varying proportion
+art = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})
+
+# From a DataFrame (absolute numbers)
+art = sti.ART(coverage=pd.read_csv('art_data.csv').set_index('year'))
+
+# Age/sex stratified (columns: Year, Gender/Sex, AgeBin, + value)
+art = sti.ART(coverage=stratified_df)
 ```
 
-ART reduces transmissibility by 96% (default) and reconstitutes CD4 counts. Coverage can be specified as absolute numbers or proportions.
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `coverage` | None | Coverage target: scalar, dict, DataFrame, or stratified DataFrame |
+| `art_initiation` | bernoulli(0.9) | Probability a newly diagnosed person initiates ART |
 
 ### VMMC
 
-Voluntary medical male circumcision. Reduces male susceptibility to HIV by 60% (default).
+Voluntary medical male circumcision. Reduces male susceptibility to HIV by 60%.
 
 ```python
-vmmc = sti.VMMC(coverage_data=vmmc_df)
+vmmc = sti.VMMC(coverage=0.3)
+vmmc = sti.VMMC(coverage={'year': [2010, 2025], 'value': [0, 0.4]})
 ```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `coverage` | None | Coverage target (same formats as ART) |
+| `eff_circ` | 0.6 | Efficacy (60% reduction in HIV acquisition risk) |
 
 ### PrEP
 
-Pre-exposure prophylaxis targeting FSWs. Reduces susceptibility by 80% (default).
+Pre-exposure prophylaxis targeting FSWs. Reduces susceptibility by 80%.
 
 ```python
 prep = sti.Prep(coverage=[0, 0.5], years=[2020, 2025])
 ```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `coverage` | ramps to 80% | Coverage at each year |
+| `years` | [2004, 2005, 2015, 2025] | Corresponding years |
+| `eff_prep` | 0.8 | Efficacy (80% reduction) |
 
 ## Combining interventions
 

--- a/stisim/analyzers.py
+++ b/stisim/analyzers.py
@@ -639,3 +639,52 @@ class art_coverage(ss.Analyzer):
 
         return
 
+    def plot(self, by_age=True):
+        """
+        Plot ART coverage over time.
+
+        Creates a 2-panel figure: aggregate coverage (left) and by age/sex (right).
+        If by_age=False, only plots aggregate.
+
+        Example::
+
+            sim.run()
+            sim.analyzers.art_coverage.plot()
+        """
+        yearvec = self.sim.t.yearvec
+        sex_colors = {'f': '#d46e9c', 'm': '#4a90d9'}
+        sex_labels = {'f': 'Women', 'm': 'Men'}
+
+        if by_age and len(self.age_bins) > 2:
+            fig, axes = pl.subplots(1, 3, figsize=(16, 5))
+        else:
+            fig, axes = pl.subplots(1, 1, figsize=(6, 5))
+            axes = [axes]
+
+        # Panel 1: aggregate
+        ax = axes[0]
+        ax.plot(yearvec, self.results['p_art'],   color='k',              linewidth=2, label='Overall')
+        ax.plot(yearvec, self.results['p_art_f'], color=sex_colors['f'], linewidth=1.5, label='Women')
+        ax.plot(yearvec, self.results['p_art_m'], color=sex_colors['m'], linewidth=1.5, label='Men')
+        ax.set_xlabel('Year')
+        ax.set_ylabel('ART coverage (proportion of infected)')
+        ax.set_title('ART coverage')
+        ax.set_ylim(0, 1)
+        ax.legend(frameon=False)
+
+        # Panels 2-3: by age (women, men)
+        if by_age and len(self.age_bins) > 2 and len(axes) > 1:
+            for sex, ax in zip(['f', 'm'], axes[1:]):
+                for i in range(len(self.age_bins) - 1):
+                    lo, hi = self.age_bins[i], self.age_bins[i + 1]
+                    key = f'p_art_{sex}_{lo}_{hi}'
+                    ax.plot(yearvec, self.results[key], label=f'{lo}-{hi}')
+                ax.set_xlabel('Year')
+                ax.set_ylabel('ART coverage')
+                ax.set_title(f'{sex_labels[sex]} by age')
+                ax.set_ylim(0, 1)
+                ax.legend(frameon=False, fontsize=9)
+
+        pl.tight_layout()
+        return fig
+

--- a/stisim/analyzers.py
+++ b/stisim/analyzers.py
@@ -12,7 +12,7 @@ import stisim as sti
 import pylab as pl
 from collections import defaultdict
 
-__all__ = ["result_grouper", "coinfection_stats", "sw_stats", "RelationshipDurations", "NetworkDegree", "DebutAge", "partner_age_diff", "TimeBetweenRelationships"]
+__all__ = ["result_grouper", "coinfection_stats", "sw_stats", "RelationshipDurations", "NetworkDegree", "DebutAge", "partner_age_diff", "TimeBetweenRelationships", "art_coverage"]
 
 class result_grouper(ss.Analyzer):
     @staticmethod
@@ -562,4 +562,80 @@ class DebutAge(ss.Analyzer):
         pl.ylabel('Share')
         pl.title('Proportion of males who are sexually active')
         pl.show()
+
+
+class art_coverage(ss.Analyzer):
+    """
+    Track ART coverage (number and proportion) by sex and age bin.
+
+    Results are stored as time series per stratum, accessible via:
+        analyzer.results['n_art_f_15_25']    # Women 15-25 on ART (count)
+        analyzer.results['p_art_m_25_35']    # Men 25-35 on ART (proportion of infected)
+
+    Args:
+        age_bins (list): age bin edges, e.g. [15, 25, 35, 45, 65]. Default: [15, 25, 35, 45, 65]
+    """
+
+    def __init__(self, age_bins=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = 'art_coverage'
+        self.age_bins = age_bins or [15, 25, 35, 45, 65]
+        return
+
+    def init_results(self):
+        super().init_results()
+        results = []
+
+        # Aggregate results
+        results.append(ss.Result('n_art',   dtype=int,   label='Total on ART'))
+        results.append(ss.Result('p_art',   scale=False, label='ART coverage (proportion of infected)'))
+        results.append(ss.Result('n_art_f', dtype=int,   label='Women on ART'))
+        results.append(ss.Result('n_art_m', dtype=int,   label='Men on ART'))
+        results.append(ss.Result('p_art_f', scale=False, label='ART coverage (women)'))
+        results.append(ss.Result('p_art_m', scale=False, label='ART coverage (men)'))
+
+        # Per age bin × sex
+        for i in range(len(self.age_bins) - 1):
+            lo, hi = self.age_bins[i], self.age_bins[i + 1]
+            for sex in ['f', 'm']:
+                results.append(ss.Result(f'n_art_{sex}_{lo}_{hi}', dtype=int, label=f'On ART {sex.upper()} {lo}-{hi}'))
+                results.append(ss.Result(f'p_art_{sex}_{lo}_{hi}', scale=False, label=f'ART coverage {sex.upper()} {lo}-{hi}'))
+
+        self.define_results(*results)
+        return
+
+    def step(self):
+        sim = self.sim
+        ti  = self.ti
+        ppl = sim.people
+        hiv = sim.diseases.hiv
+
+        on_art   = hiv.on_art
+        infected = hiv.infected
+        female   = ppl.female
+        male     = ppl.male
+        age      = ppl.age
+
+        # Aggregate
+        n_art = len(on_art.uids)
+        n_inf = len(infected.uids)
+        self.results['n_art'][ti]   = n_art
+        self.results['p_art'][ti]   = sc.safedivide(n_art, n_inf)
+        self.results['n_art_f'][ti] = len((on_art & female).uids)
+        self.results['n_art_m'][ti] = len((on_art & male).uids)
+        self.results['p_art_f'][ti] = sc.safedivide(len((on_art & female).uids), len((infected & female).uids))
+        self.results['p_art_m'][ti] = sc.safedivide(len((on_art & male).uids), len((infected & male).uids))
+
+        # Per age bin × sex
+        for i in range(len(self.age_bins) - 1):
+            lo, hi = self.age_bins[i], self.age_bins[i + 1]
+            age_mask = (age >= lo) & (age < hi)
+            for sex, sex_mask in [('f', female), ('m', male)]:
+                stratum     = age_mask & sex_mask
+                n_on        = len((on_art & stratum).uids)
+                n_inf_strat = len((infected & stratum).uids)
+                self.results[f'n_art_{sex}_{lo}_{hi}'][ti] = n_on
+                self.results[f'p_art_{sex}_{lo}_{hi}'][ti] = sc.safedivide(n_on, n_inf_strat)
+
+        return
 

--- a/stisim/analyzers.py
+++ b/stisim/analyzers.py
@@ -573,7 +573,8 @@ class art_coverage(ss.Analyzer):
         analyzer.results['p_art_m_25_35']    # Men 25-35 on ART (proportion of infected)
 
     Args:
-        age_bins (list): age bin edges, e.g. [15, 25, 35, 45, 65]. Default: [15, 25, 35, 45, 65]
+        age_bins (list): age bin edges, e.g. [15, 25, 35, 45, 65]. Default: [15, 25, 35, 45, 65].
+            Bins are half-open intervals: [lo, hi), i.e. lo <= age < hi.
     """
 
     def __init__(self, age_bins=None, *args, **kwargs):

--- a/stisim/data/downloaders.py
+++ b/stisim/data/downloaders.py
@@ -203,6 +203,7 @@ def download_data(location, indicators=None, start=1950, stop=2100, step=10):
     country_code = get_country_code(df, location)
 
     for indicator in indicators:
+        print(f'STIsim data: downloading {indicator} for {location}...')
         icode = indicator_codes[indicator]
         dfs = sc.autolist()
         if indicator == 'age': years = [start]

--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -511,6 +511,10 @@ class SEIS(BaseSTI):
         return
 
     def set_pars(self, par, uids):
+        # Handle scalar calibration values by converting to [scalar, scalar]
+        if sc.isnumber(par):
+            par = [par, par]
+
         if sc.isnumber(par[0]):  # Single par, e.g. for bernoulli
             arr = np.full(len(uids), np.nan)
             arr[self.sim.people.female[uids]] = par[0]

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -79,9 +79,11 @@ class STITest(ss.Intervention):
                         HIVDx). For STITest, a product is required.
         test_prob_data: annual testing probability (if dt_scale=True, the default)
                         or per-timestep probability (if dt_scale=False). Accepts a
-                        scalar (constant probability) or an array (one value per
-                        entry in ``years``). Default: 1.0 (test all eligible agents
-                        per year).
+                        scalar (constant probability), an array (one value per
+                        entry in ``years``), or a DataFrame (subclass-specific,
+                        e.g. SymptomaticTesting accepts risk-group-stratified
+                        DataFrames). Default: 1.0 (test all eligible agents per
+                        year).
         years (array):  calendar years corresponding to entries in test_prob_data
                         when test_prob_data is an array. Mutually exclusive with start.
         start (float):  calendar year when the intervention activates (inclusive).

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -61,22 +61,31 @@ class STITest(ss.Intervention):
     Base class for STI testing.
 
     Controls who gets tested, how often, and with what diagnostic product.
-    Each timestep, eligible agents are tested with probability test_prob_data
-    (scaled by dt if dt_scale=True). Positive results can trigger treatment.
+    Each timestep, eligible agents are tested with a probability derived from
+    test_prob_data. By default (dt_scale=True), test_prob_data is interpreted
+    as an **annual testing rate** and automatically scaled by dt to get a
+    per-timestep probability.
 
-    Important: test_prob_data is a *per-year* rate by default (dt_scale=True).
-    With monthly timesteps (dt=1/12), test_prob_data=0.1 means ~0.83% chance
-    per month, or ~10% per year. To test everyone in one timestep, use
-    test_prob_data=1/dt (e.g. 12 for monthly dt).
+    For example, with monthly timesteps (dt=1/12):
+        - test_prob_data=0.1  → ~0.83% per month → ~10% tested per year
+        - test_prob_data=1.0  → ~8.3% per month  → ~100% tested per year
+
+    If you need to specify a per-timestep probability directly (not an annual
+    rate), set dt_scale=False:
+        - test_prob_data=0.5, dt_scale=False → 50% chance per timestep
 
     Args:
         product (ss.Product):  diagnostic product that determines test outcomes
-        test_prob_data:        testing probability per year; scalar or array over years
+        test_prob_data:        annual testing rate (if dt_scale=True, the default)
+                               or per-timestep probability (if dt_scale=False);
+                               scalar or array over years
         years (array):         years corresponding to test_prob_data if array
         start/stop (float):    active period for the intervention
         eligibility (func):    function f(sim) -> BoolArr or UIDs defining who can be tested
         rel_test (float):      relative testing probability multiplier (default 1)
-        dt_scale (bool):       if True (default), scale probability by dt
+        dt_scale (bool):       if True (default), interpret test_prob_data as an annual
+                               rate and multiply by dt to get per-timestep probability.
+                               Set to False to use test_prob_data as-is per timestep.
 
     States set on agents:
         tested (bool):      ever tested

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -63,35 +63,49 @@ class STITest(ss.Intervention):
     Controls who gets tested, how often, and with what diagnostic product.
     Each timestep, eligible agents are tested with a probability derived from
     test_prob_data. By default (dt_scale=True), test_prob_data is interpreted
-    as an **annual testing rate** and automatically scaled by dt to get a
-    per-timestep probability.
-
-    For example, with monthly timesteps (dt=1/12):
-        - test_prob_data=0.1  → ~0.83% per month → ~10% tested per year
-        - test_prob_data=1.0  → ~8.3% per month  → ~100% tested per year
+    as an **annual testing probability** and converted to a per-timestep
+    probability via ``ss.probperyear``. This correctly recovers the annual
+    probability over a full year of timesteps (e.g. test_prob_data=0.24 with
+    monthly dt gives ~2.26% per month, recovering exactly 24% per year).
 
     If you need to specify a per-timestep probability directly (not an annual
-    rate), set dt_scale=False:
+    probability), set dt_scale=False:
         - test_prob_data=0.5, dt_scale=False → 50% chance per timestep
 
     Args:
-        product (ss.Product):  diagnostic product that determines test outcomes
-        test_prob_data:        annual testing rate (if dt_scale=True, the default)
-                               or per-timestep probability (if dt_scale=False);
-                               scalar or array over years
-        years (array):         years corresponding to test_prob_data if array
-        start/stop (float):    active period for the intervention
-        eligibility (func):    function f(sim) -> BoolArr or UIDs defining who can be tested
-        rel_test (float):      relative testing probability multiplier (default 1)
-        dt_scale (bool):       if True (default), interpret test_prob_data as an annual
-                               rate and multiply by dt to get per-timestep probability.
-                               Set to False to use test_prob_data as-is per timestep.
+        product:        diagnostic product (e.g. STIDx, HIVDx) that determines
+                        test outcomes (sensitivity, specificity). If None,
+                        subclasses supply a default (e.g. HIVTest uses a perfect
+                        HIVDx). For STITest, a product is required.
+        test_prob_data: annual testing probability (if dt_scale=True, the default)
+                        or per-timestep probability (if dt_scale=False). Accepts a
+                        scalar (constant probability) or an array (one value per
+                        entry in ``years``). Default: 1.0 (test all eligible agents
+                        per year).
+        years (array):  calendar years corresponding to entries in test_prob_data
+                        when test_prob_data is an array. Mutually exclusive with start.
+        start (float):  calendar year when the intervention activates (inclusive).
+                        Defaults to the first simulation year.
+        stop (float):   calendar year when the intervention deactivates (inclusive).
+                        Defaults to the last simulation year.
+        eligibility:    function ``f(sim) -> BoolArr`` or ``f(sim) -> UIDs`` defining
+                        who can be tested. Can filter on any agent property, e.g.
+                        ``lambda sim: sim.people.female & (sim.people.age > 15)``.
+                        Default: all agents (subclasses may override, e.g. HIVTest
+                        defaults to undiagnosed agents only).
+        rel_test:       relative testing probability multiplier (default 1.0)
+        dt_scale:       if True (default), interpret test_prob_data as an annual
+                        probability. Set to False to interpret test_prob_data as a
+                        per-timestep probability.
 
     States set on agents:
-        tested (bool):      ever tested
-        diagnosed (bool):   ever diagnosed positive
-        ti_tested (float):  timestep of last test
+        tested (bool):       ever tested
+        diagnosed (bool):    ever diagnosed positive
+        ti_tested (float):   timestep of last test
+        ti_scheduled (float): timestep of next scheduled test
         ti_positive (float): timestep of last positive result
+        ti_negative (float): timestep of last negative result
+        tests (float):       cumulative number of tests received
     """
 
     def __init__(self, pars=None, test_prob_data=None, years=None, start=None, stop=None, eligibility=None, product=None, name=None, label=None, **kwargs):
@@ -178,7 +192,8 @@ class STITest(ss.Intervention):
 
         # Scale and validate
         test_prob *= self.pars.rel_test
-        if self.pars.dt_scale: test_prob *= self.t.dt_year
+        if self.pars.dt_scale:
+            test_prob = ss.probperyear(test_prob).to_prob(sim.dt)
         test_prob = np.clip(test_prob, a_min=0, a_max=1)
 
         return test_prob

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -58,7 +58,31 @@ class STIDx(ss.Product):
 
 class STITest(ss.Intervention):
     """
-    Base class for STI testing
+    Base class for STI testing.
+
+    Controls who gets tested, how often, and with what diagnostic product.
+    Each timestep, eligible agents are tested with probability test_prob_data
+    (scaled by dt if dt_scale=True). Positive results can trigger treatment.
+
+    Important: test_prob_data is a *per-year* rate by default (dt_scale=True).
+    With monthly timesteps (dt=1/12), test_prob_data=0.1 means ~0.83% chance
+    per month, or ~10% per year. To test everyone in one timestep, use
+    test_prob_data=1/dt (e.g. 12 for monthly dt).
+
+    Args:
+        product (ss.Product):  diagnostic product that determines test outcomes
+        test_prob_data:        testing probability per year; scalar or array over years
+        years (array):         years corresponding to test_prob_data if array
+        start/stop (float):    active period for the intervention
+        eligibility (func):    function f(sim) -> BoolArr or UIDs defining who can be tested
+        rel_test (float):      relative testing probability multiplier (default 1)
+        dt_scale (bool):       if True (default), scale probability by dt
+
+    States set on agents:
+        tested (bool):      ever tested
+        diagnosed (bool):   ever diagnosed positive
+        ti_tested (float):  timestep of last test
+        ti_positive (float): timestep of last positive result
     """
 
     def __init__(self, pars=None, test_prob_data=None, years=None, start=None, stop=None, eligibility=None, product=None, name=None, label=None, **kwargs):

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -225,10 +225,6 @@ class ART(ss.Intervention):
         # Handle deprecated kwargs
         coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
 
-        # Default coverage: 85% of infected on ART (matches old future_coverage default)
-        if coverage is None and coverage_data is None and future_coverage is None:
-            coverage = 0.85
-
         # Handle deprecated init_prob → art_initiation
         init_prob = kwargs.pop('init_prob', None)
         if init_prob is not None:
@@ -266,8 +262,8 @@ class ART(ss.Intervention):
         """
         Get the target number of people on ART this timestep.
 
-        For stratified coverage, returns a dict of {(age_bin, sex): n_to_treat}.
-        For aggregate coverage, returns an int.
+        Returns None if no coverage data is provided (meaning: no capacity
+        constraint, just treat everyone who initiates). Returns an int otherwise.
         """
         # Legacy future_coverage mode
         if self._future_coverage is not None and self.t.now('year') >= self._future_coverage['year']:
@@ -275,7 +271,7 @@ class ART(ss.Intervention):
             return int(p_cov * len(eligible_uids))
 
         if self.coverage is None:
-            return 0
+            return None
 
         # Stratified coverage
         if isinstance(self.coverage, dict):
@@ -323,7 +319,7 @@ class ART(ss.Intervention):
         hiv = sim.diseases.hiv
         inf_uids = hiv.infected.uids
 
-        # Determine treatment target
+        # Determine treatment target (None = no capacity constraint)
         n_to_treat = self._get_n_to_treat(inf_uids)
 
         # Check who is stopping ART
@@ -337,17 +333,23 @@ class ART(ss.Intervention):
                     raise ValueError(errormsg)
 
         # Initiate ART for newly diagnosed
-        on_art = hiv.on_art
         diagnosed = hiv.ti_diagnosed == self.ti
         if len(diagnosed.uids):
             dx_to_treat = self.pars.art_initiation.filter(diagnosed.uids)
 
-            n_available_spots = n_to_treat - len(on_art.uids)
-            if n_available_spots > 0:
-                self.prioritize_art(sim, n=n_available_spots, awaiting_art_uids=dx_to_treat)
+            if n_to_treat is None:
+                # No coverage target — treat all who initiate
+                hiv.start_art(dx_to_treat)
+            else:
+                # Coverage target — only treat if spots available
+                on_art = hiv.on_art
+                n_available_spots = n_to_treat - len(on_art.uids)
+                if n_available_spots > 0:
+                    self.prioritize_art(sim, n=n_available_spots, awaiting_art_uids=dx_to_treat)
 
-        # Correct coverage to match target
-        self.art_coverage_correction(sim, target_coverage=n_to_treat)
+        # Correct coverage to match target (only if target is set)
+        if n_to_treat is not None:
+            self.art_coverage_correction(sim, target_coverage=n_to_treat)
 
         # Adjust rel_sus for protected unborn agents (only if pregnancy is modeled)
         if hasattr(sim.people, 'pregnancy') and hasattr(sim.networks, 'maternalnet'):
@@ -429,10 +431,6 @@ class VMMC(ss.Intervention):
         # Handle deprecated kwargs
         coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
 
-        # Default coverage: 10% of males circumcised (matches old future_coverage default)
-        if coverage is None and coverage_data is None and future_coverage is None:
-            coverage = 0.1
-
         self.define_pars(
             eff_circ=0.6,
         )
@@ -475,7 +473,7 @@ class VMMC(ss.Intervention):
             return int(self._future_coverage['prop'] * len(eligible_uids))
 
         if self.coverage is None:
-            return 0
+            return None
 
         # Stratified coverage
         if isinstance(self.coverage, dict):
@@ -510,7 +508,7 @@ class VMMC(ss.Intervention):
 
         n_to_circ = self._get_n_to_circ(m_uids)
 
-        if n_to_circ > 0:
+        if n_to_circ is not None and n_to_circ > 0:
             eligible_uids = (sim.people.male & ~self.circumcised).uids
             weights = self.willingness[eligible_uids]
             choices = np.argsort(-weights)[:n_to_circ]
@@ -519,7 +517,7 @@ class VMMC(ss.Intervention):
             self.circumcised[new_circs] = True
             self.ti_circumcised[new_circs] = self.ti
 
-        self.results['new_circumcisions'][self.ti] = n_to_circ
+        self.results['new_circumcisions'][self.ti] = n_to_circ or 0
         self.results['n_circumcised'][self.ti] = count(self.circumcised)
 
         # Reduce rel_sus

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -225,6 +225,10 @@ class ART(ss.Intervention):
         # Handle deprecated kwargs
         coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
 
+        # Default coverage: 85% of infected on ART (matches old future_coverage default)
+        if coverage is None and coverage_data is None and future_coverage is None:
+            coverage = 0.85
+
         # Handle deprecated init_prob → art_initiation
         init_prob = kwargs.pop('init_prob', None)
         if init_prob is not None:
@@ -424,6 +428,10 @@ class VMMC(ss.Intervention):
 
         # Handle deprecated kwargs
         coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
+
+        # Default coverage: 10% of males circumcised (matches old future_coverage default)
+        if coverage is None and coverage_data is None and future_coverage is None:
+            coverage = 0.1
 
         self.define_pars(
             eff_circ=0.6,

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -245,21 +245,20 @@ class HIVTest(STITest):
 
     The testing → diagnosis → ART pipeline works as follows:
 
-        1. HIVTest tests eligible agents each timestep (annual rate, scaled by dt)
+        1. HIVTest tests eligible agents each timestep (annual probability, converted via ss.probperyear)
         2. Positive results set hiv.diagnosed=True and hiv.ti_diagnosed
         3. ART checks for newly diagnosed agents (ti_diagnosed == current ti)
         4. Newly diagnosed agents initiate ART with probability art_initiation
         5. If coverage data is provided, ART corrects to match targets
 
     Args:
-        test_prob_data: annual testing rate (default interpretation with
-            dt_scale=True). A value of 0.1 means ~10% of eligible agents tested
-            per year. To specify a per-timestep probability instead, set
-            dt_scale=False.
+        test_prob_data: annual testing probability (if dt_scale=True, the default).
+            A value of 0.1 means ~10% of eligible agents tested per year. To
+            specify a per-timestep probability instead, set dt_scale=False.
         eligibility (func): who can be tested. Default: undiagnosed agents.
-        start (float): year testing begins
-        dt_scale (bool): if True (default), test_prob_data is an annual rate,
-            automatically scaled by dt. Set to False for per-timestep probability.
+        start (float): calendar year when testing begins
+        dt_scale (bool): if True (default), test_prob_data is an annual probability.
+            Set to False for per-timestep probability.
 
     Example::
 
@@ -312,14 +311,22 @@ class ART(ss.Intervention):
     Coverage can be specified in several formats:
         - None: no coverage target; treat all who initiate (default)
         - Scalar (e.g. 0.8): constant proportion of infected on ART
-        - Dict: {'year': [2000, 2020], 'value': [0, 0.9]} — interpolated
-        - DataFrame: index=years, column 'n_art' (numbers) or 'p_art' (proportion)
-        - Stratified DataFrame: columns Year, Gender/Sex, AgeBin + a value column
+        - Dict: {'year': [2000, 2020], 'value': [0, 0.9]} — linearly interpolated
+        - DataFrame: index=years, column 'n_art' (absolute numbers) or 'p_art'
+          (proportion of infected). Values are linearly interpolated to the sim
+          yearvec.
+        - Stratified DataFrame: columns Year, Gender/Sex, AgeBin (format
+          '[lo,hi)'), plus a numeric value column. Values are interpolated per
+          stratum.
+
+    Intervention ordering: HIVTest must appear before ART in the interventions
+    list so that agents diagnosed this timestep can initiate ART in the same step.
 
     Args:
-        coverage:         coverage target in any format above
+        coverage:         coverage target in any format above (default None)
         art_initiation:   probability a newly diagnosed person initiates ART
-                          (default: ss.bernoulli(p=0.9))
+                          (default: ss.bernoulli(p=0.9)). Set to 1 to treat all
+                          diagnosed.
 
     Example::
 
@@ -361,10 +368,14 @@ class ART(ss.Intervention):
     def init_pre(self, sim):
         super().init_pre(sim)
 
-        # Warn if no HIV testing intervention found
-        has_hiv_test = any(isinstance(m, HIVTest) for m in sim.interventions())
-        if not has_hiv_test:
+        # Warn if no HIV testing intervention found, or if it comes after ART
+        intvs = list(sim.interventions())
+        hiv_test_indices = [i for i, m in enumerate(intvs) if isinstance(m, HIVTest)]
+        art_index = next((i for i, m in enumerate(intvs) if m is self), len(intvs))
+        if not hiv_test_indices:
             ss.warn('ART intervention added without an HIV testing intervention; diagnosed agents may never be identified')
+        elif all(i > art_index for i in hiv_test_indices):
+            ss.warn('HIVTest appears after ART in the intervention list; agents diagnosed this timestep will not initiate ART until the next step')
 
         # Parse coverage data
         self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
@@ -536,14 +547,15 @@ class VMMC(ss.Intervention):
 
     Coverage formats (same as ART):
         - Scalar: constant proportion of males (e.g. 0.3)
-        - Dict: {'year': [...], 'value': [...]} — interpolated
+        - Dict: {'year': [...], 'value': [...]} — linearly interpolated
         - DataFrame: index=years, column 'n_vmmc' or 'p_vmmc'
         - Stratified DataFrame: Year/Gender/AgeBin columns
 
     Args:
-        coverage:    coverage target in any format above
+        coverage:    coverage target in any format above (default None; VMMC does
+                     nothing without coverage data)
         eff_circ:    efficacy (default 0.6 = 60% reduction in HIV acquisition)
-        eligibility: optional eligibility function
+        eligibility: optional function to restrict who is eligible (default: all males)
 
     Example::
 
@@ -654,17 +666,18 @@ class VMMC(ss.Intervention):
 
 class Prep(ss.Intervention):
     """
-    Pre-exposure prophylaxis (PrEP) for female sex workers.
+    Pre-exposure prophylaxis (PrEP).
 
-    Reduces HIV susceptibility by eff_prep (default 80%) for eligible FSWs
-    who are HIV-negative and not already on PrEP. Coverage ramps up over
-    time according to the years/coverage parameters.
+    By default targets HIV-negative FSWs who are not already on PrEP.
+    Reduces HIV susceptibility by eff_prep (default 80%). Coverage ramps up
+    over time according to the years/coverage parameters (linearly interpolated).
+    Use the eligibility parameter to target a different population.
 
     Args:
-        coverage (list):  coverage values at each year (default ramps 0→80%)
-        years (list):     corresponding years
+        coverage (list):  coverage values at each year (default [0, 0.01, 0.5, 0.8])
+        years (list):     corresponding calendar years (default [2004, 2005, 2015, 2025])
         eff_prep (float): efficacy (default 0.8 = 80% reduction in acquisition)
-        eligibility:      optional custom eligibility function
+        eligibility:      function to override default FSW targeting
 
     Example::
 
@@ -702,6 +715,7 @@ def _parse_age_bin(ab_str):
     """
     Parse age bin string like "[15,25)" into (lo, hi).
     Also handles numeric tuples and plain strings like "15-25".
+    All bins are treated as half-open intervals [lo, hi) regardless of bracket style.
     """
     if isinstance(ab_str, (tuple, list)):
         return float(ab_str[0]), float(ab_str[1])

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -75,12 +75,16 @@ def _parse_coverage_df(data, valid_names, yearvec):
 
     Handles two cases:
         1. Legacy: index=years, single column in valid_names → 1D interpolated array
-        2. Stratified: columns include Year, Gender, AgeBin, and a value column → dict of arrays by (age, sex)
+        2. Stratified: columns include Year, Gender/Sex, AgeBin, and a value column → dict of arrays by (age, sex)
     """
 
-    # Check for stratified format (has Year, Gender, AgeBin columns)
-    stratified_cols = {'Year', 'Gender', 'AgeBin'}
-    if stratified_cols.issubset(set(data.columns)):
+    # Check for stratified format — normalize column names for flexible matching
+    col_lower = {c.lower(): c for c in data.columns}
+    has_year   = 'year' in col_lower
+    has_sex    = 'gender' in col_lower or 'sex' in col_lower
+    has_agebin = 'agebin' in col_lower or 'age_bin' in col_lower or 'age' in col_lower
+
+    if has_year and has_sex and has_agebin:
         return _parse_stratified_df(data, yearvec)
 
     # Legacy single-column format: index=years, column in valid_names
@@ -104,16 +108,64 @@ def _parse_coverage_df(data, valid_names, yearvec):
     raise ValueError(errormsg)
 
 
+def _normalize_stratified_cols(data):
+    """
+    Normalize column names in a stratified DataFrame to canonical form.
+    Supports: Year/year, Gender/Sex/gender/sex, AgeBin/age_bin/agebin/age,
+    Count/count, lb/LB, ub/UB.
+
+    Returns a copy of the DataFrame with canonical column names, and raises
+    ValueError if required columns (year, sex/gender, age bin) are missing.
+    """
+    rename = {}
+    col_lower = {c.lower(): c for c in data.columns}
+
+    # Year
+    for alias in ['year']:
+        if alias in col_lower:
+            rename[col_lower[alias]] = 'Year'
+            break
+    else:
+        raise ValueError(f'Stratified coverage DataFrame must have a "Year" column. Found: {list(data.columns)}')
+
+    # Sex/Gender
+    for alias in ['gender', 'sex']:
+        if alias in col_lower:
+            rename[col_lower[alias]] = 'Gender'
+            break
+    else:
+        raise ValueError(f'Stratified coverage DataFrame must have a "Gender" or "Sex" column. Found: {list(data.columns)}')
+
+    # Age bin
+    for alias in ['agebin', 'age_bin', 'age']:
+        if alias in col_lower:
+            rename[col_lower[alias]] = 'AgeBin'
+            break
+    else:
+        raise ValueError(f'Stratified coverage DataFrame must have an "AgeBin" or "Age" column. Found: {list(data.columns)}')
+
+    # Optional columns
+    for alias, canonical in [('count', 'Count'), ('lb', 'lb'), ('ub', 'ub')]:
+        if alias in col_lower:
+            rename[col_lower[alias]] = canonical
+
+    df = data.rename(columns=rename)
+    return df
+
+
 def _parse_stratified_df(data, yearvec):
     """
-    Parse a stratified coverage DataFrame with Year, Gender, AgeBin columns.
+    Parse a stratified coverage DataFrame.
+
+    Accepts flexible column names (Year/year, Gender/Sex, AgeBin/age_bin/age).
+    The value column is detected as the first numeric column that's not a
+    metadata column (Year, Gender, AgeBin, Count, lb, ub).
 
     Returns a dict keyed by (age_bin, sex) with interpolated arrays, plus
     the list of age_bins and sex_keys for iteration.
-
-    The value column is detected as the first numeric column that's not
-    Year, Gender, Count, lb, ub.
     """
+    data = _normalize_stratified_cols(data)
+
     skip_cols = {'Year', 'Gender', 'AgeBin', 'Count', 'lb', 'ub'}
     val_col = None
     for col in data.columns:
@@ -139,7 +191,6 @@ def _parse_stratified_df(data, yearvec):
             else:
                 years = subset['Year'].values.astype(float)
                 vals  = subset[val_col].values.astype(float)
-                # Fill NaNs with the last known value
                 mask = ~np.isnan(vals)
                 if mask.any():
                     vals = np.interp(years, years[mask], vals[mask])

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -237,7 +237,39 @@ class HIVDx(ss.Product):
 
 class HIVTest(STITest):
     """
-    Base class for HIV testing
+    HIV-specific testing intervention.
+
+    Tests eligible agents for HIV; positive results set hiv.diagnosed=True,
+    which is a prerequisite for ART initiation. By default, only undiagnosed
+    agents are eligible.
+
+    The testing → diagnosis → ART pipeline works as follows:
+
+        1. HIVTest tests eligible agents each timestep (per-year probability)
+        2. Positive results set hiv.diagnosed=True and hiv.ti_diagnosed
+        3. ART checks for newly diagnosed agents (ti_diagnosed == current ti)
+        4. Newly diagnosed agents initiate ART with probability art_initiation
+        5. If coverage data is provided, ART corrects to match targets
+
+    Args:
+        test_prob_data: per-year testing probability (scaled by dt). A value of
+            0.1 means ~10% of eligible agents tested per year. With monthly dt,
+            this is ~0.83% per timestep. Use 1/dt (e.g. 12) to test everyone
+            immediately.
+        eligibility (func): who can be tested. Default: undiagnosed agents.
+        start (float): year testing begins
+
+    Example::
+
+        # Test 20% of undiagnosed agents per year starting in 2000
+        test = sti.HIVTest(test_prob_data=0.2, start=2000, name='hiv_test')
+
+        # FSW-targeted testing at higher rate
+        fsw_test = sti.HIVTest(
+            test_prob_data=0.5,
+            name='fsw_test',
+            eligibility=lambda sim: sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.diagnosed,
+        )
     """
     def __init__(self, product=None, pars=None, test_prob_data=None, years=None, start=None, eligibility=None, name=None, label=None, **kwargs):
         if product is None: product = HIVDx(name=f'HIVDx_{name}')
@@ -256,18 +288,47 @@ class HIVTest(STITest):
 
 class ART(ss.Intervention):
     """
-    ART-treatment intervention.
+    Antiretroviral therapy intervention.
 
-    Coverage can be specified as:
-        - A scalar (constant proportion of infected)
-        - A dict with 'year' and 'value' keys (interpolated over time)
-        - A DataFrame with index=years, single column 'n_art' or 'p_art' (legacy)
-        - A DataFrame with Year/Gender/AgeBin columns (age/sex stratified)
+    Requires HIVTest (or equivalent) to diagnose agents first — ART only
+    initiates agents who have hiv.diagnosed=True. A warning is raised if no
+    HIVTest is found in the sim.
+
+    Processing flow each timestep:
+        1. Agents scheduled to stop ART are removed
+        2. Newly diagnosed agents (ti_diagnosed == this timestep) are filtered
+           by art_initiation probability
+        3. If coverage is specified: agents are added/removed to match the target
+           number, prioritized by CD4 count and care-seeking propensity
+        4. If no coverage is specified: all newly diagnosed who pass art_initiation
+           go directly on ART (no capacity constraint)
+        5. Mothers on ART protect unborn infants (rel_sus=0) via MaternalNet
+
+    Coverage can be specified in several formats:
+        - None: no coverage target; treat all who initiate (default)
+        - Scalar (e.g. 0.8): constant proportion of infected on ART
+        - Dict: {'year': [2000, 2020], 'value': [0, 0.9]} — interpolated
+        - DataFrame: index=years, column 'n_art' (numbers) or 'p_art' (proportion)
+        - Stratified DataFrame: columns Year, Gender/Sex, AgeBin + a value column
 
     Args:
-        coverage:         coverage data in any supported format
-        art_initiation:   probability that a newly diagnosed person initiates ART (ss.bernoulli)
-        coverage_data:    deprecated, use coverage instead
+        coverage:         coverage target in any format above
+        art_initiation:   probability a newly diagnosed person initiates ART
+                          (default: ss.bernoulli(p=0.9))
+
+    Example::
+
+        # Simple: 80% of infected on ART
+        art = sti.ART(coverage=0.8)
+
+        # Time-varying coverage
+        art = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})
+
+        # No coverage target — just treat everyone who gets diagnosed
+        art = sti.ART()
+
+        # From a CSV file
+        art = sti.ART(coverage=pd.read_csv('art_coverage.csv').set_index('year'))
     """
 
     def __init__(self, pars=None, coverage=None, coverage_data=None, **kwargs):
@@ -461,19 +522,30 @@ class ART(ss.Intervention):
 
 class VMMC(ss.Intervention):
     """
-    Voluntary medical male circumcision intervention.
+    Voluntary medical male circumcision.
 
-    Coverage can be specified as:
-        - A scalar (constant proportion of males)
-        - A dict with 'year' and 'value' keys (interpolated over time)
-        - A DataFrame with index=years, single column 'n_vmmc' or 'p_vmmc' (legacy)
-        - A DataFrame with Year/Gender/AgeBin columns (age stratified)
+    Reduces male susceptibility to HIV acquisition by eff_circ (default 60%).
+    Unlike ART, VMMC does not require diagnosis — it circumcises males up to a
+    coverage target, prioritized by willingness (a random per-agent score).
+
+    If no coverage is specified, VMMC does nothing. Coverage must be provided
+    explicitly via the coverage parameter.
+
+    Coverage formats (same as ART):
+        - Scalar: constant proportion of males (e.g. 0.3)
+        - Dict: {'year': [...], 'value': [...]} — interpolated
+        - DataFrame: index=years, column 'n_vmmc' or 'p_vmmc'
+        - Stratified DataFrame: Year/Gender/AgeBin columns
 
     Args:
-        coverage:    coverage data in any supported format
-        eff_circ:    efficacy of circumcision (reduction in HIV acquisition risk)
-        eligibility: optional eligibility function or filter
-        coverage_data: deprecated, use coverage instead
+        coverage:    coverage target in any format above
+        eff_circ:    efficacy (default 0.6 = 60% reduction in HIV acquisition)
+        eligibility: optional eligibility function
+
+    Example::
+
+        vmmc = sti.VMMC(coverage=0.3)
+        vmmc = sti.VMMC(coverage={'year': [2010, 2025], 'value': [0, 0.4]})
     """
 
     def __init__(self, pars=None, coverage=None, coverage_data=None, eligibility=None, **kwargs):
@@ -578,7 +650,23 @@ class VMMC(ss.Intervention):
 
 
 class Prep(ss.Intervention):
-    """ PrEP for FSW """
+    """
+    Pre-exposure prophylaxis (PrEP) for female sex workers.
+
+    Reduces HIV susceptibility by eff_prep (default 80%) for eligible FSWs
+    who are HIV-negative and not already on PrEP. Coverage ramps up over
+    time according to the years/coverage parameters.
+
+    Args:
+        coverage (list):  coverage values at each year (default ramps 0→80%)
+        years (list):     corresponding years
+        eff_prep (float): efficacy (default 0.8 = 80% reduction in acquisition)
+        eligibility:      optional custom eligibility function
+
+    Example::
+
+        prep = sti.Prep(coverage=[0, 0.5], years=[2020, 2025])
+    """
     def __init__(self, pars=None, eligibility=None, **kwargs):
         super().__init__()
         self.define_pars(

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -245,24 +245,29 @@ class HIVTest(STITest):
 
     The testing → diagnosis → ART pipeline works as follows:
 
-        1. HIVTest tests eligible agents each timestep (per-year probability)
+        1. HIVTest tests eligible agents each timestep (annual rate, scaled by dt)
         2. Positive results set hiv.diagnosed=True and hiv.ti_diagnosed
         3. ART checks for newly diagnosed agents (ti_diagnosed == current ti)
         4. Newly diagnosed agents initiate ART with probability art_initiation
         5. If coverage data is provided, ART corrects to match targets
 
     Args:
-        test_prob_data: per-year testing probability (scaled by dt). A value of
-            0.1 means ~10% of eligible agents tested per year. With monthly dt,
-            this is ~0.83% per timestep. Use 1/dt (e.g. 12) to test everyone
-            immediately.
+        test_prob_data: annual testing rate (default interpretation with
+            dt_scale=True). A value of 0.1 means ~10% of eligible agents tested
+            per year. To specify a per-timestep probability instead, set
+            dt_scale=False.
         eligibility (func): who can be tested. Default: undiagnosed agents.
         start (float): year testing begins
+        dt_scale (bool): if True (default), test_prob_data is an annual rate,
+            automatically scaled by dt. Set to False for per-timestep probability.
 
     Example::
 
         # Test 20% of undiagnosed agents per year starting in 2000
         test = sti.HIVTest(test_prob_data=0.2, start=2000, name='hiv_test')
+
+        # Test everyone every timestep (per-timestep probability)
+        test = sti.HIVTest(test_prob_data=1.0, dt_scale=False, name='hiv_test')
 
         # FSW-targeted testing at higher rate
         fsw_test = sti.HIVTest(

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -108,14 +108,32 @@ def _parse_coverage_df(data, valid_names, yearvec):
     raise ValueError(errormsg)
 
 
+def _normalize_sex(val):
+    """
+    Normalize a gender/sex value to integer form.
+    Convention: 0 = female, 1 = male.
+
+    Accepts: 0, 1, 'f', 'm', 'female', 'male' (case-insensitive).
+    """
+    if isinstance(val, str):
+        v = val.strip().lower()
+        if v in ('f', 'female'): return 0
+        if v in ('m', 'male'):   return 1
+        raise ValueError(f'Cannot parse sex value: {val!r}. Expected 0/1, f/m, or female/male.')
+    return int(val)
+
+
 def _normalize_stratified_cols(data):
     """
-    Normalize column names in a stratified DataFrame to canonical form.
+    Normalize column names and gender values in a stratified DataFrame.
     Supports: Year/year, Gender/Sex/gender/sex, AgeBin/age_bin/agebin/age,
     Count/count, lb/LB, ub/UB.
 
-    Returns a copy of the DataFrame with canonical column names, and raises
-    ValueError if required columns (year, sex/gender, age bin) are missing.
+    Gender values are normalized to integers: 0 = female, 1 = male.
+    Accepts: 0/1, 'f'/'m', 'female'/'male' (case-insensitive).
+
+    Returns a copy of the DataFrame with canonical column names and normalized
+    gender values.
     """
     rename = {}
     col_lower = {c.lower(): c for c in data.columns}
@@ -150,6 +168,10 @@ def _normalize_stratified_cols(data):
             rename[col_lower[alias]] = canonical
 
     df = data.rename(columns=rename)
+
+    # Normalize gender values to integers: 0=female, 1=male
+    df['Gender'] = df['Gender'].map(_normalize_sex)
+
     return df
 
 
@@ -426,7 +448,7 @@ class ART(ss.Intervention):
 
                 # Find eligible agents in this stratum
                 age_mask = (sim.people.age >= lo) & (sim.people.age < hi)
-                sex_mask = sim.people.female if sex == 1 else sim.people.male
+                sex_mask = sim.people.female if sex == 0 else sim.people.male
                 stratum_uids = eligible_uids[age_mask[eligible_uids] & sex_mask[eligible_uids]]
 
                 if self.coverage_format == 'n':
@@ -629,7 +651,7 @@ class VMMC(ss.Intervention):
         total = 0
         for ab in self.age_bins:
             lo, hi = _parse_age_bin(ab)
-            for sex in (self.sex_keys or [0]):  # VMMC is males only, but handle data gracefully
+            for sex in (self.sex_keys or [1]):  # VMMC is males only (1=male); handle data gracefully
                 cov = self.coverage.get((ab, sex), np.zeros(1))
                 cov_val = cov[self.ti] if len(cov) > self.ti else cov[-1]
                 age_mask = (sim.people.age >= lo) & (sim.people.age < hi)

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -329,8 +329,11 @@ class ART(ss.Intervention):
         # Time-varying coverage
         art = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})
 
-        # No coverage target — just treat everyone who gets diagnosed
+        # No coverage target — 90% of newly diagnosed initiate (default art_initiation)
         art = sti.ART()
+
+        # Treat ALL diagnosed with no coverage constraint
+        art = sti.ART(art_initiation=1)
 
         # From a CSV file
         art = sti.ART(coverage=pd.read_csv('art_coverage.csv').set_index('year'))
@@ -342,13 +345,8 @@ class ART(ss.Intervention):
         # Handle deprecated kwargs
         coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
 
-        # Handle deprecated init_prob → art_initiation
-        init_prob = kwargs.pop('init_prob', None)
-        if init_prob is not None:
-            warnings.warn('init_prob is deprecated; use art_initiation instead', FutureWarning, stacklevel=2)
-
         self.define_pars(
-            art_initiation=init_prob if init_prob is not None else ss.bernoulli(p=0.9),
+            art_initiation=ss.bernoulli(p=0.9),
         )
         self.update_pars(pars, **kwargs)
 

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -3,14 +3,169 @@ Define HIV interventions for STIsim
 By default, these all have units of a year and timesteps of 1/12
 """
 
+import warnings
 import starsim as ss
 import numpy as np
+import pandas as pd
 import sciris as sc
 from stisim.interventions.base_interventions import STITest
 
 
 # %% Helper functions
 def count(arr): return np.count_nonzero(arr)
+
+
+def parse_coverage(data, valid_names=None, yearvec=None):
+    """
+    Parse coverage data into a per-timestep array.
+
+    Accepts multiple input formats and normalizes them into
+    (coverage_array, coverage_format, age_bins, sex_keys) where:
+        - coverage_array: 1D array (len=yearvec) for aggregate, or dict of arrays for stratified
+        - coverage_format: 'n' (absolute numbers) or 'p' (proportion)
+        - age_bins: list of (lo, hi) tuples if stratified, else None
+        - sex_keys: list of sex values if stratified, else None
+
+    Supported input formats:
+        None                      → (None, None, None, None)
+        0.9                       → constant proportion
+        {'year': [...], 'value': [...]}                          → interpolated, infer format
+        {'year': [...], 'value': [...], 'format': 'n'}          → interpolated, explicit format
+        pd.DataFrame(index=years, columns=['n_art'])             → legacy single-column
+        pd.DataFrame(columns=['Year','Gender','AgeBin',...])     → age/sex stratified
+
+    Args:
+        data:        coverage input in any supported format
+        valid_names: list of valid column names, e.g. ['n_art', 'p_art']
+        yearvec:     simulation year vector for interpolation
+    """
+    if valid_names is None:
+        valid_names = []
+
+    # None → no coverage
+    if data is None:
+        return None, None, None, None
+
+    # Scalar → constant proportion
+    if sc.isnumber(data):
+        arr = np.full(len(yearvec), float(data))
+        return arr, 'p', None, None
+
+    # Dict with year + value keys → interpolate
+    if isinstance(data, dict) and 'year' in data and 'value' in data:
+        years  = np.array(data['year'], dtype=float)
+        values = np.array(data['value'], dtype=float)
+        fmt = data.get('format', None)
+        if fmt is None:
+            fmt = 'p' if np.all(values <= 1.0) else 'n'
+        arr = sc.smoothinterp(yearvec, years, values, smoothness=0)
+        return arr, fmt, None, None
+
+    # DataFrame — check for stratified vs legacy
+    if isinstance(data, pd.DataFrame):
+        return _parse_coverage_df(data, valid_names, yearvec)
+
+    errormsg = f'Coverage data format not recognized: {type(data)}. Expected None, number, dict, or DataFrame.'
+    raise ValueError(errormsg)
+
+
+def _parse_coverage_df(data, valid_names, yearvec):
+    """
+    Parse a DataFrame of coverage data.
+
+    Handles two cases:
+        1. Legacy: index=years, single column in valid_names → 1D interpolated array
+        2. Stratified: columns include Year, Gender, AgeBin, and a value column → dict of arrays by (age, sex)
+    """
+
+    # Check for stratified format (has Year, Gender, AgeBin columns)
+    stratified_cols = {'Year', 'Gender', 'AgeBin'}
+    if stratified_cols.issubset(set(data.columns)):
+        return _parse_stratified_df(data, yearvec)
+
+    # Legacy single-column format: index=years, column in valid_names
+    if len(data.columns) == 1 and data.columns[0] in valid_names:
+        colname = data.columns[0]
+        fmt = 'n' if colname.startswith('n_') else 'p'
+        arr = sc.smoothinterp(yearvec, data.index.values, data[colname].values, smoothness=0)
+        return arr, fmt, None, None
+
+    # Try to find a valid column
+    for col in data.columns:
+        if col in valid_names:
+            fmt = 'n' if col.startswith('n_') else 'p'
+            if data.index.name in ['year', 'Year'] or np.all(data.index > 1900):
+                arr = sc.smoothinterp(yearvec, data.index.values, data[col].values, smoothness=0)
+            else:
+                arr = sc.smoothinterp(yearvec, np.arange(len(data)), data[col].values, smoothness=0)
+            return arr, fmt, None, None
+
+    errormsg = f'DataFrame columns {list(data.columns)} do not match any valid names {valid_names}.'
+    raise ValueError(errormsg)
+
+
+def _parse_stratified_df(data, yearvec):
+    """
+    Parse a stratified coverage DataFrame with Year, Gender, AgeBin columns.
+
+    Returns a dict keyed by (age_bin, sex) with interpolated arrays, plus
+    the list of age_bins and sex_keys for iteration.
+
+    The value column is detected as the first numeric column that's not
+    Year, Gender, Count, lb, ub.
+    """
+    skip_cols = {'Year', 'Gender', 'AgeBin', 'Count', 'lb', 'ub'}
+    val_col = None
+    for col in data.columns:
+        if col not in skip_cols and pd.api.types.is_numeric_dtype(data[col]):
+            val_col = col
+            break
+    if val_col is None:
+        raise ValueError(f'Could not find a numeric value column in stratified coverage DataFrame. Columns: {list(data.columns)}')
+
+    fmt = 'p' if data[val_col].dropna().max() <= 1.0 else 'n'
+
+    # Extract unique age bins and sex keys
+    age_bins = sorted(data['AgeBin'].unique())
+    sex_keys = sorted(data['Gender'].unique())
+
+    # Build interpolated arrays for each (age_bin, sex) combination
+    coverage = {}
+    for ab in age_bins:
+        for sex in sex_keys:
+            subset = data[(data['AgeBin'] == ab) & (data['Gender'] == sex)].sort_values('Year')
+            if len(subset) == 0:
+                coverage[(ab, sex)] = np.zeros(len(yearvec))
+            else:
+                years = subset['Year'].values.astype(float)
+                vals  = subset[val_col].values.astype(float)
+                # Fill NaNs with the last known value
+                mask = ~np.isnan(vals)
+                if mask.any():
+                    vals = np.interp(years, years[mask], vals[mask])
+                coverage[(ab, sex)] = sc.smoothinterp(yearvec, years, vals, smoothness=0)
+
+    return coverage, fmt, age_bins, sex_keys
+
+
+def _handle_deprecated_coverage(coverage, coverage_data, kwargs):
+    """
+    Handle deprecated coverage_data and future_coverage kwargs.
+    Returns the normalized coverage input and any remaining future_coverage.
+    """
+    future_coverage = kwargs.pop('future_coverage', None)
+
+    if coverage_data is not None and coverage is not None:
+        raise ValueError('Cannot specify both coverage and coverage_data. Use coverage only.')
+
+    if coverage_data is not None:
+        warnings.warn('coverage_data is deprecated; use coverage instead', FutureWarning, stacklevel=3)
+        coverage = coverage_data
+
+    if future_coverage is not None:
+        warnings.warn('future_coverage is deprecated; extend coverage data to cover the full simulation period instead', FutureWarning, stacklevel=3)
+
+    return coverage, future_coverage
 
 
 # %% HIV classes
@@ -50,56 +205,124 @@ class HIVTest(STITest):
 
 class ART(ss.Intervention):
     """
-    ART-treatment intervention by Robyn Stuart, Daniel Klein and Cliff Kerr, edited by Alina Muellenmeister
+    ART-treatment intervention.
+
+    Coverage can be specified as:
+        - A scalar (constant proportion of infected)
+        - A dict with 'year' and 'value' keys (interpolated over time)
+        - A DataFrame with index=years, single column 'n_art' or 'p_art' (legacy)
+        - A DataFrame with Year/Gender/AgeBin columns (age/sex stratified)
+
+    Args:
+        coverage:         coverage data in any supported format
+        art_initiation:   probability that a newly diagnosed person initiates ART (ss.bernoulli)
+        coverage_data:    deprecated, use coverage instead
     """
 
-    def __init__(self, pars=None, coverage_data=None, start_year=None, **kwargs):
+    def __init__(self, pars=None, coverage=None, coverage_data=None, **kwargs):
         super().__init__()
+
+        # Handle deprecated kwargs
+        coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
+
+        # Handle deprecated init_prob → art_initiation
+        init_prob = kwargs.pop('init_prob', None)
+        if init_prob is not None:
+            warnings.warn('init_prob is deprecated; use art_initiation instead', FutureWarning, stacklevel=2)
+
         self.define_pars(
-            init_prob=ss.bernoulli(p=0.9),  # Probability that a newly diagnosed person will initiate treatment
-            future_coverage={'year': 2022, 'prop': 0.85},
+            art_initiation=init_prob if init_prob is not None else ss.bernoulli(p=0.9),
         )
         self.update_pars(pars, **kwargs)
-        self.coverage_data = coverage_data
-        self.coverage = None  # Set below
-        self.coverage_format = None  # Set below
+
+        self._raw_coverage    = coverage
+        self._future_coverage = future_coverage  # Legacy compat, removed once deprecated
+        self.coverage         = None  # Set in init_pre
+        self.coverage_format  = None  # 'n' or 'p'
+        self.age_bins         = None  # For stratified coverage
+        self.sex_keys         = None  # For stratified coverage
         return
 
     def init_pre(self, sim):
         super().init_pre(sim)
-        data = self.coverage_data
-        if data is not None:
-            if (len(data.columns) > 1) or (data.columns[0] not in ['n_art', 'p_art']):
-                errormsg = 'Expecting a dataframe with a single column labeled n_art or p_art'
-                raise ValueError(errormsg)
-            colname = data.columns[0]
-            self.coverage_format = colname
-            self.coverage = sc.smoothinterp(self.t.yearvec, data.index.values, data[colname].values)
+
+        # Warn if no HIV testing intervention found
+        has_hiv_test = any(isinstance(m, HIVTest) for m in sim.interventions())
+        if not has_hiv_test:
+            ss.warn('ART intervention added without an HIV testing intervention; diagnosed agents may never be identified')
+
+        # Parse coverage data
+        self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
+            self._raw_coverage, valid_names=['n_art', 'p_art'], yearvec=self.t.yearvec,
+        )
         self.initialized = True
         return
 
+    def _get_n_to_treat(self, eligible_uids):
+        """
+        Get the target number of people on ART this timestep.
+
+        For stratified coverage, returns a dict of {(age_bin, sex): n_to_treat}.
+        For aggregate coverage, returns an int.
+        """
+        # Legacy future_coverage mode
+        if self._future_coverage is not None and self.t.now('year') >= self._future_coverage['year']:
+            p_cov = self._future_coverage['prop']
+            return int(p_cov * len(eligible_uids))
+
+        if self.coverage is None:
+            return 0
+
+        # Stratified coverage
+        if isinstance(self.coverage, dict):
+            return self._get_n_to_treat_stratified(eligible_uids)
+
+        # Aggregate coverage
+        if self.coverage_format == 'n':
+            return int(self.coverage[self.ti] / self.sim.pars.pop_scale)
+        else:
+            return int(self.coverage[self.ti] * len(eligible_uids))
+
+    def _get_n_to_treat_stratified(self, eligible_uids):
+        """
+        Compute target ART numbers by age/sex stratum.
+
+        Returns the total target across all strata.
+        """
+        sim = self.sim
+        total = 0
+
+        for ab in self.age_bins:
+            lo, hi = _parse_age_bin(ab)
+            for sex in self.sex_keys:
+                cov = self.coverage.get((ab, sex), np.zeros(1))
+                cov_val = cov[self.ti] if len(cov) > self.ti else cov[-1]
+
+                # Find eligible agents in this stratum
+                age_mask = (sim.people.age >= lo) & (sim.people.age < hi)
+                sex_mask = sim.people.female if sex == 1 else sim.people.male
+                stratum_uids = eligible_uids[age_mask[eligible_uids] & sex_mask[eligible_uids]]
+
+                if self.coverage_format == 'n':
+                    total += int(cov_val / sim.pars.pop_scale)
+                else:
+                    total += int(cov_val * len(stratum_uids))
+
+        return total
+
     def step(self):
         """
-        Apply the ART intervention at each time step. Put agents on and off ART and adjust based on data.
+        Apply ART at each timestep: stop ART for those scheduled, initiate for newly diagnosed,
+        and correct overall coverage to match targets.
         """
         sim = self.sim
         hiv = sim.diseases.hiv
         inf_uids = hiv.infected.uids
 
-        # Figure out how many people should be treated
-        if self.t.now('year') < self.pars.future_coverage['year']:
-            if self.coverage is None:
-                n_to_treat = 0
-            else:
-                if self.coverage_format == 'n_art':
-                    n_to_treat = int(self.coverage[self.ti]/sim.pars.pop_scale)
-                elif self.coverage_format == 'p_art':
-                    n_to_treat = int(self.coverage[self.ti]*len(inf_uids))
-        else:
-            p_cov = self.pars.future_coverage['prop']
-            n_to_treat = int(p_cov*len(inf_uids))
+        # Determine treatment target
+        n_to_treat = self._get_n_to_treat(inf_uids)
 
-        # Firstly, check who is stopping ART
+        # Check who is stopping ART
         if hiv.on_art.any():
             stopping = hiv.on_art & (hiv.ti_stop_art <= self.ti)
             if stopping.any():
@@ -109,20 +332,17 @@ class ART(ss.Intervention):
                     errormsg = f'Error stopping ART for {stopping.uids}'
                     raise ValueError(errormsg)
 
-        # Next, see how many people we need to treat vs how many are already being treated
+        # Initiate ART for newly diagnosed
         on_art = hiv.on_art
-
-        # A proportion of newly diagnosed agents onto ART will be willing to initiate ART
         diagnosed = hiv.ti_diagnosed == self.ti
         if len(diagnosed.uids):
-            dx_to_treat = self.pars.init_prob.filter(diagnosed.uids)
+            dx_to_treat = self.pars.art_initiation.filter(diagnosed.uids)
 
-            # Figure out if there are treatment spots available and if so, prioritize newly diagnosed agents
             n_available_spots = n_to_treat - len(on_art.uids)
             if n_available_spots > 0:
                 self.prioritize_art(sim, n=n_available_spots, awaiting_art_uids=dx_to_treat)
 
-        # Apply correction to match ART coverage data:
+        # Correct coverage to match target
         self.art_coverage_correction(sim, target_coverage=n_to_treat)
 
         # Adjust rel_sus for protected unborn agents (only if pregnancy is modeled)
@@ -135,9 +355,7 @@ class ART(ss.Intervention):
         return
 
     def prioritize_art(self, sim, n=None, awaiting_art_uids=None):
-        """
-        Prioritize ART to n agents among those awaiting treatment
-        """
+        """ Prioritize ART to n agents among those awaiting treatment """
         hiv = sim.diseases.hiv
         if awaiting_art_uids is None:
             awaiting_art_uids = (hiv.diagnosed & ~hiv.on_art).uids
@@ -146,11 +364,11 @@ class ART(ss.Intervention):
         if n > len(awaiting_art_uids):
             start_uids = awaiting_art_uids
 
-        # Not enough spots - construct weights based on CD4 count and care seeking
+        # Not enough spots — prioritize by CD4 and care seeking
         else:
-            cd4_counts = hiv.cd4[awaiting_art_uids]
+            cd4_counts   = hiv.cd4[awaiting_art_uids]
             care_seeking = hiv.care_seeking[awaiting_art_uids]
-            weights = cd4_counts*(1/care_seeking)
+            weights = cd4_counts * (1 / care_seeking)
             choices = np.argsort(weights)[:n]
             start_uids = awaiting_art_uids[choices]
 
@@ -159,101 +377,133 @@ class ART(ss.Intervention):
         return
 
     def art_coverage_correction(self, sim, target_coverage=None):
-        """
-        Adjust ART coverage to match data
-        """
+        """ Adjust ART coverage to match data """
         hiv = sim.diseases.hiv
         on_art = hiv.on_art
 
-        # Too many agents on treatment -> remove
+        # Too many on treatment → remove
         if len(on_art.uids) > target_coverage:
-
-            # Agents with the highest CD4 counts will go off ART:
-            n_to_stop = int(len(on_art.uids) - target_coverage)
-            on_art_uids = on_art.uids
-
-            # Construct weights and choice distribution
-            cd4_counts = hiv.cd4[on_art_uids]
+            n_to_stop    = int(len(on_art.uids) - target_coverage)
+            on_art_uids  = on_art.uids
+            cd4_counts   = hiv.cd4[on_art_uids]
             care_seeking = hiv.care_seeking[on_art_uids]
-            weights = cd4_counts/care_seeking
-            choices = np.argsort(-weights)[:n_to_stop]
+            weights  = cd4_counts / care_seeking
+            choices  = np.argsort(-weights)[:n_to_stop]
             stop_uids = on_art_uids[choices]
-
             hiv.ti_stop_art[stop_uids] = self.ti
             hiv.stop_art(stop_uids)
 
-        # Not enough agents on treatment -> add
+        # Not enough on treatment → add
         elif len(on_art.uids) < target_coverage:
             n_to_add = target_coverage - len(on_art.uids)
             awaiting_art_uids = (hiv.diagnosed & ~hiv.on_art).uids
             self.prioritize_art(sim, n=n_to_add, awaiting_art_uids=awaiting_art_uids)
 
+        return
+
 
 class VMMC(ss.Intervention):
-    def __init__(self, pars=None, coverage_data=None, eligibility=None, **kwargs):
+    """
+    Voluntary medical male circumcision intervention.
+
+    Coverage can be specified as:
+        - A scalar (constant proportion of males)
+        - A dict with 'year' and 'value' keys (interpolated over time)
+        - A DataFrame with index=years, single column 'n_vmmc' or 'p_vmmc' (legacy)
+        - A DataFrame with Year/Gender/AgeBin columns (age stratified)
+
+    Args:
+        coverage:    coverage data in any supported format
+        eff_circ:    efficacy of circumcision (reduction in HIV acquisition risk)
+        eligibility: optional eligibility function or filter
+        coverage_data: deprecated, use coverage instead
+    """
+
+    def __init__(self, pars=None, coverage=None, coverage_data=None, eligibility=None, **kwargs):
         super().__init__()
+
+        # Handle deprecated kwargs
+        coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
+
         self.define_pars(
-            future_coverage={'year': 2022, 'prop': 0.1},
-            eff_circ = 0.6,  # Evidence of a 60% reduction in risk of HIV acquisition: https://www.who.int/teams/global-hiv-hepatitis-and-stis-programmes/hiv/prevention/voluntary-medical-male-circumcision
+            eff_circ=0.6,
         )
         self.update_pars(pars, **kwargs)
 
-        # Coverage data - can be number or proportion
-        self.coverage_data = coverage_data
-        self.coverage = None  # Set below
-        self.coverage_format = None  # Set below
-        self.eligibility = eligibility  # Determines denominator for coverage if given as a proportion
+        self._raw_coverage    = coverage
+        self._future_coverage = future_coverage
+        self.coverage         = None
+        self.coverage_format  = None
+        self.age_bins         = None
+        self.sex_keys         = None
+        self.eligibility      = eligibility
 
         # States
-        self.willingness = ss.FloatArr('willingness', default=ss.random())  # Willingness to undergo VMMC
-        self.circumcised = ss.BoolArr('circumcised', default=False)
-        self.ti_circumcised = ss.FloatArr('ti_circumcised')
+        self.willingness     = ss.FloatArr('willingness', default=ss.random())
+        self.circumcised     = ss.BoolArr('circumcised', default=False)
+        self.ti_circumcised  = ss.FloatArr('ti_circumcised')
 
         return
 
     def init_pre(self, sim):
         super().init_pre(sim)
-
-        # Handle coverage dataa
-        data = self.coverage_data
-        if data is not None:
-            if (len(data.columns) > 1) or (data.columns[0] not in ['n_vmmc', 'p_vmmc']):
-                errormsg = 'Expecting a dataframe with a single column labeled n_vmmc or p_vmmc'
-                raise ValueError(errormsg)
-            colname = data.columns[0]
-            self.coverage_format = colname
-            self.coverage = sc.smoothinterp(self.t.yearvec, data.index.values, data[colname].values)
-
+        self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
+            self._raw_coverage, valid_names=['n_vmmc', 'p_vmmc'], yearvec=self.t.yearvec,
+        )
         return
 
     def init_results(self):
         super().init_results()
         self.define_results(
-            ss.Result('new_circumcisions', dtype=int, label="New circumcisions", auto_plot=False),
-            ss.Result('n_circumcised', dtype=int, label="Number circumcised", auto_plot=False)
+            ss.Result('new_circumcisions', dtype=int, label='New circumcisions', auto_plot=False),
+            ss.Result('n_circumcised',     dtype=int, label='Number circumcised', auto_plot=False),
         )
         return
+
+    def _get_n_to_circ(self, eligible_uids):
+        """ Get the target number of circumcisions this timestep """
+        # Legacy future_coverage mode
+        if self._future_coverage is not None and self.t.now('year') >= self._future_coverage['year']:
+            return int(self._future_coverage['prop'] * len(eligible_uids))
+
+        if self.coverage is None:
+            return 0
+
+        # Stratified coverage
+        if isinstance(self.coverage, dict):
+            return self._get_n_stratified(eligible_uids)
+
+        # Aggregate coverage
+        if self.coverage_format == 'n':
+            return int(self.coverage[self.ti] / self.sim.pars.pop_scale)
+        else:
+            return int(self.coverage[self.ti] * len(eligible_uids))
+
+    def _get_n_stratified(self, eligible_uids):
+        """ Compute target circumcisions by age stratum """
+        sim = self.sim
+        total = 0
+        for ab in self.age_bins:
+            lo, hi = _parse_age_bin(ab)
+            for sex in (self.sex_keys or [0]):  # VMMC is males only, but handle data gracefully
+                cov = self.coverage.get((ab, sex), np.zeros(1))
+                cov_val = cov[self.ti] if len(cov) > self.ti else cov[-1]
+                age_mask = (sim.people.age >= lo) & (sim.people.age < hi)
+                stratum_uids = eligible_uids[age_mask[eligible_uids]]
+                if self.coverage_format == 'n':
+                    total += int(cov_val / sim.pars.pop_scale)
+                else:
+                    total += int(cov_val * len(stratum_uids))
+        return total
 
     def step(self):
         sim = self.sim
         m_uids = sim.people.male.uids
 
-        # Figure out how many people should be circumcised
-        if self.t.now('year') < self.pars.future_coverage['year']:
-            if self.coverage is None:
-                n_to_circ = 0
-            else:
-                if self.coverage_format == 'n_vmmc':
-                    n_to_circ = int(self.coverage[self.ti]/sim.pars.pop_scale)
-                elif self.coverage_format == 'p_vmmc':
-                    n_to_circ = int(self.coverage[self.ti]*len(m_uids))
-        else:
-            p_cov = self.pars.future_coverage['prop']
-            n_to_circ = int(p_cov*len(m_uids))
+        n_to_circ = self._get_n_to_circ(m_uids)
 
         if n_to_circ > 0:
-            # Find who's eligible to circumcise
-            eligible_uids = (sim.people.male & ~self.circumcised).uids  # Apply eligiblity
+            eligible_uids = (sim.people.male & ~self.circumcised).uids
             weights = self.willingness[eligible_uids]
             choices = np.argsort(-weights)[:n_to_circ]
             new_circs = eligible_uids[choices]
@@ -265,13 +515,13 @@ class VMMC(ss.Intervention):
         self.results['n_circumcised'][self.ti] = count(self.circumcised)
 
         # Reduce rel_sus
-        sim.diseases.hiv.rel_sus[self.circumcised] *= 1-self.pars.eff_circ
+        sim.diseases.hiv.rel_sus[self.circumcised] *= 1 - self.pars.eff_circ
 
         return
 
 
 class Prep(ss.Intervention):
-    """ Prep for FSW """
+    """ PrEP for FSW """
     def __init__(self, pars=None, eligibility=None, **kwargs):
         super().__init__()
         self.define_pars(
@@ -294,6 +544,24 @@ class Prep(ss.Intervention):
             self.pars.coverage_dist.set(p=self.coverage[self.ti])
             el_fsw = self.sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.infected & ~self.on_prep
             fsw_on_prep = self.pars.coverage_dist.filter(el_fsw)
-            self.sim.diseases.hiv.rel_sus[fsw_on_prep] *= 1-self.pars.eff_prep
+            self.sim.diseases.hiv.rel_sus[fsw_on_prep] *= 1 - self.pars.eff_prep
+
+        return
 
 
+# %% Utility functions
+def _parse_age_bin(ab_str):
+    """
+    Parse age bin string like "[15,25)" into (lo, hi).
+    Also handles numeric tuples and plain strings like "15-25".
+    """
+    if isinstance(ab_str, (tuple, list)):
+        return float(ab_str[0]), float(ab_str[1])
+    s = str(ab_str).strip('[]() ')
+    if ',' in s:
+        parts = s.split(',')
+    elif '-' in s:
+        parts = s.split('-')
+    else:
+        raise ValueError(f'Cannot parse age bin: {ab_str}')
+    return float(parts[0].strip()), float(parts[1].strip().rstrip(')'))

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -1,0 +1,337 @@
+"""
+Test HIV interventions: ART, VMMC, PrEP
+
+Tests cover:
+    - ART coverage input format equivalence (scalar, dict, DataFrame, stratified)
+    - ART functional effects (people go on ART, warning without testing)
+    - Scientific validation skeletons (mortality, parameter sensitivity, duration)
+"""
+
+import warnings
+import sciris as sc
+import numpy as np
+import pandas as pd
+import starsim as ss
+import stisim as sti
+import hivsim
+import matplotlib.pyplot as pl
+import pytest
+
+n_agents = 1_000
+do_plot  = False
+sc.options(interactive=False)
+
+
+# %% Coverage format tests
+@sc.timer()
+def test_art_specs(do_plot=do_plot):
+    """ Check that scalar, dict, and DataFrame coverage all produce ART uptake """
+    sc.heading('Testing ART coverage format equivalence...')
+
+    years = np.arange(2000, 2021)
+    p_vals = np.linspace(0, 0.9, len(years))
+
+    specs = dict(
+        scalar = sti.ART(coverage=0.5),
+        dict_p = sti.ART(coverage={'year': [2000, 2020], 'value': [0, 0.9]}),
+        df_p   = sti.ART(coverage=pd.DataFrame(index=years, data={'p_art': p_vals})),
+        df_n   = sti.ART(coverage=pd.DataFrame(index=years, data={'n_art': p_vals * 1e6})),
+    )
+
+    results = dict()
+    for label, art in specs.items():
+        sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+        sim.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), art]
+        sim.run()
+        n_art = sim.results.hiv.n_on_art[-1]
+        results[label] = n_art
+
+    for label, n_art in results.items():
+        assert n_art > 0, f'Expected people on ART with {label} format, got {n_art}'
+
+    if do_plot:
+        fig, ax = pl.subplots()
+        ax.bar(results.keys(), results.values())
+        ax.set_ylabel('People on ART (final)')
+        ax.set_title('ART coverage format comparison')
+
+    return results
+
+
+@sc.timer()
+def test_art_legacy_compat(do_plot=do_plot):
+    """ Check that deprecated coverage_data and future_coverage still work """
+    sc.heading('Testing ART legacy backward compatibility...')
+
+    years = np.arange(2000, 2011)
+    p_vals = np.linspace(0, 0.9, len(years))
+
+    # Legacy coverage_data
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        art1 = sti.ART(coverage_data=pd.DataFrame(index=years, data={'p_art': p_vals}))
+        n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
+    assert n_deprecation >= 1, f'Expected FutureWarning for coverage_data, got {n_deprecation} warnings'
+
+    # Legacy coverage_data + future_coverage
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        art2 = sti.ART(
+            coverage_data=pd.DataFrame(index=years, data={'p_art': p_vals}),
+            future_coverage={'year': 2008, 'prop': 0.85},
+        )
+        n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
+    assert n_deprecation >= 2, f'Expected 2+ FutureWarnings for coverage_data+future_coverage, got {n_deprecation}'
+
+    # Legacy init_prob
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        art3 = sti.ART(coverage=0.5, init_prob=ss.bernoulli(p=0.5))
+        n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
+    assert n_deprecation >= 1, f'Expected FutureWarning for init_prob, got {n_deprecation}'
+
+    # Run both legacy sims to verify they work
+    for art in [art1, art2]:
+        sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+        sim.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), art]
+        sim.run()
+        assert sim.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with legacy format'
+
+    return
+
+
+@sc.timer()
+def test_vmmc_specs(do_plot=do_plot):
+    """ Check that scalar and dict VMMC coverage produce circumcisions """
+    sc.heading('Testing VMMC coverage formats...')
+
+    specs = dict(
+        scalar = sti.VMMC(coverage=0.3),
+        dict_p = sti.VMMC(coverage={'year': [2000, 2020], 'value': [0, 0.3]}),
+        df_p   = sti.VMMC(coverage=pd.DataFrame(index=np.arange(2000, 2021), data={'p_vmmc': np.linspace(0, 0.3, 21)})),
+    )
+
+    results = dict()
+    for label, vmmc in specs.items():
+        sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+        sim.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.1), vmmc]
+        sim.run()
+        n_circ = sim.results.vmmc.n_circumcised[-1]
+        results[label] = n_circ
+
+    for label, n_circ in results.items():
+        assert n_circ > 0, f'Expected circumcisions with {label} format, got {n_circ}'
+
+    return results
+
+
+@sc.timer()
+def test_art_stratified_coverage(do_plot=do_plot):
+    """ Check that age/sex stratified coverage data is parsed and applied """
+    sc.heading('Testing stratified ART coverage...')
+
+    rows = []
+    for year in [2005, 2015]:
+        for gender in [0, 1]:
+            for age_bin in ['[15,25)', '[25,35)', '[35,45)']:
+                p = 0.3 if year == 2005 else 0.7
+                p *= (1.2 if gender == 1 else 1.0)
+                rows.append(dict(Year=year, Gender=gender, AgeBin=age_bin, NationalARTPrevalence=min(p, 1.0)))
+    strat_df = pd.DataFrame(rows)
+
+    sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+    sim.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), sti.ART(coverage=strat_df)]
+    sim.run()
+    assert sim.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with stratified coverage'
+
+    return sim
+
+
+# %% Functional tests
+@sc.timer()
+def test_art_effects(do_plot=do_plot):
+    """ Check that ART puts people on treatment with testing, and warns without """
+    sc.heading('Testing ART functional effects...')
+
+    # With testing → people on ART
+    sim_with = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+    sim_with.run()
+    n_art = sim_with.results.hiv.n_on_art[-1]
+    assert n_art > 0, f'Expected people on ART with the default demo, got {n_art}'
+
+    # Without testing → warning raised and no-one on ART
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        sim_without = sti.Sim(
+            diseases=sti.HIV(beta_m2f=0.05, init_prev=0.05),
+            networks=sti.StructuredSexual(),
+            demographics=[ss.Pregnancy(fertility_rate=10), ss.Deaths(death_rate=10)],
+            interventions=[sti.ART(coverage=0.9)],
+            n_agents=n_agents, dur=20, verbose=-1,
+        )
+        sim_without.run()
+        warn_texts = [str(x.message) for x in w]
+        has_testing_warn = any('testing' in t.lower() for t in warn_texts)
+
+    assert has_testing_warn, 'Expected a warning about missing HIV testing intervention'
+    n_art_no_test = sim_without.results.hiv.n_on_art[-1]
+    assert n_art_no_test == 0, f'Expected no-one on ART without testing, got {n_art_no_test}'
+
+    if do_plot:
+        fig, axes = pl.subplots(1, 2, figsize=(12, 5))
+        axes[0].plot(sim_with.t.yearvec, sim_with.results.hiv.n_on_art)
+        axes[0].set_title('With testing')
+        axes[0].set_ylabel('People on ART')
+        axes[1].plot(sim_without.t.yearvec, sim_without.results.hiv.n_on_art)
+        axes[1].set_title('Without testing')
+
+    return sim_with, sim_without
+
+
+@sc.timer()
+def test_art_no_pregnancy(do_plot=do_plot):
+    """ Check that ART works when pregnancy is not in the sim (issue #313) """
+    sc.heading('Testing ART without pregnancy module...')
+
+    sim = sti.Sim(
+        diseases=sti.HIV(beta_m2f=0.05, init_prev=0.05),
+        networks=sti.StructuredSexual(),
+        demographics=[ss.Deaths(death_rate=10)],
+        interventions=[
+            sti.HIVTest(name='hiv_test', test_prob_data=0.3),
+            sti.ART(coverage=0.8),
+        ],
+        n_agents=n_agents, dur=20, verbose=-1,
+    )
+    sim.run()
+    assert sim.results.hiv.n_on_art[-1] > 0, 'Expected people on ART without pregnancy module'
+
+    return sim
+
+
+# %% Scientific validation skeletons
+@sc.timer()
+def test_art_reduces_mortality(do_plot=do_plot):
+    """ Check that HIV mortality is lower with ART than without """
+    sc.heading('Testing ART reduces mortality...')
+
+    # Without ART
+    sim_no_art = hivsim.demo('simple', run=False, plot=False, n_agents=2_000)
+    sim_no_art.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3)]
+    sim_no_art.run()
+
+    # With ART
+    sim_art = hivsim.demo('simple', run=False, plot=False, n_agents=2_000)
+    sim_art.pars.interventions = [
+        sti.HIVTest(name='hiv_test', test_prob_data=0.3),
+        sti.ART(coverage=0.8),
+    ]
+    sim_art.run()
+
+    deaths_no_art = float(np.sum(sim_no_art.results.hiv.new_deaths))
+    deaths_art    = float(np.sum(sim_art.results.hiv.new_deaths))
+
+    if do_plot:
+        fig, ax = pl.subplots()
+        ax.plot(sim_no_art.t.yearvec, np.cumsum(sim_no_art.results.hiv.new_deaths), label='No ART')
+        ax.plot(sim_art.t.yearvec, np.cumsum(sim_art.results.hiv.new_deaths), label='With ART')
+        ax.legend()
+        ax.set_ylabel('Cumulative HIV deaths')
+        ax.set_title('ART mortality reduction')
+
+    # TODO: uncomment once parameterized and validated with sufficient population
+    # assert deaths_art < deaths_no_art, f'Expected fewer deaths with ART ({deaths_art}) than without ({deaths_no_art})'
+
+    return sim_no_art, sim_art
+
+
+@sc.timer()
+def test_art_parameter_sensitivity(do_plot=do_plot):
+    """ Check that ART coverage and initiation parameters affect outcomes as expected """
+    sc.heading('Testing ART parameter sensitivity...')
+
+    # TODO: collaborator to implement
+    # Vary art_initiation probability (low vs high)
+    # Vary coverage level (low vs high)
+    # Assert: higher coverage → more people on ART
+    # Assert: higher initiation → faster ART uptake
+
+    par_effects = dict(
+        coverage       = [0.2, 0.9],
+        art_initiation = [0.3, 0.95],
+    )
+
+    results = dict()
+    for par, (lo, hi) in par_effects.items():
+        for val in [lo, hi]:
+            if par == 'coverage':
+                art = sti.ART(coverage=val)
+            else:
+                art = sti.ART(coverage=0.5, art_initiation=ss.bernoulli(p=val))
+            sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+            sim.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), art]
+            sim.run()
+            results[(par, val)] = float(sim.results.hiv.n_on_art[-1])
+
+    # TODO: uncomment once validated with larger populations
+    # for par, (lo, hi) in par_effects.items():
+    #     v_lo = results[(par, lo)]
+    #     v_hi = results[(par, hi)]
+    #     assert v_lo <= v_hi, f'Expected higher {par} to increase ART uptake, but {par}={lo} gave {v_lo} vs {par}={hi} gave {v_hi}'
+
+    return results
+
+
+@sc.timer()
+def test_art_duration(do_plot=do_plot):
+    """ Check that agents remain on ART for expected durations """
+    sc.heading('Testing ART duration tracking...')
+
+    # TODO: collaborator to implement
+    # Run a sim with ART, check ti_art for agents
+    # Verify mean duration is reasonable (not too short, not infinite)
+
+    sim = hivsim.demo('simple', run=False, plot=False, n_agents=2_000)
+    sim.run()
+
+    hiv = sim.diseases.hiv
+    on_art = hiv.on_art.uids
+    if len(on_art):
+        ti_start = hiv.ti_art[on_art]
+        current_ti = sim.t.ti
+        durations_years = (current_ti - ti_start) * float(sim.pars.dt)
+        mean_dur = float(np.nanmean(durations_years))
+
+        if do_plot:
+            fig, ax = pl.subplots()
+            ax.hist(durations_years[~np.isnan(durations_years)], bins=20)
+            ax.set_xlabel('Years on ART')
+            ax.set_ylabel('Count')
+            ax.set_title(f'ART duration distribution (mean={mean_dur:.1f} years)')
+
+    # TODO: uncomment once expected durations are established
+    # assert mean_dur > 1, f'Expected mean ART duration > 1 year, got {mean_dur:.1f}'
+    # assert mean_dur < 30, f'Expected mean ART duration < 30 years, got {mean_dur:.1f}'
+
+    return sim
+
+
+if __name__ == '__main__':
+    do_plot = True
+    sc.options(interactive=do_plot)
+    T = sc.timer()
+
+    r1 = test_art_specs(do_plot=do_plot)
+    r2 = test_art_legacy_compat(do_plot=do_plot)
+    r3 = test_vmmc_specs(do_plot=do_plot)
+    r4 = test_art_stratified_coverage(do_plot=do_plot)
+    r5 = test_art_effects(do_plot=do_plot)
+    r6 = test_art_no_pregnancy(do_plot=do_plot)
+    r7 = test_art_reduces_mortality(do_plot=do_plot)
+    r8 = test_art_parameter_sensitivity(do_plot=do_plot)
+    r9 = test_art_duration(do_plot=do_plot)
+
+    T.toc()
+
+    if do_plot:
+        pl.show()

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -221,6 +221,103 @@ def test_art_no_pregnancy(do_plot=do_plot):
     return sim
 
 
+# %% Coverage matching tests
+@sc.timer()
+def test_art_coverage_matching(do_plot=do_plot):
+    """ Check that ART intervention matches supplied coverage data """
+    sc.heading('Testing ART coverage matching...')
+
+    # Simple constant proportion coverage
+    target_p = 0.7
+    sim = hivsim.demo('simple', run=False, plot=False, n_agents=5_000)
+    sim.pars.interventions = [
+        sti.HIVTest(name='hiv_test', test_prob_data=0.5),
+        sti.ART(coverage=target_p),
+    ]
+    sim.pars.analyzers = [sti.art_coverage()]
+    sim.run()
+
+    ac = sim.results.art_coverage
+    # Check coverage in the last few years (after ramp-up)
+    rtol = 0.2  # Generous tolerance for stochastic model with 5K agents
+    final_p = np.mean(ac.p_art[-24:])  # Last 2 years of monthly data
+    assert np.isclose(final_p, target_p, rtol=rtol), \
+        f'Expected ART coverage ~{target_p}, got {final_p:.2f} (rtol={rtol})'
+
+    if do_plot:
+        fig, axes = pl.subplots(1, 2, figsize=(12, 5))
+        axes[0].plot(sim.t.yearvec, ac.n_art, label='On ART')
+        axes[0].set_ylabel('Count')
+        axes[0].set_title('ART numbers')
+        axes[1].plot(sim.t.yearvec, ac.p_art, label='Coverage')
+        axes[1].axhline(target_p, color='k', ls='--', label=f'Target ({target_p})')
+        axes[1].set_ylabel('Proportion')
+        axes[1].set_title('ART coverage')
+        axes[1].legend()
+
+    return sim
+
+
+@sc.timer()
+def test_art_stratified_coverage_matching(do_plot=do_plot):
+    """ Check that age-stratified ART coverage approximately matches supplied targets """
+    sc.heading('Testing stratified ART coverage matching...')
+
+    # Build stratified coverage data: higher coverage for older age groups and women
+    age_bins = [15, 25, 35, 45]
+    targets = {}
+    rows = []
+    for year in [2005, 2015]:
+        for gender in [0, 1]:
+            for lo, hi in zip(age_bins[:-1], age_bins[1:]):
+                ab = f'[{lo},{hi})'
+                base_p = 0.3 if year == 2005 else 0.7
+                age_factor = 1 + (lo - 15) * 0.01  # Slightly higher for older
+                sex_factor = 1.1 if gender == 1 else 1.0  # Higher for women
+                p = min(base_p * age_factor * sex_factor, 0.95)
+                rows.append(dict(Year=year, Gender=gender, AgeBin=ab, coverage=p))
+                if year == 2015:
+                    targets[(ab, gender)] = p
+
+    strat_df = pd.DataFrame(rows)
+    sim = hivsim.demo('simple', run=False, plot=False, n_agents=5_000)
+    sim.pars.interventions = [
+        sti.HIVTest(name='hiv_test', test_prob_data=0.5),
+        sti.ART(coverage=strat_df),
+    ]
+    sim.pars.analyzers = [sti.art_coverage(age_bins=age_bins)]
+    sim.run()
+
+    ac = sim.results.art_coverage
+
+    # Check aggregate coverage is nonzero (stratified data produces a global target)
+    final_p = np.mean(ac.p_art[-24:])
+    assert final_p > 0.1, f'Expected meaningful aggregate ART coverage with stratified data, got {final_p:.2f}'
+
+    # Print per-stratum coverage for inspection (not asserted — current implementation
+    # computes a global target from stratified data, not per-stratum force-fitting)
+    for (ab, gender), target_p in targets.items():
+        lo, hi = ab.strip('[]()').split(',')
+        sex = 'f' if gender == 1 else 'm'
+        key = f'p_art_{sex}_{lo}_{hi}'
+        measured_p = np.mean(ac[key][-24:])
+        print(f'  {key}: target={target_p:.2f}, measured={measured_p:.2f}')
+
+    if do_plot:
+        fig, axes = pl.subplots(1, 2, figsize=(14, 5))
+        for sex, ax in [('f', axes[0]), ('m', axes[1])]:
+            for i in range(len(age_bins) - 1):
+                lo, hi = age_bins[i], age_bins[i + 1]
+                key = f'p_art_{sex}_{lo}_{hi}'
+                ax.plot(sim.t.yearvec, ac[key], label=f'{lo}-{hi}')
+            ax.set_ylabel('ART coverage')
+            ax.set_title(f'{"Women" if sex == "f" else "Men"}')
+            ax.legend()
+            ax.set_ylim(0, 1)
+
+    return sim
+
+
 # %% Scientific validation skeletons
 @sc.timer()
 def test_art_reduces_mortality(do_plot=do_plot):
@@ -333,15 +430,17 @@ if __name__ == '__main__':
     sc.options(interactive=do_plot)
     T = sc.timer()
 
-    r1 = test_art_specs(do_plot=do_plot)
-    r2 = test_art_legacy_compat(do_plot=do_plot)
-    r3 = test_vmmc_specs(do_plot=do_plot)
-    r4 = test_art_stratified_coverage(do_plot=do_plot)
-    r5 = test_art_effects(do_plot=do_plot)
-    r6 = test_art_no_pregnancy(do_plot=do_plot)
-    r7 = test_art_reduces_mortality(do_plot=do_plot)
-    r8 = test_art_parameter_sensitivity(do_plot=do_plot)
-    r9 = test_art_duration(do_plot=do_plot)
+    r1  = test_art_specs(do_plot=do_plot)
+    r2  = test_art_legacy_compat(do_plot=do_plot)
+    r3  = test_vmmc_specs(do_plot=do_plot)
+    r4  = test_art_stratified_coverage(do_plot=do_plot)
+    r5  = test_art_effects(do_plot=do_plot)
+    r6  = test_art_no_pregnancy(do_plot=do_plot)
+    r7  = test_art_coverage_matching(do_plot=do_plot)
+    r8  = test_art_stratified_coverage_matching(do_plot=do_plot)
+    r9  = test_art_reduces_mortality(do_plot=do_plot)
+    r10 = test_art_parameter_sensitivity(do_plot=do_plot)
+    r11 = test_art_duration(do_plot=do_plot)
 
     T.toc()
 

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -82,13 +82,6 @@ def test_art_legacy_compat(do_plot=do_plot):
         n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
     assert n_deprecation >= 2, f'Expected 2+ FutureWarnings for coverage_data+future_coverage, got {n_deprecation}'
 
-    # Legacy init_prob
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        sti.ART(coverage=0.5, init_prob=ss.bernoulli(p=0.5))
-        n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
-    assert n_deprecation >= 1, f'Expected FutureWarning for init_prob, got {n_deprecation}'
-
     # Run both legacy sims to verify they work
     for art in [art1, art2]:
         sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -15,7 +15,6 @@ import starsim as ss
 import stisim as sti
 import hivsim
 import matplotlib.pyplot as pl
-import pytest
 
 n_agents = 1_000
 do_plot  = False
@@ -86,7 +85,7 @@ def test_art_legacy_compat(do_plot=do_plot):
     # Legacy init_prob
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        art3 = sti.ART(coverage=0.5, init_prob=ss.bernoulli(p=0.5))
+        sti.ART(coverage=0.5, init_prob=ss.bernoulli(p=0.5))
         n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
     assert n_deprecation >= 1, f'Expected FutureWarning for init_prob, got {n_deprecation}'
 
@@ -142,9 +141,22 @@ def test_art_stratified_coverage(do_plot=do_plot):
     sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
     sim.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), sti.ART(coverage=strat_df)]
     sim.run()
-    assert sim.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with stratified coverage'
+    assert sim.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with stratified coverage (canonical names)'
 
-    return sim
+    # Test with lowercase column names + Sex alias
+    rows_lc = []
+    for year in [2005, 2015]:
+        for sex in [0, 1]:
+            for age_bin in ['[15,25)', '[25,35)', '[35,45)']:
+                p = 0.4 if year == 2005 else 0.8
+                rows_lc.append(dict(year=year, sex=sex, agebin=age_bin, coverage=min(p, 1.0)))
+
+    sim2 = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+    sim2.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), sti.ART(coverage=pd.DataFrame(rows_lc))]
+    sim2.run()
+    assert sim2.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with stratified coverage (lowercase/sex alias)'
+
+    return sim, sim2
 
 
 # %% Functional tests
@@ -228,8 +240,8 @@ def test_art_reduces_mortality(do_plot=do_plot):
     ]
     sim_art.run()
 
-    deaths_no_art = float(np.sum(sim_no_art.results.hiv.new_deaths))
-    deaths_art    = float(np.sum(sim_art.results.hiv.new_deaths))
+    deaths_no_art = sim_no_art.results.hiv.new_deaths.sum()
+    deaths_art    = sim_art.results.hiv.new_deaths.sum()
 
     if do_plot:
         fig, ax = pl.subplots()
@@ -250,7 +262,7 @@ def test_art_parameter_sensitivity(do_plot=do_plot):
     """ Check that ART coverage and initiation parameters affect outcomes as expected """
     sc.heading('Testing ART parameter sensitivity...')
 
-    # TODO: collaborator to implement
+    # TODO: implement
     # Vary art_initiation probability (low vs high)
     # Vary coverage level (low vs high)
     # Assert: higher coverage → more people on ART
@@ -287,7 +299,7 @@ def test_art_duration(do_plot=do_plot):
     """ Check that agents remain on ART for expected durations """
     sc.heading('Testing ART duration tracking...')
 
-    # TODO: collaborator to implement
+    # TODO: implement
     # Run a sim with ART, check ti_art for agents
     # Verify mean duration is reasonable (not too short, not infinite)
 

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -127,7 +127,7 @@ def test_art_stratified_coverage(do_plot=do_plot):
         for gender in [0, 1]:
             for age_bin in ['[15,25)', '[25,35)', '[35,45)']:
                 p = 0.3 if year == 2005 else 0.7
-                p *= (1.2 if gender == 1 else 1.0)
+                p *= (1.2 if gender == 0 else 1.0)  # Higher for women (0=female)
                 rows.append(dict(Year=year, Gender=gender, AgeBin=age_bin, NationalARTPrevalence=min(p, 1.0)))
     strat_df = pd.DataFrame(rows)
 
@@ -136,10 +136,10 @@ def test_art_stratified_coverage(do_plot=do_plot):
     sim.run()
     assert sim.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with stratified coverage (canonical names)'
 
-    # Test with lowercase column names + Sex alias
+    # Test with lowercase column names + Sex alias + string gender values
     rows_lc = []
     for year in [2005, 2015]:
-        for sex in [0, 1]:
+        for sex in ['f', 'm']:
             for age_bin in ['[15,25)', '[25,35)', '[35,45)']:
                 p = 0.4 if year == 2005 else 0.8
                 rows_lc.append(dict(year=year, sex=sex, agebin=age_bin, coverage=min(p, 1.0)))
@@ -147,7 +147,7 @@ def test_art_stratified_coverage(do_plot=do_plot):
     sim2 = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
     sim2.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), sti.ART(coverage=pd.DataFrame(rows_lc))]
     sim2.run()
-    assert sim2.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with stratified coverage (lowercase/sex alias)'
+    assert sim2.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with stratified coverage (string sex values)'
 
     return sim, sim2
 
@@ -266,7 +266,7 @@ def test_art_stratified_coverage_matching(do_plot=do_plot):
                 ab = f'[{lo},{hi})'
                 base_p = 0.3 if year == 2005 else 0.7
                 age_factor = 1 + (lo - 15) * 0.01  # Slightly higher for older
-                sex_factor = 1.1 if gender == 1 else 1.0  # Higher for women
+                sex_factor = 1.1 if gender == 0 else 1.0  # Higher for women (0=female)
                 p = min(base_p * age_factor * sex_factor, 0.95)
                 rows.append(dict(Year=year, Gender=gender, AgeBin=ab, coverage=p))
                 if year == 2015:
@@ -291,7 +291,7 @@ def test_art_stratified_coverage_matching(do_plot=do_plot):
     # computes a global target from stratified data, not per-stratum force-fitting)
     for (ab, gender), target_p in targets.items():
         lo, hi = ab.strip('[]()').split(',')
-        sex = 'f' if gender == 1 else 'm'
+        sex = 'f' if gender == 0 else 'm'
         key = f'p_art_{sex}_{lo}_{hi}'
         measured_p = np.mean(ac[key][-24:])
         print(f'  {key}: target={target_p:.2f}, measured={measured_p:.2f}')


### PR DESCRIPTION
## Summary

- Refactor ART and VMMC coverage input handling (#126): accept scalar, dict, DataFrame, or age/sex-stratified DataFrame via a unified `coverage` parameter
- Document the HIV testing → diagnosis → ART pipeline (#314): comprehensive docstrings, user guide section with flow diagram, updated tutorial
- Add `art_coverage` analyzer for tracking ART coverage by age/sex with a built-in `plot()` method
- Guard pregnancy/maternalnet access in interventions (#313, merged separately)
- Add `custom` module support to STIsim Sim constructor (merged separately)
- New `test_hiv_interventions.py` with 11 tests covering coverage formats, backward compat, functional effects, and scientific validation skeletons

## Key changes

**ART class:**
- `coverage` replaces `coverage_data` (deprecated with FutureWarning)
- `art_initiation` replaces `init_prob` (deprecated with FutureWarning)
- `future_coverage` deprecated
- No coverage = no force-fitting, just treat all who initiate
- Warns if no HIVTest intervention found
- Supports age/sex-stratified coverage DataFrames

**VMMC class:** Same coverage refactor pattern

**Documentation:**
- `test_prob_data` clearly documented as an annual rate (dt_scale=True) with `dt_scale=False` for per-timestep probability
- User guide: full HIV pipeline section with flow diagram, parameter tables, coverage format examples
- Tutorial: updated to use `hivsim.demo`, new ART coverage formats section, `art_coverage` analyzer demo

## Test plan

- [x] All 11 new tests in `test_hiv_interventions.py` pass
- [x] All 6 existing tests in `test_sim.py` pass (with expected deprecation warnings)
- [x] Backward compat verified with `anc_sti_screening` repo
- [ ] Review tutorial notebook renders correctly