### PR TITLE
Consistent interpolation and PrEP refactor (#327)

### DIFF
--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -304,7 +304,7 @@ class SymptomaticTesting(STITest):
     def init_pre(self, sim):
         super().init_pre(sim)
         if self.treat_prob_data is not None:
-            self.treat_prob = np.interp(sim.yearvec, self.treat_prob_data.year.values, self.treat_prob_data.treat_prob.values)
+            self.treat_prob = sc.smoothinterp(sim.yearvec, self.treat_prob_data.year.values, self.treat_prob_data.treat_prob.values, smoothness=0)
         return
 
     def init_results(self):

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -139,7 +139,7 @@ class ART(ss.Intervention):
         art = sti.ART(coverage=pd.read_csv('art_coverage.csv').set_index('year'))
     """
 
-    def __init__(self, pars=None, coverage=None, coverage_data=None, **kwargs):
+    def __init__(self, pars=None, coverage=None, coverage_data=None, smoothness=0, **kwargs):
         super().__init__()
 
         # Handle deprecated kwargs
@@ -152,6 +152,7 @@ class ART(ss.Intervention):
 
         self._raw_coverage    = coverage
         self._future_coverage = future_coverage  # Legacy compat, removed once deprecated
+        self._smoothness      = smoothness
         self.coverage         = None  # Set in init_pre
         self.coverage_format  = None  # 'n' or 'p'
         self.age_bins         = None  # For stratified coverage
@@ -173,6 +174,7 @@ class ART(ss.Intervention):
         # Parse coverage data
         self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
             self._raw_coverage, valid_names=['n_art', 'p_art'], yearvec=self.t.yearvec,
+            smoothness=self._smoothness,
         )
         self.initialized = True
         return
@@ -312,7 +314,7 @@ class VMMC(ss.Intervention):
         vmmc = sti.VMMC(coverage={'year': [2010, 2025], 'value': [0, 0.4]})
     """
 
-    def __init__(self, pars=None, coverage=None, coverage_data=None, eligibility=None, **kwargs):
+    def __init__(self, pars=None, coverage=None, coverage_data=None, eligibility=None, smoothness=0, **kwargs):
         super().__init__(eligibility=eligibility)
 
         # Handle deprecated kwargs
@@ -325,6 +327,7 @@ class VMMC(ss.Intervention):
 
         self._raw_coverage    = coverage
         self._future_coverage = future_coverage
+        self._smoothness      = smoothness
         self.coverage         = None
         self.coverage_format  = None
         self.age_bins         = None
@@ -341,6 +344,7 @@ class VMMC(ss.Intervention):
         super().init_pre(sim)
         self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
             self._raw_coverage, valid_names=['n_vmmc', 'p_vmmc'], yearvec=self.t.yearvec,
+            smoothness=self._smoothness,
         )
         return
 
@@ -392,42 +396,63 @@ class Prep(ss.Intervention):
 
     By default targets HIV-negative FSWs who are not already on PrEP.
     Reduces HIV susceptibility by eff_prep (default 80%). Coverage ramps up
-    over time according to the years/coverage parameters (linearly interpolated).
+    over time via ``parse_coverage`` (same flexible inputs as ART/VMMC).
     Use the eligibility parameter to target a different population.
 
+    Note: PrEP uses a per-agent probability model (coverage = probability of
+    being on PrEP) rather than a target-count model like ART/VMMC.
+
     Args:
-        coverage (list):  coverage values at each year (default [0, 0.01, 0.5, 0.8])
-        years (list):     corresponding calendar years (default [2004, 2005, 2015, 2025])
-        eff_prep (float): efficacy (default 0.8 = 80% reduction in acquisition)
-        eligibility:      function to override default FSW targeting
+        coverage:    coverage data in any format accepted by parse_coverage;
+                     also accepts legacy (years, coverage) list pairs via pars
+        eff_prep:    efficacy (default 0.8 = 80% reduction in acquisition)
+        smoothness:  interpolation smoothness (0=linear, default)
+        eligibility: function to override default FSW targeting
 
-    Example::
+    Examples::
 
-        prep = sti.Prep(coverage=[0, 0.5], years=[2020, 2025])
+        prep = sti.Prep(coverage={'year': [2020, 2025], 'value': [0, 0.5]})
+        prep = sti.Prep(coverage=0.3)
     """
-    def __init__(self, pars=None, eligibility=None, **kwargs):
+    def __init__(self, pars=None, coverage=None, eligibility=None, smoothness=0, **kwargs):
         super().__init__()
         self.define_pars(
             coverage_dist=ss.bernoulli(p=0),
-            coverage=[0, 0.01, 0.5, 0.8],
-            years=[2004, 2005, 2015, 2025],
             eff_prep=0.8,
         )
         self.update_pars(pars, **kwargs)
         self.eligibility = eligibility
+        self._smoothness = smoothness
+        self._coverage_arr = None  # Set in init_pre
+
+        # Support legacy (years, coverage) pars by converting to dict format
+        if coverage is None and 'years' in self.pars and 'coverage' in self.pars:
+            coverage = {'year': self.pars.years, 'value': self.pars.coverage}
+        elif coverage is None:
+            coverage = {'year': [2004, 2005, 2015, 2025], 'value': [0, 0.01, 0.5, 0.8]}
+        self._raw_coverage = coverage
+
         self.define_states(
             ss.BoolArr('on_prep', label='On PrEP'),
         )
         return
 
+    def init_pre(self, sim):
+        super().init_pre(sim)
+        self._coverage_arr, _, _, _ = parse_coverage(
+            self._raw_coverage, valid_names=['p_prep'], yearvec=self.t.yearvec,
+            smoothness=self._smoothness,
+        )
+        return
+
     def step(self):
         sim = self.sim
-        self.coverage = np.interp(self.t.yearvec, self.pars.years, self.pars.coverage)
-        if self.coverage[self.ti] > 0:
-            self.pars.coverage_dist.set(p=self.coverage[self.ti])
-            el_fsw = self.sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.infected & ~self.on_prep
+        cov_val = self._coverage_arr[self.ti]
+        if cov_val > 0:
+            self.pars.coverage_dist.set(p=cov_val)
+            el_fsw = sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.infected & ~self.on_prep
             fsw_on_prep = self.pars.coverage_dist.filter(el_fsw)
-            self.sim.diseases.hiv.rel_sus[fsw_on_prep] *= 1 - self.pars.eff_prep
+            sim.diseases.hiv.rel_sus[fsw_on_prep] *= 1 - self.pars.eff_prep
 
         return
 

--- a/stisim/interventions/utils.py
+++ b/stisim/interventions/utils.py
@@ -14,7 +14,7 @@ import sciris as sc
 
 # %% Coverage parsing
 
-def parse_coverage(data, valid_names=None, yearvec=None):
+def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, **interp_kw):
     """
     Parse coverage data into a per-timestep array.
 
@@ -41,10 +41,17 @@ def parse_coverage(data, valid_names=None, yearvec=None):
         # Age/sex stratified DataFrame (Gender column is optional)
         parse_coverage(strat_df, valid_names=['p_art'], yearvec=yearvec)
 
+        # Smooth interpolation between data points
+        parse_coverage(data, yearvec=yearvec, smoothness=5)
+
     Args:
         data:        coverage input in any of the formats above, or None
         valid_names: list of valid column names, e.g. ['n_art', 'p_art']
         yearvec:     simulation year vector for interpolation
+        smoothness:  interpolation smoothness (0=linear, higher=smoother S-curves);
+                     passed to sc.smoothinterp
+        **interp_kw: additional keyword arguments passed to sc.smoothinterp
+                     (e.g. method='nearest', growth=0.1)
     """
     if valid_names is None:
         valid_names = []
@@ -65,18 +72,18 @@ def parse_coverage(data, valid_names=None, yearvec=None):
         fmt = data.get('format', None)
         if fmt is None:
             fmt = 'p' if np.all(values <= 1.0) else 'n'
-        arr = sc.smoothinterp(yearvec, years, values, smoothness=0)
+        arr = sc.smoothinterp(yearvec, years, values, smoothness=smoothness, **interp_kw)
         return arr, fmt, None, None
 
     # DataFrame — check for stratified vs single-column
     if isinstance(data, pd.DataFrame):
-        return _parse_coverage_df(data, valid_names, yearvec)
+        return _parse_coverage_df(data, valid_names, yearvec, smoothness=smoothness, **interp_kw)
 
     errormsg = f'Coverage data format not recognized: {type(data)}. Expected None, number, dict, or DataFrame.'
     raise ValueError(errormsg)
 
 
-def _parse_coverage_df(data, valid_names, yearvec):
+def _parse_coverage_df(data, valid_names, yearvec, smoothness=0, **interp_kw):
     """
     Parse a DataFrame of coverage data.
 
@@ -91,13 +98,13 @@ def _parse_coverage_df(data, valid_names, yearvec):
     has_agebin = 'agebin' in col_lower or 'age_bin' in col_lower or 'age' in col_lower
 
     if has_year and has_agebin:  # Gender/Sex column is optional
-        return _parse_stratified_df(data, yearvec)
+        return _parse_stratified_df(data, yearvec, smoothness=smoothness, **interp_kw)
 
     # Single-column format: index=years, column in valid_names (e.g. n_art or p_art)
     if len(data.columns) == 1 and data.columns[0] in valid_names:
         colname = data.columns[0]
         fmt = 'n' if colname.startswith('n_') else 'p'
-        arr = sc.smoothinterp(yearvec, data.index.values, data[colname].values, smoothness=0)
+        arr = sc.smoothinterp(yearvec, data.index.values, data[colname].values, smoothness=smoothness, **interp_kw)
         return arr, fmt, None, None
 
     # Try to find a valid column
@@ -105,9 +112,9 @@ def _parse_coverage_df(data, valid_names, yearvec):
         if col in valid_names:
             fmt = 'n' if col.startswith('n_') else 'p'
             if data.index.name in ['year', 'Year'] or np.all(data.index > 1900):
-                arr = sc.smoothinterp(yearvec, data.index.values, data[col].values, smoothness=0)
+                arr = sc.smoothinterp(yearvec, data.index.values, data[col].values, smoothness=smoothness, **interp_kw)
             else:
-                arr = sc.smoothinterp(yearvec, np.arange(len(data)), data[col].values, smoothness=0)
+                arr = sc.smoothinterp(yearvec, np.arange(len(data)), data[col].values, smoothness=smoothness, **interp_kw)
             return arr, fmt, None, None
 
     errormsg = f'DataFrame columns {list(data.columns)} do not match any valid names {valid_names}.'
@@ -182,7 +189,7 @@ def _normalize_stratified_cols(data):
     return df
 
 
-def _parse_stratified_df(data, yearvec):
+def _parse_stratified_df(data, yearvec, smoothness=0, **interp_kw):
     """
     Parse a stratified coverage DataFrame.
 
@@ -232,10 +239,11 @@ def _parse_stratified_df(data, yearvec):
             else:
                 years = subset['Year'].values.astype(float)
                 vals  = subset[val_col].values.astype(float)
+                # Fill NaN gaps before interpolating to yearvec
                 mask = ~np.isnan(vals)
                 if mask.any():
-                    vals = np.interp(years, years[mask], vals[mask])
-                coverage[key] = sc.smoothinterp(yearvec, years, vals, smoothness=0)
+                    vals = sc.smoothinterp(years, years[mask], vals[mask], smoothness=0)
+                coverage[key] = sc.smoothinterp(yearvec, years, vals, smoothness=smoothness, **interp_kw)
 
     return coverage, fmt, age_bins, sex_keys
 


### PR DESCRIPTION
## Summary
- Add `smoothness` parameter to `parse_coverage` (and ART/VMMC constructors), with `**interp_kw` passed through to `sc.smoothinterp` for full flexibility
- Standardize all interpolation on `sc.smoothinterp` (smoothness=0 = linear, matching existing behavior)
- Refactor PrEP to use `parse_coverage` instead of inline `np.interp` — now accepts same flexible coverage inputs as ART/VMMC
- Replace `np.interp` with `sc.smoothinterp(smoothness=0)` in `STITreatment.init_pre`

Depends on #387 (`shared-coverage` branch)
Closes #327