### PR TITLE
Mixed n/p coverage format (#383)

### DIFF
--- a/hivsim_examples/zimbabwe/sim.py
+++ b/hivsim_examples/zimbabwe/sim.py
@@ -91,8 +91,8 @@ def make_sim(**kwargs):
     # Create modules
     hiv = sti.HIV(init_prev_data=init_prev, **sti_pars)
     network = sti.StructuredSexual(condom_data=condom_data, **nw_pars)
-    art = sti.ART(coverage_data=art_data)
-    vmmc = sti.VMMC(coverage_data=vmmc_data)
+    art = sti.ART(coverage=art_data)
+    vmmc = sti.VMMC(coverage=vmmc_data)
 
     # Combine interventions: testing + ART/VMMC + any user additions
     intvs = make_interventions() + [art, vmmc]

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -304,7 +304,7 @@ class SymptomaticTesting(STITest):
     def init_pre(self, sim):
         super().init_pre(sim)
         if self.treat_prob_data is not None:
-            self.treat_prob = np.interp(sim.yearvec, self.treat_prob_data.year.values, self.treat_prob_data.treat_prob.values)
+            self.treat_prob = sc.smoothinterp(sim.yearvec, self.treat_prob_data.year.values, self.treat_prob_data.treat_prob.values, smoothness=0)
         return
 
     def init_results(self):

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -7,7 +7,7 @@ import starsim as ss
 import numpy as np
 from stisim.interventions.base_interventions import STITest
 from stisim.interventions.utils import (
-    parse_coverage, _handle_deprecated_coverage, compute_coverage_target,
+    parse_coverage, compute_coverage_target,
 )
 from stisim.utils import count
 
@@ -101,16 +101,16 @@ class ART(ss.Intervention):
            go directly on ART (no capacity constraint)
         5. Mothers on ART protect unborn infants (rel_sus=0) via MaternalNet
 
-    Coverage can be specified in several formats:
-        - None: no coverage target; treat all who initiate (default)
-        - Scalar (e.g. 0.8): constant proportion of infected on ART
-        - Dict: {'year': [2000, 2020], 'value': [0, 0.9]} — linearly interpolated
-        - DataFrame: index=years, column 'n_art' (absolute numbers) or 'p_art'
-          (proportion of infected). Values are linearly interpolated to the sim
-          yearvec.
-        - Stratified DataFrame: columns Year, Gender/Sex, AgeBin (format
-          '[lo,hi)'), plus a numeric value column. Values are interpolated per
-          stratum.
+    Coverage is parsed by :func:`parse_coverage` and accepts:
+        - ``None``: no coverage target; treat all who initiate (default)
+        - Scalar (e.g. ``0.8``): constant proportion of infected on ART
+        - Dict: ``{'year': [...], 'value': [...]}`` — interpolated to yearvec
+        - Dict with mixed format: ``{'year': [...], 'value': [...], 'format': ['n','n','p','p']}``
+        - Single-column DataFrame: index=years, column ``n_art`` or ``p_art``
+        - Dual-column DataFrame: both ``n_art`` and ``p_art`` columns — uses
+          ``format_priority`` to resolve (default: ``n_art`` when non-NaN)
+        - Stratified DataFrame: columns Year, AgeBin (e.g. ``[15,25)``), and
+          optionally Gender/Sex, plus a numeric value column
 
     Intervention ordering: HIVTest must appear before ART in the interventions
     list so that agents diagnosed this timestep can initiate ART in the same step.
@@ -120,8 +120,11 @@ class ART(ss.Intervention):
         art_initiation:   probability a newly diagnosed person initiates ART
                           (default: ss.bernoulli(p=0.9)). Set to 1 to treat all
                           diagnosed.
+        smoothness:       interpolation smoothness (0=linear, default)
+        format_priority:  when both n_art and p_art are non-NaN, prefer this format
+                          ('n' or 'p', default 'n')
 
-    Example::
+    Examples::
 
         # Simple: 80% of infected on ART
         art = sti.ART(coverage=0.8)
@@ -132,18 +135,18 @@ class ART(ss.Intervention):
         # No coverage target — 90% of newly diagnosed initiate (default art_initiation)
         art = sti.ART()
 
-        # Treat ALL diagnosed with no coverage constraint
-        art = sti.ART(art_initiation=1)
-
         # From a CSV file
         art = sti.ART(coverage=pd.read_csv('art_coverage.csv').set_index('year'))
+
+        # Historical n_art then projected p_art
+        df = pd.read_csv('n_art.csv').set_index('year')
+        df['p_art'] = np.nan
+        df.loc[2023:, 'p_art'] = 0.90
+        art = sti.ART(coverage=df)
     """
 
-    def __init__(self, pars=None, coverage=None, coverage_data=None, smoothness=0, **kwargs):
+    def __init__(self, pars=None, coverage=None, smoothness=0, format_priority='n', **kwargs):
         super().__init__()
-
-        # Handle deprecated kwargs
-        coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
 
         self.define_pars(
             art_initiation=ss.bernoulli(p=0.9),
@@ -151,10 +154,10 @@ class ART(ss.Intervention):
         self.update_pars(pars, **kwargs)
 
         self._raw_coverage    = coverage
-        self._future_coverage = future_coverage  # Legacy compat, removed once deprecated
         self._smoothness      = smoothness
+        self._format_priority = format_priority
         self.coverage         = None  # Set in init_pre
-        self.coverage_format  = None  # 'n' or 'p'
+        self.coverage_format  = None  # 'n', 'p', or per-timestep array
         self.age_bins         = None  # For stratified coverage
         self.sex_keys         = None  # For stratified coverage
         return
@@ -174,7 +177,7 @@ class ART(ss.Intervention):
         # Parse coverage data
         self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
             self._raw_coverage, valid_names=['n_art', 'p_art'], yearvec=self.t.yearvec,
-            smoothness=self._smoothness,
+            smoothness=self._smoothness, format_priority=self._format_priority,
         )
         self.initialized = True
         return
@@ -184,7 +187,6 @@ class ART(ss.Intervention):
         return compute_coverage_target(
             self.coverage, self.coverage_format, self.age_bins, self.sex_keys,
             self.ti, eligible_uids, self.sim,
-            future_coverage=self._future_coverage,
         )
 
     def step(self):
@@ -296,29 +298,26 @@ class VMMC(ss.Intervention):
     If no coverage is specified, VMMC does nothing. Coverage must be provided
     explicitly via the coverage parameter.
 
-    Coverage formats (same as ART):
-        - Scalar: constant proportion of males (e.g. 0.3)
-        - Dict: {'year': [...], 'value': [...]} — linearly interpolated
-        - DataFrame: index=years, column 'n_vmmc' or 'p_vmmc'
-        - Stratified DataFrame: Year/Gender/AgeBin columns
+    Coverage is parsed by :func:`parse_coverage` (same formats as ART, using
+    ``n_vmmc``/``p_vmmc`` column names). Age-only stratification is supported
+    (no Gender column required, since VMMC is males-only).
 
     Args:
-        coverage:    coverage target in any format above (default None; VMMC does
-                     nothing without coverage data)
-        eff_circ:    efficacy (default 0.6 = 60% reduction in HIV acquisition)
-        eligibility: optional function to restrict who is eligible (default: all males)
+        coverage:         coverage target (default None; VMMC does nothing without data).
+                          See :func:`parse_coverage` for supported formats.
+        eff_circ:         efficacy (default 0.6 = 60% reduction in HIV acquisition)
+        eligibility:      optional function to restrict who is eligible (default: all males)
+        smoothness:       interpolation smoothness (0=linear, default)
+        format_priority:  when both n_vmmc and p_vmmc are non-NaN, prefer this format
 
-    Example::
+    Examples::
 
         vmmc = sti.VMMC(coverage=0.3)
         vmmc = sti.VMMC(coverage={'year': [2010, 2025], 'value': [0, 0.4]})
     """
 
-    def __init__(self, pars=None, coverage=None, coverage_data=None, eligibility=None, smoothness=0, **kwargs):
+    def __init__(self, pars=None, coverage=None, eligibility=None, smoothness=0, format_priority='n', **kwargs):
         super().__init__(eligibility=eligibility)
-
-        # Handle deprecated kwargs
-        coverage, future_coverage = _handle_deprecated_coverage(coverage, coverage_data, kwargs)
 
         self.define_pars(
             eff_circ=0.6,
@@ -326,8 +325,8 @@ class VMMC(ss.Intervention):
         self.update_pars(pars, **kwargs)
 
         self._raw_coverage    = coverage
-        self._future_coverage = future_coverage
         self._smoothness      = smoothness
+        self._format_priority = format_priority
         self.coverage         = None
         self.coverage_format  = None
         self.age_bins         = None
@@ -344,7 +343,7 @@ class VMMC(ss.Intervention):
         super().init_pre(sim)
         self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
             self._raw_coverage, valid_names=['n_vmmc', 'p_vmmc'], yearvec=self.t.yearvec,
-            smoothness=self._smoothness,
+            smoothness=self._smoothness, format_priority=self._format_priority,
         )
         return
 
@@ -361,7 +360,6 @@ class VMMC(ss.Intervention):
         return compute_coverage_target(
             self.coverage, self.coverage_format, self.age_bins, self.sex_keys,
             self.ti, eligible_uids, self.sim,
-            future_coverage=self._future_coverage,
         )
 
     def step(self):

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -139,7 +139,7 @@ class ART(ss.Intervention):
         art = sti.ART(coverage=pd.read_csv('art_coverage.csv').set_index('year'))
     """
 
-    def __init__(self, pars=None, coverage=None, coverage_data=None, **kwargs):
+    def __init__(self, pars=None, coverage=None, coverage_data=None, smoothness=0, **kwargs):
         super().__init__()
 
         # Handle deprecated kwargs
@@ -152,6 +152,7 @@ class ART(ss.Intervention):
 
         self._raw_coverage    = coverage
         self._future_coverage = future_coverage  # Legacy compat, removed once deprecated
+        self._smoothness      = smoothness
         self.coverage         = None  # Set in init_pre
         self.coverage_format  = None  # 'n' or 'p'
         self.age_bins         = None  # For stratified coverage
@@ -173,6 +174,7 @@ class ART(ss.Intervention):
         # Parse coverage data
         self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
             self._raw_coverage, valid_names=['n_art', 'p_art'], yearvec=self.t.yearvec,
+            smoothness=self._smoothness,
         )
         self.initialized = True
         return
@@ -312,7 +314,7 @@ class VMMC(ss.Intervention):
         vmmc = sti.VMMC(coverage={'year': [2010, 2025], 'value': [0, 0.4]})
     """
 
-    def __init__(self, pars=None, coverage=None, coverage_data=None, eligibility=None, **kwargs):
+    def __init__(self, pars=None, coverage=None, coverage_data=None, eligibility=None, smoothness=0, **kwargs):
         super().__init__(eligibility=eligibility)
 
         # Handle deprecated kwargs
@@ -325,6 +327,7 @@ class VMMC(ss.Intervention):
 
         self._raw_coverage    = coverage
         self._future_coverage = future_coverage
+        self._smoothness      = smoothness
         self.coverage         = None
         self.coverage_format  = None
         self.age_bins         = None
@@ -341,6 +344,7 @@ class VMMC(ss.Intervention):
         super().init_pre(sim)
         self.coverage, self.coverage_format, self.age_bins, self.sex_keys = parse_coverage(
             self._raw_coverage, valid_names=['n_vmmc', 'p_vmmc'], yearvec=self.t.yearvec,
+            smoothness=self._smoothness,
         )
         return
 
@@ -392,42 +396,63 @@ class Prep(ss.Intervention):
 
     By default targets HIV-negative FSWs who are not already on PrEP.
     Reduces HIV susceptibility by eff_prep (default 80%). Coverage ramps up
-    over time according to the years/coverage parameters (linearly interpolated).
+    over time via ``parse_coverage`` (same flexible inputs as ART/VMMC).
     Use the eligibility parameter to target a different population.
 
+    Note: PrEP uses a per-agent probability model (coverage = probability of
+    being on PrEP) rather than a target-count model like ART/VMMC.
+
     Args:
-        coverage (list):  coverage values at each year (default [0, 0.01, 0.5, 0.8])
-        years (list):     corresponding calendar years (default [2004, 2005, 2015, 2025])
-        eff_prep (float): efficacy (default 0.8 = 80% reduction in acquisition)
-        eligibility:      function to override default FSW targeting
+        coverage:    coverage data in any format accepted by parse_coverage;
+                     also accepts legacy (years, coverage) list pairs via pars
+        eff_prep:    efficacy (default 0.8 = 80% reduction in acquisition)
+        smoothness:  interpolation smoothness (0=linear, default)
+        eligibility: function to override default FSW targeting
 
-    Example::
+    Examples::
 
-        prep = sti.Prep(coverage=[0, 0.5], years=[2020, 2025])
+        prep = sti.Prep(coverage={'year': [2020, 2025], 'value': [0, 0.5]})
+        prep = sti.Prep(coverage=0.3)
     """
-    def __init__(self, pars=None, eligibility=None, **kwargs):
+    def __init__(self, pars=None, coverage=None, eligibility=None, smoothness=0, **kwargs):
         super().__init__()
         self.define_pars(
             coverage_dist=ss.bernoulli(p=0),
-            coverage=[0, 0.01, 0.5, 0.8],
-            years=[2004, 2005, 2015, 2025],
             eff_prep=0.8,
         )
         self.update_pars(pars, **kwargs)
         self.eligibility = eligibility
+        self._smoothness = smoothness
+        self._coverage_arr = None  # Set in init_pre
+
+        # Support legacy (years, coverage) pars by converting to dict format
+        if coverage is None and 'years' in self.pars and 'coverage' in self.pars:
+            coverage = {'year': self.pars.years, 'value': self.pars.coverage}
+        elif coverage is None:
+            coverage = {'year': [2004, 2005, 2015, 2025], 'value': [0, 0.01, 0.5, 0.8]}
+        self._raw_coverage = coverage
+
         self.define_states(
             ss.BoolArr('on_prep', label='On PrEP'),
         )
         return
 
+    def init_pre(self, sim):
+        super().init_pre(sim)
+        self._coverage_arr, _, _, _ = parse_coverage(
+            self._raw_coverage, valid_names=['p_prep'], yearvec=self.t.yearvec,
+            smoothness=self._smoothness,
+        )
+        return
+
     def step(self):
         sim = self.sim
-        self.coverage = np.interp(self.t.yearvec, self.pars.years, self.pars.coverage)
-        if self.coverage[self.ti] > 0:
-            self.pars.coverage_dist.set(p=self.coverage[self.ti])
-            el_fsw = self.sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.infected & ~self.on_prep
+        cov_val = self._coverage_arr[self.ti]
+        if cov_val > 0:
+            self.pars.coverage_dist.set(p=cov_val)
+            el_fsw = sim.networks.structuredsexual.fsw & ~sim.diseases.hiv.infected & ~self.on_prep
             fsw_on_prep = self.pars.coverage_dist.filter(el_fsw)
-            self.sim.diseases.hiv.rel_sus[fsw_on_prep] *= 1 - self.pars.eff_prep
+            sim.diseases.hiv.rel_sus[fsw_on_prep] *= 1 - self.pars.eff_prep
 
         return
 

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -101,7 +101,7 @@ class ART(ss.Intervention):
            go directly on ART (no capacity constraint)
         5. Mothers on ART protect unborn infants (rel_sus=0) via MaternalNet
 
-    Coverage is parsed by :func:`parse_coverage` and accepts:
+    Coverage is parsed by `parse_coverage` and accepts:
         - ``None``: no coverage target; treat all who initiate (default)
         - Scalar (e.g. ``0.8``): constant proportion of infected on ART
         - Dict: ``{'year': [...], 'value': [...]}`` — interpolated to yearvec
@@ -298,13 +298,13 @@ class VMMC(ss.Intervention):
     If no coverage is specified, VMMC does nothing. Coverage must be provided
     explicitly via the coverage parameter.
 
-    Coverage is parsed by :func:`parse_coverage` (same formats as ART, using
+    Coverage is parsed by `parse_coverage` (same formats as ART, using
     ``n_vmmc``/``p_vmmc`` column names). Age-only stratification is supported
     (no Gender column required, since VMMC is males-only).
 
     Args:
         coverage:         coverage target (default None; VMMC does nothing without data).
-                          See :func:`parse_coverage` for supported formats.
+                          See `parse_coverage` for supported formats.
         eff_circ:         efficacy (default 0.6 = 60% reduction in HIV acquisition)
         eligibility:      optional function to restrict who is eligible (default: all males)
         smoothness:       interpolation smoothness (0=linear, default)

--- a/stisim/interventions/utils.py
+++ b/stisim/interventions/utils.py
@@ -5,7 +5,6 @@ Coverage parsing, stratified targeting, and related helpers used across
 intervention classes (ART, VMMC, etc.).
 """
 
-import warnings
 import starsim as ss
 import numpy as np
 import pandas as pd
@@ -14,7 +13,40 @@ import sciris as sc
 
 # %% Coverage parsing
 
-def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, **interp_kw):
+def _interp_by_format(years, values, formats, yearvec, smoothness=0, **interp_kw):
+    """
+    Interpolate values onto yearvec, handling mixed n/p format segments.
+
+    Interpolates within same-format segments separately (so we don't blend
+    absolute numbers with proportions). Returns (coverage_array, format_array).
+    """
+    formats = np.array(formats)
+    arr = np.full(len(yearvec), np.nan)
+    fmt_arr = np.empty(len(yearvec), dtype='U1')
+
+    # Forward-fill format from input years to yearvec
+    for i, yr in enumerate(years):
+        idx = np.searchsorted(yearvec, yr, side='left')
+        end = np.searchsorted(yearvec, years[i + 1], side='left') if i + 1 < len(years) else len(yearvec)
+        fmt_arr[idx:end] = formats[i]
+    # Fill any leading timesteps before first data year
+    first_idx = np.searchsorted(yearvec, years[0], side='left')
+    if first_idx > 0:
+        fmt_arr[:first_idx] = formats[0]
+
+    # Interpolate each format segment separately
+    for fmt in np.unique(formats):
+        seg_mask = formats == fmt
+        seg_years = years[seg_mask]
+        seg_values = values[seg_mask]
+        if len(seg_years) > 0:
+            yv_mask = fmt_arr == fmt
+            arr[yv_mask] = sc.smoothinterp(yearvec[yv_mask], seg_years, seg_values, smoothness=smoothness, **interp_kw)
+
+    return arr, fmt_arr
+
+
+def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, format_priority='n', **interp_kw):
     """
     Parse coverage data into a per-timestep array.
 
@@ -26,7 +58,7 @@ def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, **interp_
 
     Returns (coverage_array, coverage_format, age_bins, sex_keys) where:
         - coverage_array: 1D array (len=yearvec) for aggregate, or dict of arrays for stratified
-        - coverage_format: 'n' (absolute numbers) or 'p' (proportion)
+        - coverage_format: 'n' or 'p' (string if uniform), or 1D array of 'n'/'p' per timestep (if mixed)
         - age_bins: list of age bin strings if stratified, else None
         - sex_keys: list of sex integer values (0=female, 1=male) if stratified, else None
 
@@ -41,8 +73,14 @@ def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, **interp_
         # Time-varying dict with explicit format
         parse_coverage({'year': [2000, 2020], 'value': [1000, 50000], 'format': 'n'}, yearvec=yearvec)
 
+        # Mixed format: switch from absolute numbers to proportion
+        parse_coverage({'year': [2000, 2020, 2023], 'value': [1000, 50000, 0.9], 'format': ['n', 'n', 'p']}, yearvec=yearvec)
+
         # Single-column DataFrame
         parse_coverage(pd.DataFrame(index=years, data={'n_art': vals}), valid_names=['n_art'], yearvec=yearvec)
+
+        # Dual-column DataFrame: n_art for historical, p_art for projected
+        parse_coverage(dual_df, valid_names=['n_art', 'p_art'], yearvec=yearvec)
 
         # Age/sex stratified DataFrame (Sex column is optional)
         parse_coverage(strat_df, valid_names=['p_art'], yearvec=yearvec)
@@ -51,13 +89,14 @@ def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, **interp_
         parse_coverage(data, yearvec=yearvec, smoothness=5)
 
     Args:
-        data:        coverage input in any of the formats above, or None
-        valid_names: list of valid column names, e.g. ['n_art', 'p_art']
-        yearvec:     simulation year vector for interpolation
-        smoothness:  interpolation smoothness (0=linear, higher=smoother S-curves);
-                     passed to sc.smoothinterp
-        **interp_kw: additional keyword arguments passed to sc.smoothinterp
-                     (e.g. method='nearest', growth=0.1)
+        data:             coverage input in any of the formats above, or None
+        valid_names:      list of valid column names, e.g. ['n_art', 'p_art']
+        yearvec:          simulation year vector for interpolation
+        smoothness:       interpolation smoothness (0=linear, higher=smoother S-curves);
+                          passed to sc.smoothinterp
+        format_priority:  when both n_* and p_* are non-NaN, prefer this format ('n' or 'p')
+        **interp_kw:      additional keyword arguments passed to sc.smoothinterp
+                          (e.g. method='nearest', growth=0.1)
     """
     if valid_names is None:
         valid_names = []
@@ -78,24 +117,32 @@ def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, **interp_
         fmt = data.get('format', None)
         if fmt is None:
             fmt = 'p' if np.all(values <= 1.0) else 'n'
+
+        # Mixed format: per-entry format list
+        if isinstance(fmt, (list, np.ndarray)):
+            arr, fmt_arr = _interp_by_format(years, values, fmt, yearvec, smoothness=smoothness, **interp_kw)
+            return arr, fmt_arr, None, None
+
+        # Uniform format
         arr = sc.smoothinterp(yearvec, years, values, smoothness=smoothness, **interp_kw)
         return arr, fmt, None, None
 
     # DataFrame — check for stratified vs single-column
     if isinstance(data, pd.DataFrame):
-        return _parse_coverage_df(data, valid_names, yearvec, smoothness=smoothness, **interp_kw)
+        return _parse_coverage_df(data, valid_names, yearvec, smoothness=smoothness, format_priority=format_priority, **interp_kw)
 
     errormsg = f'Coverage data format not recognized: {type(data)}. Expected None, number, dict, or DataFrame.'
     raise ValueError(errormsg)
 
 
-def _parse_coverage_df(data, valid_names, yearvec, smoothness=0, **interp_kw):
+def _parse_coverage_df(data, valid_names, yearvec, smoothness=0, format_priority='n', **interp_kw):
     """
     Parse a DataFrame of coverage data.
 
-    Handles two cases:
-        1. Single-column: index=years, column in valid_names → 1D interpolated array
-        2. Stratified: columns include Year, AgeBin, and optionally Gender/Sex → dict of arrays by stratum
+    Handles three cases:
+        1. Stratified: columns include Year, AgeBin, and optionally Gender/Sex → dict of arrays by stratum
+        2. Dual-column: both n_* and p_* columns present → mixed-format with per-timestep format array
+        3. Single-column: index=years, column in valid_names → 1D interpolated array
     """
 
     # Check for stratified format — normalize column names for flexible matching
@@ -105,6 +152,13 @@ def _parse_coverage_df(data, valid_names, yearvec, smoothness=0, **interp_kw):
 
     if has_year and has_agebin:  # Sex column is optional
         return _parse_stratified_df(data, yearvec, smoothness=smoothness, **interp_kw)
+
+    # Check for dual-column format (both n_* and p_* columns)
+    n_cols = [c for c in data.columns if c in valid_names and c.startswith('n_')]
+    p_cols = [c for c in data.columns if c in valid_names and c.startswith('p_')]
+    if n_cols and p_cols:
+        return _parse_dual_column_df(data, n_cols[0], p_cols[0], yearvec,
+                                     format_priority=format_priority, smoothness=smoothness, **interp_kw)
 
     # Single-column format: index=years, column in valid_names (e.g. n_art or p_art)
     if len(data.columns) == 1 and data.columns[0] in valid_names:
@@ -125,6 +179,56 @@ def _parse_coverage_df(data, valid_names, yearvec, smoothness=0, **interp_kw):
 
     errormsg = f'DataFrame columns {list(data.columns)} do not match any valid names {valid_names}.'
     raise ValueError(errormsg)
+
+
+def _parse_dual_column_df(data, n_col, p_col, yearvec, format_priority='n', smoothness=0, **interp_kw):
+    """
+    Parse a DataFrame with both n_* and p_* columns into a mixed-format coverage array.
+
+    For each year, uses the priority column when non-NaN, falls back to the other.
+    Interpolates within same-format segments separately.
+    """
+    years = data.index.values.astype(float)
+    n_vals = data[n_col].values.astype(float)
+    p_vals = data[p_col].values.astype(float)
+
+    n_valid = ~np.isnan(n_vals)
+    p_valid = ~np.isnan(p_vals)
+
+    # Build per-year format: priority column wins when non-NaN
+    values = np.full(len(years), np.nan)
+    formats = np.empty(len(years), dtype='U1')
+
+    if format_priority == 'n':
+        use_n = n_valid | (~n_valid & ~p_valid)  # Use n when available, or when both NaN
+        use_p = ~n_valid & p_valid
+    else:
+        use_p = p_valid | (~p_valid & ~n_valid)
+        use_n = ~p_valid & n_valid
+
+    values[use_n] = n_vals[use_n]
+    values[use_p] = p_vals[use_p]
+    formats[use_n] = 'n'
+    formats[use_p] = 'p'
+
+    # Drop rows where both are NaN
+    valid = ~np.isnan(values)
+    if not valid.any():
+        return np.zeros(len(yearvec)), 'p', None, None
+
+    years = years[valid]
+    values = values[valid]
+    formats = formats[valid]
+
+    # If all same format, return uniform
+    unique_fmts = np.unique(formats)
+    if len(unique_fmts) == 1:
+        arr = sc.smoothinterp(yearvec, years, values, smoothness=smoothness, **interp_kw)
+        return arr, unique_fmts[0], None, None
+
+    # Mixed format: interpolate segments separately
+    arr, fmt_arr = _interp_by_format(years, values, formats, yearvec, smoothness=smoothness, **interp_kw)
+    return arr, fmt_arr, None, None
 
 
 def _normalize_sex(val):
@@ -263,25 +367,6 @@ def _parse_stratified_df(data, yearvec, smoothness=0, **interp_kw):
     return coverage, fmt, age_bins, sex_keys
 
 
-def _handle_deprecated_coverage(coverage, coverage_data, kwargs):
-    """
-    Handle deprecated coverage_data and future_coverage kwargs.
-    Returns the normalized coverage input and any remaining future_coverage.
-    """
-    future_coverage = kwargs.pop('future_coverage', None)
-
-    if coverage_data is not None and coverage is not None:
-        raise ValueError('Cannot specify both coverage and coverage_data. Use coverage only.')
-
-    if coverage_data is not None:
-        warnings.warn('coverage_data is deprecated; use coverage instead', FutureWarning, stacklevel=3)
-        coverage = coverage_data
-
-    if future_coverage is not None:
-        warnings.warn('future_coverage is deprecated; extend coverage data to cover the full simulation period instead', FutureWarning, stacklevel=3)
-
-    return coverage, future_coverage
-
 
 # %% Coverage targeting helpers
 
@@ -328,22 +413,22 @@ def _coverage_to_number(cov_val, coverage_format, pop_scale=None, n_eligible=Non
 
 
 def compute_coverage_target(coverage, coverage_format, age_bins, sex_keys,
-                            ti, eligible_uids, sim, future_coverage=None):
+                            ti, eligible_uids, sim):
     """
     Compute the target number of people to cover this timestep.
 
-    Handles aggregate, stratified, and legacy future_coverage modes.
+    Handles aggregate and stratified coverage, including mixed n/p format
+    (where coverage_format is a per-timestep array).
     Returns None if no coverage constraint, int otherwise.
 
     Shared by ART, VMMC, and potentially other coverage-targeted interventions.
     """
-    # Legacy future_coverage mode (deprecated, will be removed)
-    if future_coverage is not None and sim.t.now('year') >= future_coverage['year']:
-        return int(future_coverage['prop'] * len(eligible_uids))
-
     # No coverage data — no constraint
     if coverage is None:
         return None
+
+    # Resolve format for this timestep (string if uniform, array if mixed)
+    fmt = coverage_format[ti] if isinstance(coverage_format, np.ndarray) else coverage_format
 
     # Stratified coverage: loop over age/sex strata and sum targets
     if isinstance(coverage, dict):
@@ -357,12 +442,12 @@ def compute_coverage_target(coverage, coverage_format, age_bins, sex_keys,
 
                 # Count eligible agents and convert to a target number
                 n = (age_sex_mask(ab, sex, sim.people) & eligible_uids).count()
-                total += _coverage_to_number(cov_val, coverage_format,
+                total += _coverage_to_number(cov_val, fmt,
                                             pop_scale=sim.pars.pop_scale, n_eligible=n)
         return total
 
     # Aggregate coverage: single value for the whole population
     cov_val = coverage[ti]
     n_eligible = len(eligible_uids)
-    return _coverage_to_number(cov_val, coverage_format,
+    return _coverage_to_number(cov_val, fmt,
                               pop_scale=sim.pars.pop_scale, n_eligible=n_eligible)

--- a/stisim/interventions/utils.py
+++ b/stisim/interventions/utils.py
@@ -14,7 +14,7 @@ import sciris as sc
 
 # %% Coverage parsing
 
-def parse_coverage(data, valid_names=None, yearvec=None):
+def parse_coverage(data, valid_names=None, yearvec=None, smoothness=0, **interp_kw):
     """
     Parse coverage data into a per-timestep array.
 
@@ -47,10 +47,17 @@ def parse_coverage(data, valid_names=None, yearvec=None):
         # Age/sex stratified DataFrame (Sex column is optional)
         parse_coverage(strat_df, valid_names=['p_art'], yearvec=yearvec)
 
+        # Smooth interpolation between data points
+        parse_coverage(data, yearvec=yearvec, smoothness=5)
+
     Args:
         data:        coverage input in any of the formats above, or None
         valid_names: list of valid column names, e.g. ['n_art', 'p_art']
         yearvec:     simulation year vector for interpolation
+        smoothness:  interpolation smoothness (0=linear, higher=smoother S-curves);
+                     passed to sc.smoothinterp
+        **interp_kw: additional keyword arguments passed to sc.smoothinterp
+                     (e.g. method='nearest', growth=0.1)
     """
     if valid_names is None:
         valid_names = []
@@ -71,18 +78,18 @@ def parse_coverage(data, valid_names=None, yearvec=None):
         fmt = data.get('format', None)
         if fmt is None:
             fmt = 'p' if np.all(values <= 1.0) else 'n'
-        arr = sc.smoothinterp(yearvec, years, values, smoothness=0)
+        arr = sc.smoothinterp(yearvec, years, values, smoothness=smoothness, **interp_kw)
         return arr, fmt, None, None
 
     # DataFrame — check for stratified vs single-column
     if isinstance(data, pd.DataFrame):
-        return _parse_coverage_df(data, valid_names, yearvec)
+        return _parse_coverage_df(data, valid_names, yearvec, smoothness=smoothness, **interp_kw)
 
     errormsg = f'Coverage data format not recognized: {type(data)}. Expected None, number, dict, or DataFrame.'
     raise ValueError(errormsg)
 
 
-def _parse_coverage_df(data, valid_names, yearvec):
+def _parse_coverage_df(data, valid_names, yearvec, smoothness=0, **interp_kw):
     """
     Parse a DataFrame of coverage data.
 
@@ -97,13 +104,13 @@ def _parse_coverage_df(data, valid_names, yearvec):
     has_agebin = 'agebin' in col_lower or 'age_bin' in col_lower or 'age' in col_lower
 
     if has_year and has_agebin:  # Sex column is optional
-        return _parse_stratified_df(data, yearvec)
+        return _parse_stratified_df(data, yearvec, smoothness=smoothness, **interp_kw)
 
     # Single-column format: index=years, column in valid_names (e.g. n_art or p_art)
     if len(data.columns) == 1 and data.columns[0] in valid_names:
         colname = data.columns[0]
         fmt = 'n' if colname.startswith('n_') else 'p'
-        arr = sc.smoothinterp(yearvec, data.index.values, data[colname].values, smoothness=0)
+        arr = sc.smoothinterp(yearvec, data.index.values, data[colname].values, smoothness=smoothness, **interp_kw)
         return arr, fmt, None, None
 
     # Try to find a valid column
@@ -111,9 +118,9 @@ def _parse_coverage_df(data, valid_names, yearvec):
         if col in valid_names:
             fmt = 'n' if col.startswith('n_') else 'p'
             if data.index.name in ['year', 'Year'] or np.all(data.index > 1900):
-                arr = sc.smoothinterp(yearvec, data.index.values, data[col].values, smoothness=0)
+                arr = sc.smoothinterp(yearvec, data.index.values, data[col].values, smoothness=smoothness, **interp_kw)
             else:
-                arr = sc.smoothinterp(yearvec, np.arange(len(data)), data[col].values, smoothness=0)
+                arr = sc.smoothinterp(yearvec, np.arange(len(data)), data[col].values, smoothness=smoothness, **interp_kw)
             return arr, fmt, None, None
 
     errormsg = f'DataFrame columns {list(data.columns)} do not match any valid names {valid_names}.'
@@ -197,7 +204,7 @@ def _normalize_stratified_cols(data):
     return df
 
 
-def _parse_stratified_df(data, yearvec):
+def _parse_stratified_df(data, yearvec, smoothness=0, **interp_kw):
     """
     Parse a stratified coverage DataFrame.
 
@@ -247,10 +254,11 @@ def _parse_stratified_df(data, yearvec):
             else:
                 years = subset['Year'].values.astype(float)
                 vals  = subset[val_col].values.astype(float)
+                # Fill NaN gaps before interpolating to yearvec
                 mask = ~np.isnan(vals)
                 if mask.any():
-                    vals = np.interp(years, years[mask], vals[mask])
-                coverage[key] = sc.smoothinterp(yearvec, years, vals, smoothness=0)
+                    vals = sc.smoothinterp(years, years[mask], vals[mask], smoothness=0)
+                coverage[key] = sc.smoothinterp(yearvec, years, vals, smoothness=smoothness, **interp_kw)
 
     return coverage, fmt, age_bins, sex_keys
 

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -58,38 +58,36 @@ def test_art_specs(do_plot=do_plot):
 
 
 @sc.timer()
-def test_art_legacy_compat(do_plot=do_plot):
-    """ Check that deprecated coverage_data and future_coverage still work """
-    sc.heading('Testing ART legacy backward compatibility...')
+def test_art_mixed_coverage(do_plot=do_plot):
+    """ Check that mixed n/p coverage format works (dual-column DF and dict with format list) """
+    sc.heading('Testing mixed n/p coverage format...')
 
-    years = np.arange(2000, 2011)
-    p_vals = np.linspace(0, 0.9, len(years))
+    # Dual-column DataFrame: n_art for early years, p_art for later
+    years = np.arange(2000, 2021)
+    df = pd.DataFrame(index=years)
+    df['n_art'] = np.nan
+    df['p_art'] = np.nan
+    df.loc[2000:2010, 'n_art'] = np.linspace(0, 5000, 11)
+    df.loc[2011:2020, 'p_art'] = np.linspace(0.5, 0.9, 10)
 
-    # Legacy coverage_data
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        art1 = sti.ART(coverage_data=pd.DataFrame(index=years, data={'p_art': p_vals}))
-        n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
-    assert n_deprecation >= 1, f'Expected FutureWarning for coverage_data, got {n_deprecation} warnings'
+    art1 = sti.ART(coverage=df)
+    sim1 = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+    sim1.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), art1]
+    sim1.run()
+    assert sim1.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with dual-column DataFrame'
 
-    # Legacy coverage_data + future_coverage
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
-        art2 = sti.ART(
-            coverage_data=pd.DataFrame(index=years, data={'p_art': p_vals}),
-            future_coverage={'year': 2008, 'prop': 0.85},
-        )
-        n_deprecation = sum(1 for x in w if issubclass(x.category, FutureWarning))
-    assert n_deprecation >= 2, f'Expected 2+ FutureWarnings for coverage_data+future_coverage, got {n_deprecation}'
+    # Dict with per-entry format list
+    art2 = sti.ART(coverage={
+        'year':   [2000, 2010, 2015, 2020],
+        'value':  [0,    5000, 0.5,  0.9],
+        'format': ['n',  'n',  'p',  'p'],
+    })
+    sim2 = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
+    sim2.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), art2]
+    sim2.run()
+    assert sim2.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with mixed-format dict'
 
-    # Run both legacy sims to verify they work
-    for art in [art1, art2]:
-        sim = hivsim.demo('simple', run=False, plot=False, n_agents=n_agents)
-        sim.pars.interventions = [sti.HIVTest(name='hiv_test', test_prob_data=0.3), art]
-        sim.run()
-        assert sim.results.hiv.n_on_art[-1] > 0, 'Expected people on ART with legacy format'
-
-    return
+    return sim1, sim2
 
 
 @sc.timer()
@@ -441,7 +439,7 @@ if __name__ == '__main__':
     T = sc.timer()
 
     r1  = test_art_specs(do_plot=do_plot)
-    r2  = test_art_legacy_compat(do_plot=do_plot)
+    r2  = test_art_mixed_coverage(do_plot=do_plot)
     r3  = test_vmmc_specs(do_plot=do_plot)
     r4  = test_art_stratified_coverage(do_plot=do_plot)
     r5  = test_art_effects(do_plot=do_plot)


### PR DESCRIPTION
## Summary
- Support dual-column DataFrames (both `n_art` and `p_art`) with `format_priority` parameter
- Support dict with per-entry format list: `{'format': ['n','n','p','p']}`
- `coverage_format` becomes per-timestep array when mixed; `coverage_to_number` resolves per timestep
- Remove deprecated `future_coverage` and `coverage_data` code paths
- Update ART/VMMC docstrings with full coverage format documentation
- Update Zimbabwe demo example

Depends on #388 (`consistent-interp` branch)
Closes #383