### PR TITLE
Add age/sex-stratified susceptibility: rel_sus_age

### DIFF
--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -39,6 +39,9 @@ class HIVPars(BaseSTIPars):
         self.beta_breastfeed = ss.permonth(0.005)  # Postnatal MTCT via breastfeeding (~14% over 12 months without ART)
         self.rel_trans_acute = ss.normal(loc=5.3, scale=0.5)  # Increase transmissibility during acute HIV infection (Bellan 2015: RH=5.3, EHM≈7.3)
         self.rel_trans_falling = ss.normal(loc=8, scale=0.5)  # Increase transmissibility during late HIV infection
+        self.rel_beta_m2f_by_age = None  # Age-dependent M→F susceptibility multipliers for females.
+        # List of (age_lo, age_hi, multiplier) tuples; applies to rel_sus so affects M→F only.
+        # Example (EMOD eSwatini calibration): [(15, 25, 1.72), (25, np.inf, 1.0)]
         self.eff_condom = 0.9
 
         # Initialization
@@ -460,6 +463,15 @@ class HIV(BaseSTI):
         # Reset susceptibility and infectiousness
         self.rel_sus[:] = 1
         self.rel_trans[:] = 1
+
+        # Age-dependent M→F susceptibility: modulate female rel_sus by age bin.
+        # Only affects M→F transmission (p_transmit = rel_trans[src] * rel_sus[trg] * beta).
+        # Does not affect F→M because rel_sus[male_trg] is unchanged.
+        if self.pars.rel_beta_m2f_by_age is not None:
+            ppl = self.sim.people
+            for age_lo, age_hi, mult in self.pars.rel_beta_m2f_by_age:
+                in_bin = ppl.female & (ppl.age >= age_lo) & (ppl.age < age_hi)
+                self.rel_sus[in_bin] *= mult
 
         # Update rel_trans to account for acute and late-stage infection
         self.rel_trans[self.acute] *= self.pars.rel_trans_acute.rvs(self.acute.uids)

--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -39,9 +39,11 @@ class HIVPars(BaseSTIPars):
         self.beta_breastfeed = ss.permonth(0.005)  # Postnatal MTCT via breastfeeding (~14% over 12 months without ART)
         self.rel_trans_acute = ss.normal(loc=5.3, scale=0.5)  # Increase transmissibility during acute HIV infection (Bellan 2015: RH=5.3, EHM≈7.3)
         self.rel_trans_falling = ss.normal(loc=8, scale=0.5)  # Increase transmissibility during late HIV infection
-        self.rel_beta_m2f_by_age = None  # Age-dependent M→F susceptibility multipliers for females.
-        # List of (age_lo, age_hi, multiplier) tuples; applies to rel_sus so affects M→F only.
-        # Example (EMOD eSwatini calibration): [(15, 25, 1.72), (25, np.inf, 1.0)]
+        self.rel_sus_age = None  # Age/sex-stratified rel_sus multipliers.
+        # List of (age_lo, age_hi, sex, multiplier) tuples; sex is 'f', 'm', or None for both.
+        # Multiplied into rel_sus each timestep alongside other contributors (PrEP, connectors, etc.),
+        # so values are ceteris-paribus differences, not absolute susceptibilities.
+        # Example: [(15, 25, 'f', 1.7), (25, 50, 'f', 1.0), (15, 50, 'm', 1.0)]
         self.eff_condom = 0.9
 
         # Initialization
@@ -464,13 +466,15 @@ class HIV(BaseSTI):
         self.rel_sus[:] = 1
         self.rel_trans[:] = 1
 
-        # Age-dependent M→F susceptibility: modulate female rel_sus by age bin.
-        # Only affects M→F transmission (p_transmit = rel_trans[src] * rel_sus[trg] * beta).
-        # Does not affect F→M because rel_sus[male_trg] is unchanged.
-        if self.pars.rel_beta_m2f_by_age is not None:
+        # Age/sex-stratified susceptibility. Multiplied in alongside other contributors
+        # (PrEP, connectors, etc.) so values are ceteris-paribus, not absolute.
+        if self.pars.rel_sus_age is not None:
             ppl = self.sim.people
-            for age_lo, age_hi, mult in self.pars.rel_beta_m2f_by_age:
-                in_bin = ppl.female & (ppl.age >= age_lo) & (ppl.age < age_hi)
+            for age_lo, age_hi, sex, mult in self.pars.rel_sus_age:
+                if sex == 'f':   sex_mask = ppl.female
+                elif sex == 'm': sex_mask = ppl.male
+                else:            sex_mask = ppl.alive
+                in_bin = sex_mask & (ppl.age >= age_lo) & (ppl.age < age_hi)
                 self.rel_sus[in_bin] *= mult
 
         # Update rel_trans to account for acute and late-stage infection

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -669,6 +669,34 @@ def test_par_ranges(n_agents=1000):
     return
 
 
+def test_rel_beta_m2f_by_age(n_agents=3000):
+    """
+    Higher rel_beta_m2f_by_age multiplier for young women should produce more
+    infections in that age group relative to a sim with uniform susceptibility.
+    """
+    import numpy as np
+    hiv_age = sti.HIV(
+        rel_beta_m2f_by_age=[(15, 25, 3.0), (25, np.inf, 1.0)],
+        init_prev=0.1,
+    )
+    sim_age = sti.Sim(diseases=hiv_age, n_agents=n_agents, dur=10, rand_seed=1, verbose=0)
+    sim_uni = sti.Sim(diseases='hiv', n_agents=n_agents, dur=10, rand_seed=1, verbose=0)
+    ss.parallel(sim_age, sim_uni)
+
+    def young_female_infections(sim):
+        ppl = sim.people
+        ti_inf = sim.diseases.hiv.ti_infected.values
+        return ((ppl.age.values >= 15) & (ppl.age.values < 25) & ppl.female.values & (ti_inf >= 0)).sum()
+
+    yf_age = young_female_infections(sim_age)
+    yf_uni = young_female_infections(sim_uni)
+    assert yf_age > yf_uni, (
+        f'Higher rel_beta_m2f_by_age for young women should produce more young female '
+        f'infections; age-dep={yf_age}, uniform={yf_uni}'
+    )
+    return sim_age, sim_uni
+
+
 def test_prevalence_by_sex(n_agents=3000):
     """
     Under default parameters, female HIV prevalence should exceed male prevalence.

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -669,14 +669,14 @@ def test_par_ranges(n_agents=1000):
     return
 
 
-def test_rel_beta_m2f_by_age(n_agents=3000):
+def test_rel_sus_age(n_agents=3000):
     """
-    Higher rel_beta_m2f_by_age multiplier for young women should produce more
-    infections in that age group relative to a sim with uniform susceptibility.
+    Higher rel_sus_age multiplier for young women should produce more infections
+    in that group relative to a sim with uniform susceptibility.
     """
     import numpy as np
     hiv_age = sti.HIV(
-        rel_beta_m2f_by_age=[(15, 25, 3.0), (25, np.inf, 1.0)],
+        rel_sus_age=[(15, 25, 'f', 3.0), (25, np.inf, 'f', 1.0)],
         init_prev=0.1,
     )
     sim_age = sti.Sim(diseases=hiv_age, n_agents=n_agents, dur=10, rand_seed=1, verbose=0)
@@ -691,8 +691,8 @@ def test_rel_beta_m2f_by_age(n_agents=3000):
     yf_age = young_female_infections(sim_age)
     yf_uni = young_female_infections(sim_uni)
     assert yf_age > yf_uni, (
-        f'Higher rel_beta_m2f_by_age for young women should produce more young female '
-        f'infections; age-dep={yf_age}, uniform={yf_uni}'
+        f'rel_sus_age multiplier for young women should increase their infections; '
+        f'age-dep={yf_age}, uniform={yf_uni}'
     )
     return sim_age, sim_uni
 


### PR DESCRIPTION
## Summary

Adds `rel_sus_age` to `HIVPars`: a list of `(age_lo, age_hi, sex, multiplier)` tuples applied to `rel_sus` each timestep in `update_transmission`.

```python
# Example — EMOD eSwatini calibration (Silhol et al. 2021), normalised:
sti.HIV(rel_sus_age=[(15, 25, 'f', 1.72), (25, 50, 'f', 1.0)])

# Any combination of age/sex bins:
sti.HIV(rel_sus_age=[(15, 25, 'f', 2.0), (25, 50, 'f', 1.2), (15, 50, 'm', 0.9)])
```

`sex` is `'f'`, `'m'`, or `None` for both. Multipliers stack with other `rel_sus` contributors (PrEP, connectors, etc.) — values are ceteris-paribus differences, not absolute susceptibilities. This is mathematically equivalent to age-stratified M→F betas as in EMOD.

**Default: `None`** (disabled — existing behaviour preserved).

Closes #395.

## Test plan
- [x] `test_rel_sus_age`: 3× multiplier for young women produces significantly more young female infections
- [x] All 55 existing tests pass