### PR TITLE
Remove BaseSTI.infect() override; tighten set_outcomes contract

### DIFF
--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -9,7 +9,6 @@ import sciris as sc
 import stisim.utils as ut
 import pandas as pd
 
-ss_int_ = ss.dtypes.int
 ss_float_ = ss.dtypes.float
 
 __all__ = ['BaseSTI', 'SEIS', 'BaseSTIPars', 'STIPars']
@@ -288,48 +287,7 @@ class BaseSTI(ss.Infection):
             self.set_outcomes(new_cases, sources, net_ids=networks)
         return new_cases, sources, networks
 
-    def infect(self):
-        """ Determine who gets infected on this timestep via transmission on the network """
-
-        new_cases = []
-        sources = []
-        networks = []
-        betamap = self.validate_beta()
-
-        rel_trans = self.rel_trans.asnew(self.infectious * self.rel_trans)
-        rel_sus   = self.rel_sus.asnew(self.susceptible * self.rel_sus)
-
-        for i, (nkey,net) in enumerate(self.sim.networks.items()):
-            nk = ss.standardize_netkey(nkey)
-            if len(net): # Skip networks with no edges
-                edges = net.edges
-                p1p2b0 = [edges.p1, edges.p2, betamap[nk][0]] # Person 1, person 2, beta 0
-                p2p1b1 = [edges.p2, edges.p1, betamap[nk][1]] # Person 2, person 1, beta 1
-                for src, trg, beta in [p1p2b0, p2p1b1]:
-                    if beta: # Skip networks with no transmission
-                        disease_beta = beta.to_prob(self.t.dt) if isinstance(beta, ss.Rate) else beta
-                        beta_per_dt = net.net_beta(disease_beta=disease_beta, disease=self) # Compute beta for this network and timestep
-                        randvals = self.trans_rng.rvs(src, trg) # Generate a new random number based on the two other random numbers
-                        args = (src, trg, rel_trans, rel_sus, beta_per_dt, randvals) # Set up the arguments to calculate transmission
-                        target_uids, source_uids = self.compute_transmission(*args) # Actually calculate it
-                        new_cases.append(target_uids)
-                        sources.append(source_uids)
-                        networks.append(np.full(len(target_uids), dtype=ss_int_, fill_value=i))
-
-        # Finalize
-        if len(new_cases) and len(sources):
-            new_cases = ss.uids.cat(new_cases)
-            new_cases, inds = new_cases.unique(return_index=True)
-            sources = ss.uids.cat(sources)[inds]
-            networks = np.concatenate(networks)[inds]
-        else:
-            new_cases = ss.uids()
-            sources = ss.uids()
-            networks = np.empty(0, dtype=ss_int_)
-
-        return new_cases, sources, networks
-
-    def set_outcomes(self, uids, sources=None, net_ids=None):
+    def set_outcomes(self, uids, sources, net_ids=None):
         """
         Set prognoses for newly infected agents and track transmission routes.
 
@@ -344,42 +302,41 @@ class BaseSTI(ss.Infection):
         self.new_transmissions[:] = 0
         self.new_transmissions_sex[:] = 0
 
-        if sources is not None:
-            # Classify each new infection by its transmission route.
-            # net_ids is an integer array (one per new infection) where each value
-            # is the index into sim.networks (in insertion order) of the network
-            # that caused that infection. We loop over the unique network indices,
-            # look up the actual network object, and use isinstance to classify
-            # as prenatal MTCT, postnatal MTCT, or horizontal (sexual) transmission.
-            is_prenatal = np.zeros(len(uids), dtype=bool)
-            is_postnatal = np.zeros(len(uids), dtype=bool)
-            if net_ids is not None:
-                net_list = list(self.sim.networks.values())
-                for idx in np.unique(net_ids):
-                    net = net_list[idx]
-                    mask = net_ids == idx
-                    if isinstance(net, ss.PrenatalNet):
-                        is_prenatal |= mask
-                    elif isinstance(net, ss.PostnatalNet):
-                        is_postnatal |= mask
+        # Classify each new infection by its transmission route.
+        # net_ids is an integer array (one per new infection) where each value
+        # is the index into sim.networks (in insertion order) of the network
+        # that caused that infection. We loop over the unique network indices,
+        # look up the actual network object, and use isinstance to classify
+        # as prenatal MTCT, postnatal MTCT, or horizontal (sexual) transmission.
+        is_prenatal = np.zeros(len(uids), dtype=bool)
+        is_postnatal = np.zeros(len(uids), dtype=bool)
+        if net_ids is not None:
+            net_list = list(self.sim.networks.values())
+            for idx in np.unique(net_ids):
+                net = net_list[idx]
+                mask = net_ids == idx
+                if isinstance(net, ss.PrenatalNet):
+                    is_prenatal |= mask
+                elif isinstance(net, ss.PostnatalNet):
+                    is_postnatal |= mask
 
-            is_mtct = is_prenatal | is_postnatal
+        is_mtct = is_prenatal | is_postnatal
 
-            # Store network index per agent for use in update_results
-            if net_ids is not None:
-                self.infection_net[uids] = net_ids.astype(float)
+        # Store network index per agent for use in update_results
+        if net_ids is not None:
+            self.infection_net[uids] = net_ids.astype(float)
 
-            sex_transmission = sources[~is_mtct]
-            mtc_transmission = sources[is_mtct]
+        sex_transmission = sources[~is_mtct]
+        mtc_transmission = sources[is_mtct]
 
-            # Track per-source transmission counts
-            unique_sources, counts = np.unique(sources, return_counts=True)
-            self.ti_transmitted[unique_sources] = self.ti
-            unique_sources_sex, counts_sex = np.unique(sex_transmission, return_counts=True)
-            self.ti_transmitted_sex[sex_transmission] = self.ti
-            self.ti_transmitted_mtc[mtc_transmission] = self.ti
-            self.new_transmissions[unique_sources] = counts
-            self.new_transmissions_sex[unique_sources_sex] = counts_sex
+        # Track per-source transmission counts
+        unique_sources, counts = np.unique(sources, return_counts=True)
+        self.ti_transmitted[unique_sources] = self.ti
+        unique_sources_sex, counts_sex = np.unique(sex_transmission, return_counts=True)
+        self.ti_transmitted_sex[sex_transmission] = self.ti
+        self.ti_transmitted_mtc[mtc_transmission] = self.ti
+        self.new_transmissions[unique_sources] = counts
+        self.new_transmissions_sex[unique_sources_sex] = counts_sex
 
         return
 


### PR DESCRIPTION
## Summary

- Deletes `BaseSTI.infect()` — parent `ss.Infection.infect()` is a strict superset. The override duplicated the network-transmission loop but skipped the `ss.Route` (mixing pools) branch, so any non-Network route would `AttributeError` on `.edges`. Removing the override gains mixing-pool compatibility for free.
- Drops `sources=None` default and the `if sources is not None:` guard in `BaseSTI.set_outcomes()`. Per review on #401, `sources` is always passed by `step()` — the default and guard were dead.
- Keeps the `step()` override, which is still needed to thread `net_ids=networks` into `set_outcomes` for per-source MTC/sex transmission classification.
- Removes the now-unused `ss_int_` module-level alias.

Closes #412.
Closes #421.

## Test plan
- [x] Full test suite passes (`test_sim.py`, `test_stis.py`, `test_networks.py`, `test_hiv.py`, `test_connectors.py`, `test_hiv_interventions.py`, `test_baselines.py`, `test_calibration.py` — 57 tests)