### PR TITLE
Breastfeeding HIV transmission and prenatal/postnatal MTCT tracking (#323)

### DIFF
--- a/hivsim/sim.py
+++ b/hivsim/sim.py
@@ -49,7 +49,7 @@ class Sim(sti.Sim):
 
         # Handle networks
         if not modules.networks:
-            modules.networks = [sti.StructuredSexual(), ss.MaternalNet()]
+            modules.networks = [sti.StructuredSexual(), ss.MaternalNet(), ss.BreastfeedingNet()]
 
         # Handle interventions
         if not modules.interventions:

--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -28,7 +28,8 @@ class HIVPars(BaseSTIPars):
         self.beta = 0  # Placeholder, replaced by network-specific betas
         self.beta_m2f = 0.05
         self.rel_beta_f2m = 0.5
-        self.beta_m2c = ss.permonth(0.025)  # Approx 0.2 over the course of the pregnany
+        self.beta_m2c = ss.permonth(0.025)  # Prenatal MTCT: ~20% over pregnancy
+        self.beta_breastfeed = ss.permonth(0.005)  # Postnatal MTCT via breastfeeding (~14% over 12 months without ART)
         self.rel_trans_acute = ss.normal(loc=6, scale=0.5)  # Increase transmissibility during acute HIV infection
         self.rel_trans_falling = ss.normal(loc=8, scale=0.5)  # Increase transmissibility during late HIV infection
         self.eff_condom = 0.9

--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -116,8 +116,9 @@ class BaseSTI(ss.Infection):
         # Set initial prevalence
         self.init_prev_data = init_prev_data
 
-        # MTCT tracking: count of congenital infections this timestep, set in set_outcomes()
-        self._n_mtct = 0
+        # MTCT tracking: counts set in set_outcomes()
+        self._n_prenatal = 0
+        self._n_postnatal = 0
 
         # Results
         self.age_range = [15, 50]  # Age range for main results e.g. prevalence
@@ -171,6 +172,8 @@ class BaseSTI(ss.Infection):
             betamap['structuredsexual'][1] = self.pars.beta_m2f * self.pars.rel_beta_f2m
         if self.pars.beta_m2c is not None and betamap and 'maternal' in betamap.keys():
             betamap['maternal'][0] = ss.permonth(self.pars.beta_m2c)
+        if hasattr(self.pars, 'beta_breastfeed') and betamap and 'breastfeeding' in betamap.keys():
+            betamap['breastfeeding'][0] = ss.permonth(self.pars.beta_breastfeed)
         if self.pars.beta_m2m is not None and betamap and 'msm' in betamap.keys():
             betamap['msm'][0] = self.pars.beta_m2m
             betamap['msm'][1] = self.pars.beta_m2m
@@ -236,11 +239,20 @@ class BaseSTI(ss.Infection):
         results += [
             ss.Result('new_infections_sex', dtype=int, label='New infections (sexual)', auto_plot=False),
             ss.Result('new_infections_mtct', dtype=int, label='New infections (MTCT)', auto_plot=False),
+            ss.Result('new_infections_prenatal', dtype=int, label='New infections (prenatal MTCT)', auto_plot=False),
+            ss.Result('new_infections_postnatal', dtype=int, label='New infections (postnatal MTCT)', auto_plot=False),
         ]
 
         self.define_results(*results)
 
         return
+
+    def step(self):
+        """ Override to pass network indices to set_outcomes for MTCT tracking """
+        new_cases, sources, networks = self.infect()
+        if len(new_cases):
+            self.set_outcomes(new_cases, sources, networks)
+        return new_cases, sources, networks
 
     def infect(self):
         """ Determine who gets infected on this timestep via transmission on the network """
@@ -283,21 +295,35 @@ class BaseSTI(ss.Infection):
 
         return new_cases, sources, networks
 
-    def set_outcomes(self, uids, sources=None):
+    def set_outcomes(self, uids, sources=None, networks=None):
         super().set_outcomes(uids, sources=sources)
         self.new_transmissions[:] = 0  # Total
         self.new_transmissions_sex[:] = 0  # Sexual transmissions only
-        self._n_mtct = 0
+        self._n_prenatal = 0
+        self._n_postnatal = 0
 
         if sources is not None:
-            # Separate sexual and congenital transmission
-            congenital = self.sim.people.age[uids] <= 0
-            self._n_mtct = np.count_nonzero(congenital)
-            sex_transmission = sources[~congenital]
-            mtc_transmission = sources[congenital]
+            # Classify infections by network type (prenatal, postnatal, or sexual)
+            is_prenatal = np.zeros(len(uids), dtype=bool)
+            is_postnatal = np.zeros(len(uids), dtype=bool)
+            if networks is not None:
+                net_list = list(self.sim.networks.values())
+                for idx in np.unique(networks):
+                    net = net_list[idx]
+                    mask = networks == idx
+                    if isinstance(net, ss.PrenatalNet):
+                        is_prenatal |= mask
+                    elif isinstance(net, ss.PostnatalNet):
+                        is_postnatal |= mask
+
+            is_mtct = is_prenatal | is_postnatal
+            self._n_prenatal = np.count_nonzero(is_prenatal)
+            self._n_postnatal = np.count_nonzero(is_postnatal)
+
+            sex_transmission = sources[~is_mtct]
+            mtc_transmission = sources[is_mtct]
 
             # Get the unique sources and counts
-            # Only needed for sexual transmission, not MTC.
             unique_sources, counts = np.unique(sources, return_counts=True)
             self.ti_transmitted[unique_sources] = self.ti
             unique_sources_sex, counts_sex = np.unique(sex_transmission, return_counts=True)
@@ -347,8 +373,10 @@ class BaseSTI(ss.Infection):
                     ai += 1
 
         # Transmission route results
-        self.results['new_infections_mtct'][ti] = self._n_mtct
-        self.results['new_infections_sex'][ti] = self.results['new_infections'][ti] - self._n_mtct
+        self.results['new_infections_prenatal'][ti] = self._n_prenatal
+        self.results['new_infections_postnatal'][ti] = self._n_postnatal
+        self.results['new_infections_mtct'][ti] = self._n_prenatal + self._n_postnatal
+        self.results['new_infections_sex'][ti] = self.results['new_infections'][ti] - self.results['new_infections_mtct'][ti]
 
         return
 

--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -322,7 +322,12 @@ class BaseSTI(ss.Infection):
         self.new_transmissions_sex[:] = 0
 
         if sources is not None:
-            # Classify infections by network type (prenatal, postnatal, or sexual)
+            # Classify each new infection by its transmission route.
+            # net_ids is an integer array (one per new infection) where each value
+            # is the index into sim.networks (in insertion order) of the network
+            # that caused that infection. We loop over the unique network indices,
+            # look up the actual network object, and use isinstance to classify
+            # as prenatal MTCT, postnatal MTCT, or horizontal (sexual) transmission.
             is_prenatal = np.zeros(len(uids), dtype=bool)
             is_postnatal = np.zeros(len(uids), dtype=bool)
             if net_ids is not None:

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -220,26 +220,40 @@ def test_doubling_hiv_sexual_beta_doubles_transmissions():
 
 
 @sc.timer()
-def test_mtc_transmission_occurs():
-    sc.heading("Ensuring that pre-term mother-to-child transmission occurs.")
+def test_mtct(do_plot=do_plot):
+    """ Check prenatal and postnatal MTCT: both occur, results are consistent """
+    sc.heading('Testing MTCT (prenatal + postnatal)...')
 
-    # setting fertility rate super high to enable shrinking the test agent/timewise
-    analyzer = MTCTransmissionCountTracker()
-    sim = build_testing_sim(analyzers=[analyzer], n_agents=500, duration=1, pregnancy=ss.Pregnancy(fertility_rate=1000))
+    # High fertility + high breastfeeding beta to ensure both transmission routes
+    sim = hivsim.demo('simple', run=False, plot=False, n_agents=2_000,
+                      beta_breastfeed=ss.permonth(0.1), init_prev=0.3)
     sim.run()
 
-    mtc_tranmissions = sim.results[analyzer.name][analyzer.result_name]
-    total_mtc_tranmissions = sum(mtc_tranmissions)
-
-    if verbose:
-        print(f"{total_mtc_tranmissions} mother-to-child transmissions were recorded")
-    assert total_mtc_tranmissions > 0, f"Expected MTC transmissions to occur, but none were recorded."
-
-    # Verify consistency: new_infections_mtct + new_infections_sex == new_infections
     total = sim.results.hiv.new_infections.sum()
     sex = sim.results.hiv.new_infections_sex.sum()
     mtct = sim.results.hiv.new_infections_mtct.sum()
+    prenatal = sim.results.hiv.new_infections_prenatal.sum()
+    postnatal = sim.results.hiv.new_infections_postnatal.sum()
+
+    if verbose:
+        print(f'Total: {total}, Sexual: {sex}, MTCT: {mtct} (prenatal: {prenatal}, postnatal: {postnatal})')
+
+    # Both routes should produce infections
+    assert prenatal > 0, f'Expected prenatal MTCT infections, got {prenatal}'
+    assert postnatal > 0, f'Expected postnatal MTCT infections with BreastfeedingNet, got {postnatal}'
+
+    # Consistency checks
     assert sex + mtct == total, f'Expected sex ({sex}) + mtct ({mtct}) == total ({total})'
+    assert prenatal + postnatal == mtct, f'Expected prenatal ({prenatal}) + postnatal ({postnatal}) == mtct ({mtct})'
+
+    if do_plot:
+        fig, ax = plt.subplots()
+        ax.plot(sim.t.yearvec, sim.results.hiv.new_infections_prenatal, label='Prenatal')
+        ax.plot(sim.t.yearvec, sim.results.hiv.new_infections_postnatal, label='Postnatal')
+        ax.set_ylabel('New MTCT infections')
+        ax.set_xlabel('Year')
+        ax.legend()
+        ax.set_title('Prenatal vs postnatal MTCT')
 
     return sim
 
@@ -627,7 +641,7 @@ if __name__ == '__main__':
     test_no_sexual_transmission_without_network()
     test_doubling_hiv_maternal_beta_doubles_transmissions()
     test_doubling_hiv_sexual_beta_doubles_transmissions()
-    test_mtc_transmission_occurs()
+    test_mtct()
     test_cd4_rises_on_ART()
     test_art_increases_longevity()
     test_no_hiv_with_no_outbreaks()

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -23,6 +23,12 @@ def test_minimal_hiv():
     assert sim.results.hiv.cum_infections[-1] > 0
     return sim
 
+def test_starsim():
+    """ Test that starsim modules can be used in sti.Sim """
+    sim = ss.Sim(diseases='sir', networks='random', n_agents=500, dur=10)
+    sim.run()
+    return sim 
+
 
 def test_minimal_sti():
     """ Simplest possible non-HIV STI sim """
@@ -81,9 +87,27 @@ def test_sim_creation():
     assert len(sim1.diseases) == 5, "Incorrect number of diseases initialized"
 
     # Test 2: mix of strings and modules
+    class MyNetwork(ss.Network):
+        def __init__(self, pars=None):
+            super().__init__(pars)
+            self.pars.debut = ss.lognorm_ex(20, 5)
+
+    class MentalHealth(ss.Disease):
+        def __init__(self, pars=None):
+            super().__init__(pars)
+            self.pars.beta_m2f = 0.01
+
+        def step(self):
+            """ Increase rel_sus to HIV """
+            hiv = self.sim.diseases.hiv
+            hiv.pars.rel_sus *= 1.01
+
+            # Plus then some mental health dynamics here...
+            
+
     demographics = [ss.Pregnancy(), ss.Deaths()]
-    networks = sti.StructuredSexual()
-    diseases = [sti.Gonorrhea(), 'hiv']
+    networks = [sti.StructuredSexual(), MyNetwork()]
+    diseases = [sti.Gonorrhea(), 'hiv', MentalHealth()]
 
     sim2 = sti.Sim(
         pars=pars,
@@ -95,7 +119,7 @@ def test_sim_creation():
     sim2.init()
 
     assert isinstance(sim2.networks.structuredsexual, sti.StructuredSexual), "Network not initialized correctly"
-    assert len(sim2.diseases) == 2, "Incorrect number of diseases initialized"
+    assert len(sim2.diseases) == 3, "Incorrect number of diseases initialized"
     assert len(sim2.demographics) == 2, "Incorrect number of demographics initialized"
 
     # Test 3: flat pars dict
@@ -132,7 +156,7 @@ def test_hivsim_defaults():
     # Check default modules are present
     assert 'hiv' in sim.diseases, "HIV disease not added"
     assert len(sim.diseases) == 1, "Should have exactly 1 disease"
-    assert len(sim.networks) == 2, "Should have 2 networks (sexual + maternal)"
+    assert len(sim.networks) == 3, "Should have 3 networks (sexual + maternal + breastfeeding)"
     assert len(sim.demographics) == 2, "Should have 2 demographics (pregnancy + deaths)"
     assert len(sim.interventions) == 4, "Should have 4 interventions (test, ART, VMMC, PrEP)"
 
@@ -160,7 +184,7 @@ def test_hivsim_custom_modules():
     assert len(sim.interventions) == 1, f"Expected 1 intervention, got {len(sim.interventions)}"
 
     # But other defaults should still be present
-    assert len(sim.networks) == 2, "Default networks should still be present"
+    assert len(sim.networks) == 3, "Default networks should still be present"
     assert len(sim.demographics) == 2, "Default demographics should still be present"
     return sim
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -23,12 +23,6 @@ def test_minimal_hiv():
     assert sim.results.hiv.cum_infections[-1] > 0
     return sim
 
-def test_starsim():
-    """ Test that starsim modules can be used in sti.Sim """
-    sim = ss.Sim(diseases='sir', networks='random', n_agents=500, dur=10)
-    sim.run()
-    return sim 
-
 
 def test_minimal_sti():
     """ Simplest possible non-HIV STI sim """
@@ -87,27 +81,9 @@ def test_sim_creation():
     assert len(sim1.diseases) == 5, "Incorrect number of diseases initialized"
 
     # Test 2: mix of strings and modules
-    class MyNetwork(ss.Network):
-        def __init__(self, pars=None):
-            super().__init__(pars)
-            self.pars.debut = ss.lognorm_ex(20, 5)
-
-    class MentalHealth(ss.Disease):
-        def __init__(self, pars=None):
-            super().__init__(pars)
-            self.pars.beta_m2f = 0.01
-
-        def step(self):
-            """ Increase rel_sus to HIV """
-            hiv = self.sim.diseases.hiv
-            hiv.pars.rel_sus *= 1.01
-
-            # Plus then some mental health dynamics here...
-            
-
     demographics = [ss.Pregnancy(), ss.Deaths()]
-    networks = [sti.StructuredSexual(), MyNetwork()]
-    diseases = [sti.Gonorrhea(), 'hiv', MentalHealth()]
+    networks = sti.StructuredSexual()
+    diseases = [sti.Gonorrhea(), 'hiv']
 
     sim2 = sti.Sim(
         pars=pars,


### PR DESCRIPTION
## Summary
- Add `BreastfeedingNet` to hivsim.Sim default networks
- Add `beta_breastfeed` parameter to HIVPars (separate from prenatal `beta_m2c`)
- Replace `age <= 0` heuristic with network-type classification in `set_outcomes()`
- Add `new_infections_prenatal` and `new_infections_postnatal` results
- Combined `test_mtct` covering both routes with consistency checks

Depends on #401 (`add-mtct` branch)
Closes #323