### PR TITLE
Add MTCT tracking results to BaseSTI (#325)

### DIFF
--- a/docs/user_guide/diseases/hiv.md
+++ b/docs/user_guide/diseases/hiv.md
@@ -90,3 +90,44 @@ HIV in STIsim is modeled with CD4-based disease progression through acute, laten
 |-----------|---------|-------------|
 | `care_seeking` | normal(1, 0.1) | Relative care-seeking behavior (per agent) |
 | `maternal_care_scale` | 2 | Multiplicative increase in care seeking during pregnancy |
+
+## Results
+
+HIV produces the standard BaseSTI results (`new_infections`, `prevalence`, `incidence`, etc.) plus HIV-specific results:
+
+### HIV-specific results
+
+| Result | Description |
+|--------|-------------|
+| `new_deaths` | HIV/AIDS deaths this timestep |
+| `cum_deaths` | Cumulative HIV/AIDS deaths |
+| `new_diagnoses` | Newly diagnosed this timestep |
+| `cum_diagnoses` | Cumulative diagnoses |
+| `new_agents_on_art` | Agents starting ART this timestep |
+| `p_on_art` | Proportion of infected agents on ART |
+| `prevalence_15_49` | HIV prevalence among 15-49 year olds |
+| `n_on_art_pregnant` | Number of pregnant women on ART (only present when pregnancy is in the sim) |
+
+### Transmission route results
+
+All STI diseases (including HIV) track infections by transmission route:
+
+| Result | Description |
+|--------|-------------|
+| `new_infections` | Total new infections (sexual + MTCT) |
+| `new_infections_sex` | New infections via sexual transmission |
+| `new_infections_mtct` | New infections via mother-to-child transmission |
+
+These are always consistent: `new_infections_sex + new_infections_mtct == new_infections`.
+
+**Accessing MTCT results:**
+
+```python
+sim.run()
+
+# Total MTCT infections over the simulation
+total_mtct = sim.results.hiv.new_infections_mtct.sum()
+
+# Time series
+plt.plot(sim.t.yearvec, sim.results.hiv.new_infections_mtct)
+```

--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -116,8 +116,9 @@ class BaseSTI(ss.Infection):
         # Set initial prevalence
         self.init_prev_data = init_prev_data
 
-        # MTCT tracking: count of congenital infections this timestep, set in set_outcomes()
+        # Transmission route counts this timestep, set in set_outcomes()
         self._n_mtct = 0
+        self._n_sexual = 0
 
         # Results
         self.age_range = [15, 50]  # Age range for main results e.g. prevalence
@@ -284,20 +285,28 @@ class BaseSTI(ss.Infection):
         return new_cases, sources, networks
 
     def set_outcomes(self, uids, sources=None):
+        """
+        Set prognoses for newly infected agents and track transmission routes.
+
+        Args:
+            uids: UIDs of agents newly infected this timestep (not all agents)
+            sources: UIDs of the agents who transmitted to each new case
+        """
         super().set_outcomes(uids, sources=sources)
-        self.new_transmissions[:] = 0  # Total
-        self.new_transmissions_sex[:] = 0  # Sexual transmissions only
+        self.new_transmissions[:] = 0
+        self.new_transmissions_sex[:] = 0
         self._n_mtct = 0
+        self._n_sexual = 0
 
         if sources is not None:
-            # Separate sexual and congenital transmission
+            # Separate sexual and congenital transmission (age <= 0 = unborn)
             congenital = self.sim.people.age[uids] <= 0
-            self._n_mtct = np.count_nonzero(congenital)
+            self._n_mtct = ut.count(congenital)
+            self._n_sexual = ut.count(~congenital)
             sex_transmission = sources[~congenital]
             mtc_transmission = sources[congenital]
 
-            # Get the unique sources and counts
-            # Only needed for sexual transmission, not MTC.
+            # Track per-source transmission counts
             unique_sources, counts = np.unique(sources, return_counts=True)
             self.ti_transmitted[unique_sources] = self.ti
             unique_sources_sex, counts_sex = np.unique(sex_transmission, return_counts=True)
@@ -346,9 +355,9 @@ class BaseSTI(ss.Infection):
                     self.results[f'{akey}{ask}'][ti] = ares[ai]
                     ai += 1
 
-        # Transmission route results
+        # Transmission route results (set in set_outcomes)
         self.results['new_infections_mtct'][ti] = self._n_mtct
-        self.results['new_infections_sex'][ti] = self.results['new_infections'][ti] - self._n_mtct
+        self.results['new_infections_sex'][ti] = self._n_sexual
 
         return
 

--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -116,6 +116,9 @@ class BaseSTI(ss.Infection):
         # Set initial prevalence
         self.init_prev_data = init_prev_data
 
+        # MTCT tracking: count of congenital infections this timestep, set in set_outcomes()
+        self._n_mtct = 0
+
         # Results
         self.age_range = [15, 50]  # Age range for main results e.g. prevalence
         self.age_bins = np.array([0, 15, 20, 25, 30, 35, 50, 65, 100])  # Age bins for results
@@ -229,6 +232,12 @@ class BaseSTI(ss.Infection):
                     ss.Result('new_treated'+skk, dtype=int, label="Treatments"+skl, auto_plot=False),
                 ]
 
+        # Transmission route results
+        results += [
+            ss.Result('new_infections_sex', dtype=int, label='New infections (sexual)', auto_plot=False),
+            ss.Result('new_infections_mtct', dtype=int, label='New infections (MTCT)', auto_plot=False),
+        ]
+
         self.define_results(*results)
 
         return
@@ -278,10 +287,12 @@ class BaseSTI(ss.Infection):
         super().set_outcomes(uids, sources=sources)
         self.new_transmissions[:] = 0  # Total
         self.new_transmissions_sex[:] = 0  # Sexual transmissions only
+        self._n_mtct = 0
 
         if sources is not None:
             # Separate sexual and congenital transmission
             congenital = self.sim.people.age[uids] <= 0
+            self._n_mtct = np.count_nonzero(congenital)
             sex_transmission = sources[~congenital]
             mtc_transmission = sources[congenital]
 
@@ -334,6 +345,11 @@ class BaseSTI(ss.Infection):
                     ask = f'{skk}_{ab1}_{ab2}'
                     self.results[f'{akey}{ask}'][ti] = ares[ai]
                     ai += 1
+
+        # Transmission route results
+        self.results['new_infections_mtct'][ti] = self._n_mtct
+        self.results['new_infections_sex'][ti] = self.results['new_infections'][ti] - self._n_mtct
+
         return
 
 

--- a/tests/hiv_natural_history_analyzers.py
+++ b/tests/hiv_natural_history_analyzers.py
@@ -186,7 +186,7 @@ class SexualTransmissionCountTracker(ss.Analyzer):
 class MTCTransmissionCountTracker(ss.Analyzer):
     """
     Records the number of mother-to-child HIV transmissions per timestep, results obtainable by analyzer key
-    'hiv.n_mtc_transmissions' .
+    'hiv.n_mtc_transmissions'. Uses the built-in new_infections_mtct result from BaseSTI.
     """
 
     result_name = 'hiv.n_mtc_transmissions'
@@ -199,14 +199,7 @@ class MTCTransmissionCountTracker(ss.Analyzer):
         self.define_results(ss.Result(self.result_name, dtype=list, scale=False))
 
     def update_results(self):
-        hiv = self.sim.diseases.hiv
-        transmitting_mothers = hiv.ti_transmitted_mtc == self.ti
-
-        # now back-out mtc transmissions by removing any potential sexual transmissions
-        # TODO: Update how mtc transmissions are counted once this issue is fixed:
-        #  https://github.com/starsimhub/stisim/issues/325
-        transmissions =  sum(hiv.new_transmissions[transmitting_mothers] - hiv.new_transmissions_sex[transmitting_mothers])
-        self.results[self.result_name][self.ti] = transmissions
+        self.results[self.result_name][self.ti] = self.sim.diseases.hiv.results['new_infections_mtct'][self.ti]
 
 
 # perinatal infection progression not currently implemented in hivsim, so leaving this untested analyzer out for

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -234,6 +234,13 @@ def test_mtc_transmission_occurs():
     if verbose:
         print(f"{total_mtc_tranmissions} mother-to-child transmissions were recorded")
     assert total_mtc_tranmissions > 0, f"Expected MTC transmissions to occur, but none were recorded."
+
+    # Verify consistency: new_infections_mtct + new_infections_sex == new_infections
+    total = sim.results.hiv.new_infections.sum()
+    sex = sim.results.hiv.new_infections_sex.sum()
+    mtct = sim.results.hiv.new_infections_mtct.sum()
+    assert sex + mtct == total, f'Expected sex ({sex}) + mtct ({mtct}) == total ({total})'
+
     return sim
 
 


### PR DESCRIPTION
## Summary
- Add `new_infections_mtct` and `new_infections_sex` results to BaseSTI, available for all STI diseases (HIV, syphilis, etc.)
- Track MTCT count directly in `set_outcomes()` using the existing `age <= 0` check
- Simplify `MTCTransmissionCountTracker` test analyzer to use the new built-in result
- Add consistency test: `new_infections_sex + new_infections_mtct == new_infections`

Closes #325. Actually only closes 4/5 tasks in #325 but the last one is a separate issue (#323)