### PR TITLE
Add sti.route_pars; refactor separate_pars (#451)

### DIFF
--- a/docs/examples/dynamic_debut.qmd
+++ b/docs/examples/dynamic_debut.qmd
@@ -102,7 +102,7 @@ msim = ss.parallel(sim_static, sim_dynamic)
 
 def afs_by_cohort(sim, cohort_bin=5):
     ppl = sim.people
-    net = sim.networks.structuredsexual
+    net = sim.networks.mfnetwork
     # .values gives numpy arrays for active agents only
     debut  = net.debut.values
     age    = ppl.age.values

--- a/hivsim_examples/simple/sim.py
+++ b/hivsim_examples/simple/sim.py
@@ -13,12 +13,19 @@ import hivsim
 
 
 def make_sim(**kwargs):
-    """Create a simple HIV simulation using ``sti.MFNetwork``."""
+    """Create a simple HIV simulation using ``sti.MFNetwork``.
+
+    Flat ``**kwargs`` are auto-routed via ``sti.route_pars`` — pass network
+    pars (``debut_f=18``, ``prop_f0=0.7``), sim pars (``n_agents=5000``,
+    ``dur=10``), or sti pars (``init_prev=0.05``) directly.
+    """
     kwargs.setdefault('n_agents', 2000)
     kwargs.setdefault('dur', 20)
+    nw_kwargs = sti.route_pars(kwargs).nw
+    for k in nw_kwargs: kwargs.pop(k)  # consumed here, don't re-route in sti.Sim
 
     if 'networks' not in kwargs:
-        nets = [sti.MFNetwork(), ss.MaternalNet()]
+        nets = [sti.MFNetwork(**nw_kwargs), ss.MaternalNet()]
         # BreastfeedingNet only makes sense if Pregnancy is in demographics.
         # User-supplied demographics: respect them. Otherwise hivsim.Sim defaults
         # to Pregnancy + Deaths, so include BreastfeedingNet.
@@ -26,6 +33,5 @@ def make_sim(**kwargs):
         if demog is None or any(isinstance(m, ss.Pregnancy) for m in sc.tolist(demog)):
             nets.append(ss.BreastfeedingNet())
         kwargs['networks'] = nets
-
     kwargs.setdefault('interventions', [sti.HIVTest(), sti.ART(), sti.VMMC()])
     return hivsim.Sim(**kwargs)

--- a/hivsim_examples/zimbabwe/sim.py
+++ b/hivsim_examples/zimbabwe/sim.py
@@ -17,15 +17,15 @@ import stisim as sti
 datadir = sc.thispath()
 
 # Sim settings
-sim_pars = dict(start=1990, stop=2025, age_scale=1000)
+default_sim_pars = dict(start=1990, stop=2025, age_scale=1000)
 
 # Calibrated parameters
-sti_pars = dict(
+default_hiv_pars = dict(
     beta_m2f=0.035,
     eff_condom=0.95,
     rel_init_prev=1.0,
 )
-nw_pars = dict(
+default_nw_pars = dict(
     prop_f0=0.79,
     prop_m0=0.83,
     f1_conc=0.16,
@@ -71,57 +71,38 @@ def make_sim(**kwargs):
     """
     Create a Zimbabwe HIV simulation with calibrated parameters.
 
-    Loads demographic, behavioral, and epidemiological data from CSV files
-    in this directory and creates a fully configured simulation.
-
-    Args:
-        **kwargs: Override any parameter passed to sti.Sim (e.g. n_agents, dur).
-            If 'interventions' is provided, they are added to the defaults.
-
-    Returns:
-        sti.Sim: Configured simulation ready to run.
+    Flat ``**kwargs`` are auto-routed via ``sti.route_pars`` — pass any
+    network par (e.g. ``debut_f=18``), HIV par (``beta_m2f=0.04``), or sim
+    par (``n_agents=5000``) directly. User values override the calibrated
+    defaults baked into this builder.
     """
-    # Load data
-    init_prev = pd.read_csv(datadir / 'init_prev_hiv.csv')
+    routed = sti.route_pars(kwargs)
+    nw_pars  = sc.mergedicts(default_nw_pars,  routed.nw)
+    hiv_pars = sc.mergedicts(default_hiv_pars, routed.sti)
+    for k in (*routed.nw, *routed.sti): kwargs.pop(k)  # consumed here
+
+    init_prev   = pd.read_csv(datadir / 'init_prev_hiv.csv')
     condom_data = pd.read_csv(datadir / 'condom_use.csv')
-    art_data = pd.read_csv(datadir / 'art_coverage.csv').set_index('year')
-    vmmc_data = pd.read_csv(datadir / 'vmmc_coverage.csv').set_index('year')
-    hiv_data = pd.read_csv(datadir / 'zimbabwe_hiv_data.csv')
+    art_data    = pd.read_csv(datadir / 'art_coverage.csv').set_index('year')
+    vmmc_data   = pd.read_csv(datadir / 'vmmc_coverage.csv').set_index('year')
+    hiv_data    = pd.read_csv(datadir / 'zimbabwe_hiv_data.csv')
 
-    # Pull user overrides for HIV / network out of kwargs so they reach module
-    # construction. Supports both disease-keyed dicts (`hiv=dict(...)`,
-    # `structuredsexual=dict(...)`) and flat kwargs. Matches sti.Sim test 3.
-    hiv_overrides = dict(kwargs.pop('hiv', None) or {})
-    for k in list(kwargs):
-        if k in sti.HIVPars().keys():
-            hiv_overrides[k] = kwargs.pop(k)
-    nw_overrides = dict(kwargs.pop('structuredsexual', None) or {})
-    for k in list(kwargs):
-        if k in sti.NetworkPars().keys():
-            nw_overrides[k] = kwargs.pop(k)
+    hiv     = sti.HIV(init_prev_data=init_prev, **hiv_pars)
+    network = sti.StructuredSexual(condom_data=condom_data, **nw_pars)
+    art     = sti.ART(coverage=art_data)
+    vmmc    = sti.VMMC(coverage=vmmc_data)
 
-    # Create modules (user overrides take precedence over calibrated defaults)
-    hiv = sti.HIV(init_prev_data=init_prev, **sc.mergedicts(sti_pars, hiv_overrides))
-    network = sti.StructuredSexual(condom_data=condom_data, **sc.mergedicts(nw_pars, nw_overrides))
-    art = sti.ART(coverage=art_data)
-    vmmc = sti.VMMC(coverage=vmmc_data)
-
-    # Combine interventions: testing + ART/VMMC + any user additions
-    intvs = make_interventions() + [art, vmmc]
+    intvs      = make_interventions() + [art, vmmc]
     user_intvs = sc.tolist(kwargs.pop('interventions', []))
+    sim_pars   = sc.mergedicts(default_sim_pars, kwargs.pop('sim_pars', None))
 
-    # Merge user sim_pars with defaults (user overrides take precedence)
-    user_sim_pars = kwargs.pop('sim_pars', {})
-    merged_sim_pars = sc.mergedicts(sim_pars, user_sim_pars)
-
-    sim = sti.Sim(
+    return sti.Sim(
         demographics='zimbabwe',
         datafolder=datadir,
         diseases=[hiv],
         networks=[network, ss.MaternalNet(), ss.BreastfeedingNet()],
         interventions=intvs + user_intvs,
-        sim_pars=merged_sim_pars,
+        sim_pars=sim_pars,
         data=hiv_data,
         **kwargs,
     )
-    return sim

--- a/stisim/parameters.py
+++ b/stisim/parameters.py
@@ -6,7 +6,8 @@ import starsim as ss
 import stisim as sti
 
 
-__all__ = ['SimPars', 'sti_aliases', 'sti_register', 'merged_sti_pars', 'make_sti', 'mergepars', 'dem_pars']
+__all__ = ['SimPars', 'sti_aliases', 'sti_register', 'merged_sti_pars', 'make_sti', 'mergepars',
+           'dem_pars', 'connector_register', 'merged_connector_pars']
 
 
 class SimPars(ss.SimPars):
@@ -130,6 +131,28 @@ def mergepars(*args):
     dicts = [dict(sc.dcp(arg)) for arg in args if arg is not None]
     merged_pars = sc.objdict(sc.mergedicts(*dicts))
     return merged_pars
+
+
+def connector_register():
+    """Auto-discoverable connectors keyed by ``<d1>_<d2>``. Only includes
+    connectors that follow the ``(disease1_module, disease2_module, ...)`` constructor
+    convention, so ``sti.Sim`` can build them automatically from a disease list."""
+    from stisim.connectors.hiv_sti import hiv_syph, hiv_tv, hiv_ng, hiv_ct, hiv_bv
+    return sc.objdict(
+        hiv_syph=hiv_syph,
+        hiv_tv=hiv_tv,
+        hiv_ng=hiv_ng,
+        hiv_ct=hiv_ct,
+        hiv_bv=hiv_bv,
+    )
+
+
+def merged_connector_pars():
+    """Merge all parameters from auto-discoverable connectors."""
+    merged = {}
+    for cls in connector_register().values():
+        merged.update(cls(None, None).pars)
+    return merged
 
 
 # Demographic pars

--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -143,6 +143,7 @@ class Sim(ss.Sim):
         self._user_sti_pars = {**routed.sti, **nested_sti}
         self._user_nw_pars  = dict(routed.nw)
         self._user_dem_pars = dict(routed.dem)
+        self._user_connector_pars = dict(routed.connector)
 
         return routed.sim
 
@@ -382,36 +383,39 @@ class Sim(ss.Sim):
         Auto-add coinfection connectors for disease pairs that have a registered
         ``sti.<d1>_<d2>`` class (e.g. ``hiv_syph``, ``hiv_ng``). Skipped if the
         user already supplied any connectors — pass your own list to take full
-        control.
+        control. Flat connector pars (e.g. ``rel_sus_hiv_syph=3.5``) are routed
+        to whichever auto-added connector accepts them.
         """
+        user_pars = self._user_connector_pars
+
         if len(self.pars['connectors']) > 0:
+            if user_pars:
+                raise ValueError(
+                    f'Got flat connector pars {sorted(user_pars)} but `connectors=` '
+                    f'was also supplied. Pass pars to the connector constructor directly.'
+                )
             return []
 
         connectors = []
+        consumed = set()
         diseases = [(m.name, m) for m in self.pars['diseases']]
         for (k1, m1), (k2, m2) in itertools.combinations(diseases, 2):
-            cls = getattr(sti, f'{k1}_{k2}', None)
-            if cls is not None:
-                connectors.append(cls(m1, m2))
+            if (cls := getattr(sti, f'{k1}_{k2}', None)) is not None:
+                args = (m1, m2)
+            elif (cls := getattr(sti, f'{k2}_{k1}', None)) is not None:
+                args = (m2, m1)  # reversed to match class name
+            else:
                 continue
-            cls = getattr(sti, f'{k2}_{k1}', None)
-            if cls is not None:
-                connectors.append(cls(m2, m1))  # reversed to match class name
+            accepted = set(cls(None, None).pars.keys())
+            kwargs = {k: v for k, v in user_pars.items() if k in accepted}
+            consumed.update(kwargs)
+            connectors.append(cls(*args, **kwargs))
+
+        if (unused := set(user_pars) - consumed):
+            raise ValueError(
+                f'Unused connector par(s): {sorted(unused)}. The matching '
+                f'connector(s) were not auto-added because the required disease '
+                f'pair is not in the sim.'
+            )
         return connectors
 
-    def case_insensitive_getattr(self, searchspace, attrname):
-        """
-        Find a class in the given package that matches the name, ignoring case.
-
-        Args:
-            searchspace (list): A list of classes or modules to search through.
-            attrname (str): The name of the attribute to find, case-insensitive.
-        """
-        if not isinstance(searchspace, list):
-            searchspace = [searchspace]
-
-        for classname in searchspace:
-            for attr in dir(classname):
-                if attr.lower() == attrname.lower():
-                    return getattr(classname, attr)
-        return None

--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -104,117 +104,46 @@ class Sim(ss.Sim):
         self.pars.update(updated_pars)
         return
     
-    def get_valid_pars(self):
-        """ Helper function to identify valid parameters """
-        vp = sc.objdict()
-        vp.sim_pars = self.pars # STIsim and Starsim Sim parameters
-        vp.all_sti_pars = sc.objdict(sti.merged_sti_pars())  # All STI parameters, ignoring duplicates
-        vp.default_nw_pars = sti.NetworkPars()
-        vp.default_dem_pars = sti.dem_pars()
-        
-        # Validation
-        all_pars = sorted([key for d in vp.values() for key in d.keys()])
-        duplicates = [key for key in all_pars if all_pars.count(key) > 1]
-        # if duplicates: # TODO: decide if we want to make this an error
-        #     errormsg = f'Duplicate parameters found: {duplicates}'
-        #     raise ValueError(errormsg)
-        return vp, duplicates
-
     def separate_pars(self, pars=None, sim_pars=None, sti_pars=None, nw_pars=None, dem_pars=None, sim_kwargs=None, **kwargs):
         """
-        Create a nested dict of parameters that get passed to Sim constructor and the component modules
-        Prioritization:
-            - If any key appears in both pars and *_pars, the value from *_pars will be used.
-            - If any key appears in both pars and kwargs, the value from kwargs will be used.
+        Sort all incoming pars into per-category dicts. Most of the work is
+        delegated to ``sti.route_pars``; this method handles sti.Sim-specific
+        bits: legacy renames, nested per-module dicts (``hiv=dict(...)``),
+        defaults, and stashing for the two-phase init.
         """
-        # Fail loudly on overlapping keys between `pars` and `**kwargs` — rather
-        # than silently taking one, force the caller to pick one.
-        if pars and kwargs:
-            overlap = set(pars) & set(kwargs)
-            if overlap:
-                detail = '; '.join(
-                    f'{k}: pars={pars[k]!r} kwargs={kwargs[k]!r}' for k in sorted(overlap)
-                )
-                raise ValueError(
-                    f'Keys appear in both `pars` and kwargs — specify each in exactly one place:\n  {detail}'
-                )
+        merged = self.remap_pars(sc.mergedicts(pars, sim_kwargs, kwargs))
 
-        # Merge in pars and kwargs
-        all_pars = sc.mergedicts(pars, sim_pars, sti_pars, nw_pars, dem_pars, sim_kwargs, kwargs)
-        all_pars = self.remap_pars(all_pars)  # Remap any parameter names
-        vp, duplicates = self.get_valid_pars()
+        # Pull out per-module nested dicts (e.g. hiv=dict(init_prev=0.05))
+        # before flat routing — these aren't valid par-names themselves, but
+        # their values contain sti pars scoped to a single disease module.
+        sti_keys = set(sti.merged_sti_pars())
+        nested_sti = {}
+        for k in list(merged):
+            v = merged[k]
+            if isinstance(v, dict) and any(gk in sti_keys for gk in v):
+                nested_sti[k] = merged.pop(k)
 
-        # Check if any parameter in all_pars is in duplicates. Duplicates are
-        # names that exist in multiple par categories (e.g. `dt` in both
-        # SimPars and STIPars). When the user passes such a key without
-        # disambiguating, we warn — the routing below will pick the first
-        # category that matches.
-        ambiguous = set(all_pars.keys()) & set(duplicates)
-        if ambiguous:
-            categories = {k: [cat for cat, d in vp.items() if k in d] for k in ambiguous}
-            detail = '; '.join(f'"{k}" appears in {cats}' for k, cats in categories.items())
-            warnmsg = (
-                f'Ambiguous parameter(s) found: {sorted(ambiguous)}. {detail}. '
-                f'To disambiguate, pass via the explicit category kwarg '
-                f'(e.g. sim_pars=dict(dt=...), sti_pars=dict(dt=...)).'
-            )
-            ss.warn(warnmsg)
+        routed = sti.route_pars(
+            merged,
+            sim_pars=sim_pars, sti_pars=sti_pars, nw_pars=nw_pars,
+            dem_pars=dem_pars,
+            strict=True, verbose=True,
+        )
 
-        # Deal with sim pars
-        if 'dur' in all_pars.keys():
+        if 'dur' in routed.sim:
             self.pars['stop'] = None
-        user_sim_pars = {k: v for k, v in all_pars.items() if k in vp.sim_pars}
-        for k in user_sim_pars: all_pars.pop(k)
-        sim_pars = sc.mergedicts(sim_pars, user_sim_pars, _copy=True)  # kwargs override sim_pars
 
-        # Deal with STI pars
-        user_sti_pars = {}
-        for k, v in all_pars.items():
-            if k in vp.all_sti_pars.keys(): user_sti_pars[k] = v  # Just set
-            if sc.checktype(v, dict):  # See whether it contains STI pars
-                user_sti_pars[k] = {gk: gv for gk, gv in v.items() if gk in vp.all_sti_pars}
-        for k in user_sti_pars: all_pars.pop(k)
-        sti_pars = sc.mergedicts(user_sti_pars, sti_pars, _copy=True)
+        self.sti_pars = sc.mergedicts(routed.sti, nested_sti, _copy=True)
+        self.nw_pars  = sc.mergedicts(sti.NetworkPars(), routed.nw, _copy=True)
+        self.dem_pars = sc.mergedicts(sti.dem_pars(), routed.dem, _copy=True)
 
-        # Deal with network pars
-        user_nw_pars = {k: v for k, v in all_pars.items() if k in vp.default_nw_pars.keys()}
-        for k in user_nw_pars: all_pars.pop(k)
-        nw_pars = sc.mergedicts(vp.default_nw_pars, user_nw_pars, nw_pars, _copy=True)
+        # Track user-supplied contributions (excluding defaults) so process_*
+        # methods can raise XOR errors when both a module and pars are given.
+        self._user_sti_pars = {**routed.sti, **nested_sti}
+        self._user_nw_pars  = dict(routed.nw)
+        self._user_dem_pars = dict(routed.dem)
 
-        # Deal with demographics parameters
-        user_dem_pars = {k: v for k, v in all_pars.items() if k in vp.default_dem_pars.keys()}
-        for k in user_dem_pars: all_pars.pop(k)
-        dem_pars = sc.mergedicts(vp.default_dem_pars, user_dem_pars, dem_pars, _copy=True)
-
-        # Raise an exception if there are any leftover pars
-        if all_pars:
-            par_options = []
-            errormsg = f'Unrecognized parameters: {all_pars.keys()}. Valid parameters are:\n'
-            for key,subdict in vp.items():
-                errormsg += f'\n  {key}: \n'
-                for subkey in sorted(subdict.keys()):
-                    errormsg += f'    {subkey}\n'
-                    par_options.append(subkey)
-            
-            for key in all_pars.keys():
-                suggest = sc.suggest(key, par_options)
-                errormsg += f'\nDid you mean "{suggest}" instead of "{key}"?'
-            
-            raise ValueError(errormsg)
-
-        # Store the parameters for the modules - thse will be fed into the modules during init
-        self.sti_pars = sti_pars    # Parameters for the STI modules
-        self.nw_pars = nw_pars      # Parameters for the networks
-        self.dem_pars = dem_pars
-
-        # Track just the user-provided contributions (separate from defaults)
-        # so process_* methods can raise XOR errors when the user supplies both
-        # a module instance and pars for the same slot.
-        self._user_sti_pars = dict(user_sti_pars)
-        self._user_nw_pars = dict(user_nw_pars)
-        self._user_dem_pars = dict(user_dem_pars)
-
-        return sim_pars
+        return routed.sim
 
     @staticmethod
     def remap_pars(pars):

--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -2,6 +2,7 @@
 User API for creating an STI simulation
 """
 
+import itertools
 import starsim as ss
 import stisim as sti
 import sciris as sc
@@ -378,43 +379,24 @@ class Sim(ss.Sim):
 
     def process_connectors(self):
         """
-        Get the default connectors for the diseases in the simulation.
-        Connectors are loaded based on the disease names or modules provided in the format <d1>_<d2>.
+        Auto-add coinfection connectors for disease pairs that have a registered
+        ``sti.<d1>_<d2>`` class (e.g. ``hiv_syph``, ``hiv_ng``). Skipped if the
+        user already supplied any connectors — pass your own list to take full
+        control.
         """
+        if len(self.pars['connectors']) > 0:
+            return []
+
         connectors = []
-        parsed_diseases = []
-        add_connectors = False
-
-        if isinstance(self.pars.connectors, bool) and self.pars.connectors:
-            errormsg = ('STIsim does not currently support automatically adding connectors. This feature'
-                        ' will be added in a future release. For the time being, please add connectors '
-                        'manually, e.g. by passing sti.hiv_syph(hiv, syphilis) to the sim.')
-            raise NotImplementedError(errormsg)
-
-            # TODO: The remaining code will be re-enabled once debugged
-        #     self.pars['connectors'] = ss.ndict()  # Reset
-        #     add_connectors = True
-        #
-        # if add_connectors:
-        #     for disease in self.pars['diseases']:
-        #         if isinstance(disease, str):
-        #             parsed_diseases.append(disease.lower())
-        #         if isinstance(disease, ss.Module):
-        #             parsed_diseases.append(disease.name.lower())
-        #
-        #     # sort the diseases and then get all combinations of their pairs
-        #     disease_pairs = combinations(parsed_diseases, 2)
-        #
-        #     # TODO: this does not quite work as intended because the ordering matters...
-        #     for (d1, d2) in disease_pairs:
-        #         try:
-        #             connector = getattr(sti, f'{d1}_{d2}')
-        #         except:
-        #             try:
-        #                 connector = getattr(sti, f'{d2}_{d1}')
-        #             except:
-        #                 continue
-        #         connectors.append(connector(d1, d2))
+        diseases = [(m.name, m) for m in self.pars['diseases']]
+        for (k1, m1), (k2, m2) in itertools.combinations(diseases, 2):
+            cls = getattr(sti, f'{k1}_{k2}', None)
+            if cls is not None:
+                connectors.append(cls(m1, m2))
+                continue
+            cls = getattr(sti, f'{k2}_{k1}', None)
+            if cls is not None:
+                connectors.append(cls(m2, m1))  # reversed to match class name
         return connectors
 
     def case_insensitive_getattr(self, searchspace, attrname):

--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -104,13 +104,20 @@ class Sim(ss.Sim):
         updated_pars = self.separate_pars(pars, sim_pars, sti_pars, nw_pars, dem_pars, sim_kwargs, **kwargs)
         self.pars.update(updated_pars)
         return
-    
-    def separate_pars(self, pars=None, sim_pars=None, sti_pars=None, nw_pars=None, dem_pars=None, sim_kwargs=None, **kwargs):
+
+    def separate_pars(self, pars=None, sim_pars=None, sti_pars=None, nw_pars=None, dem_pars=None,
+                      sim_kwargs=None, verbose=True, **kwargs):
         """
-        Sort all incoming pars into per-category dicts. Most of the work is
-        delegated to ``sti.route_pars``; this method handles sti.Sim-specific
-        bits: legacy renames, nested per-module dicts (``hiv=dict(...)``),
-        defaults, and stashing for the two-phase init.
+        Sort all incoming pars into per-category dicts (sim, sti, nw, dem,
+        connector). Most of the work is delegated to ``sti.route_pars``; this
+        method handles sti.Sim-specific bits: legacy renames, nested per-module
+        dicts (``hiv=dict(...)``), defaults, and stashing user-supplied pars
+        (``_user_sti_pars``, ``_user_nw_pars``, ``_user_dem_pars``,
+        ``_user_connector_pars``) for the two-phase init's XOR checks.
+
+        Args:
+            verbose (bool): If True, ``route_pars`` prints one line per
+                cross-category broadcast. See ``sti.route_pars`` for design.
         """
         merged = self.remap_pars(sc.mergedicts(pars, sim_kwargs, kwargs))
 
@@ -128,7 +135,7 @@ class Sim(ss.Sim):
             merged,
             sim_pars=sim_pars, sti_pars=sti_pars, nw_pars=nw_pars,
             dem_pars=dem_pars,
-            strict=True, verbose=True,
+            strict=True, verbose=verbose,
         )
 
         if 'dur' in routed.sim:
@@ -383,8 +390,16 @@ class Sim(ss.Sim):
         Auto-add coinfection connectors for disease pairs that have a registered
         ``sti.<d1>_<d2>`` class (e.g. ``hiv_syph``, ``hiv_ng``). Skipped if the
         user already supplied any connectors — pass your own list to take full
-        control. Flat connector pars (e.g. ``rel_sus_hiv_syph=3.5``) are routed
-        to whichever auto-added connector accepts them.
+        control. Connector module pars (e.g. ``rel_sus_hiv_syph=3.5``) passed
+        as kwargs to ``sti.Sim`` are routed to whichever auto-added connector
+        accepts them.
+
+        Auto-routing of kwargs only resolves against the default connector
+        classes (``sti.merged_connector_pars``). Custom connectors supplied via
+        ``connectors=[...]`` are not introspected — pass their pars to the
+        constructor directly: ``connectors=[MyConn(rel_sus_hiv_syph=3.5)]``.
+        Mixing ``connectors=[...]`` with kwargs that match default-connector
+        pars raises rather than silently dropping them.
         """
         user_pars = self._user_connector_pars
 

--- a/stisim/utils.py
+++ b/stisim/utils.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 import starsim as ss
 
-__all__ = ['count', 'div', 'countdiv', 'cond_prob', 'TimeSeries']
+__all__ = ['count', 'div', 'countdiv', 'cond_prob', 'route_pars', 'TimeSeries']
 
 
 
@@ -14,6 +14,77 @@ def count(arr): return np.count_nonzero(arr)
 def div(a, b): return sc.safedivide(a, b)
 def countdiv(a, b): return sc.safedivide(count(a), count(b))
 def cond_prob(a, b): return sc.safedivide(count(a & b), count(b))
+
+
+def _par_registry():
+    """Registry of category -> set of valid par-names. Built lazily to avoid
+    circular imports at module load time."""
+    import stisim as sti
+    return {
+        'sim': set(sti.SimPars()),
+        'sti': set(sti.merged_sti_pars()),
+        'nw':  set(sti.NetworkPars()),
+        'dem': set(sti.dem_pars()),
+    }
+
+
+def route_pars(pars=None, sim_pars=None, sti_pars=None, nw_pars=None,
+               dem_pars=None, *, strict=False, verbose=True, **kwargs):
+    """
+    Sort mixed user-supplied pars into categories (sim, sti, nw, dem).
+
+    Flat keys (from ``pars`` and ``**kwargs``) are matched against an internal
+    registry of per-category par-classes. A key valid in N categories is
+    broadcast to all N (with a printed note if ``verbose``). Pre-categorized
+    dicts (``sim_pars``, ``sti_pars``, ``nw_pars``, ``dem_pars``) are merged
+    into their bucket as-is.
+
+    Args:
+        pars (dict): Flat pars to route by registry lookup.
+        sim_pars, sti_pars, nw_pars, dem_pars (dict): Pre-categorized pars.
+        strict (bool): If True, raise on flat-pars keys that match no
+            category. If False, unmatched keys appear in ``routed.unmatched``.
+        verbose (bool): If True, print one line per cross-category broadcast.
+        **kwargs: Same routing as ``pars``.
+
+    Returns:
+        sc.objdict with keys ``sim``, ``sti``, ``nw``, ``dem``, ``unmatched``.
+        Each value is a dict.
+    """
+    routed = sc.objdict(
+        sim=sc.dcp(dict(sim_pars or {})),
+        sti=sc.dcp(dict(sti_pars or {})),
+        nw=sc.dcp(dict(nw_pars or {})),
+        dem=sc.dcp(dict(dem_pars or {})),
+        unmatched={},
+    )
+
+    flat = sc.mergedicts(pars, kwargs)
+    if not flat:
+        return routed
+
+    registry = _par_registry()
+    for k, v in flat.items():
+        matches = [cat for cat, valid in registry.items() if k in valid]
+        if not matches:
+            routed.unmatched[k] = sc.dcp(v)
+            continue
+        if len(matches) > 1 and verbose:
+            print(f"route_pars: {k!r} broadcast to {matches}")
+        for cat in matches:
+            routed[cat][k] = sc.dcp(v)
+
+    if strict and routed.unmatched:
+        valid = sorted({k for keys in registry.values() for k in keys})
+        suggestions = '\n'.join(
+            f'  {k!r}: did you mean {sc.suggest(k, valid)!r}?'
+            for k in routed.unmatched
+        )
+        raise ValueError(
+            f'Unrecognized parameter(s): {sorted(routed.unmatched)}\n{suggestions}'
+        )
+
+    return routed
 
 
 

--- a/stisim/utils.py
+++ b/stisim/utils.py
@@ -21,10 +21,11 @@ def _par_registry():
     circular imports at module load time."""
     import stisim as sti
     return {
-        'sim': set(sti.SimPars()),
-        'sti': set(sti.merged_sti_pars()),
-        'nw':  set(sti.NetworkPars()),
-        'dem': set(sti.dem_pars()),
+        'sim':       set(sti.SimPars()),
+        'sti':       set(sti.merged_sti_pars()),
+        'nw':        set(sti.NetworkPars()),
+        'dem':       set(sti.dem_pars()),
+        'connector': set(sti.merged_connector_pars()),
     }
 
 
@@ -56,6 +57,7 @@ def route_pars(pars=None, sim_pars=None, sti_pars=None, nw_pars=None,
         sti=sc.dcp(dict(sti_pars or {})),
         nw=sc.dcp(dict(nw_pars or {})),
         dem=sc.dcp(dict(dem_pars or {})),
+        connector={},
         unmatched={},
     )
 

--- a/stisim/utils.py
+++ b/stisim/utils.py
@@ -18,7 +18,13 @@ def cond_prob(a, b): return sc.safedivide(count(a & b), count(b))
 
 def _par_registry():
     """Registry of category -> set of valid par-names. Built lazily to avoid
-    circular imports at module load time."""
+    circular imports at module load time.
+
+    The registry is built from the default out-of-the-box module classes only.
+    User-supplied modules (custom connectors, networks, etc.) are not
+    introspected — pars for those should be passed to the module constructor
+    directly. See ``sti.Sim.process_connectors`` for the connector case.
+    """
     import stisim as sti
     return {
         'sim':       set(sti.SimPars()),
@@ -30,34 +36,57 @@ def _par_registry():
 
 
 def route_pars(pars=None, sim_pars=None, sti_pars=None, nw_pars=None,
-               dem_pars=None, *, strict=False, verbose=True, **kwargs):
+               dem_pars=None, connector_pars=None, *, strict=False, verbose=True, **kwargs):
     """
-    Sort mixed user-supplied pars into categories (sim, sti, nw, dem).
+    Sort mixed user-supplied pars into categories (sim, sti, nw, dem, connector).
 
     Flat keys (from ``pars`` and ``**kwargs``) are matched against an internal
     registry of per-category par-classes. A key valid in N categories is
     broadcast to all N (with a printed note if ``verbose``). Pre-categorized
-    dicts (``sim_pars``, ``sti_pars``, ``nw_pars``, ``dem_pars``) are merged
-    into their bucket as-is.
+    dicts (``sim_pars``, ``sti_pars``, ``nw_pars``, ``dem_pars``,
+    ``connector_pars``) are merged into their bucket as-is.
+
+    Design — when does broadcasting happen?
+
+    STIsim's par-name registry (``stisim/parameters.py``) is intentionally
+    designed so that names *do not collide across categories* — except in two
+    deliberate cases where broadcasting is the desired behavior:
+
+    1. **Universal pars** (e.g. ``dt``). Every module has these, and Starsim
+       already broadcasts them: ``sti.Sim(dt=ss.years(0.5))`` sets ``dt`` on
+       every module. This isn't STIsim doing anything new.
+
+    2. **Multi-disease shared pars** (e.g. ``beta_m2f``, ``init_prev``).
+       Several STI disease modules register the same par name on purpose.
+       ``sti.Sim(diseases=['hiv','syph'], beta_m2f=0.04)`` sets ``beta_m2f``
+       on both — that's the convenience the registry is built for. Override
+       per-disease via ``sti_pars=dict(hiv=dict(beta_m2f=...), syph=...)``
+       or by passing instances: ``diseases=[sti.HIV(beta_m2f=...), ...]``.
+
+    Custom modules supplied by the user can introduce *unintended* name
+    clashes with the built-in registry. In that case ``route_pars`` prints a
+    one-line note (``verbose=True``) listing the categories the key landed
+    in. This is allowed, not an error — the print is the documentation.
 
     Args:
         pars (dict): Flat pars to route by registry lookup.
-        sim_pars, sti_pars, nw_pars, dem_pars (dict): Pre-categorized pars.
+        sim_pars, sti_pars, nw_pars, dem_pars, connector_pars (dict):
+            Pre-categorized pars; merged into their bucket as-is.
         strict (bool): If True, raise on flat-pars keys that match no
             category. If False, unmatched keys appear in ``routed.unmatched``.
         verbose (bool): If True, print one line per cross-category broadcast.
         **kwargs: Same routing as ``pars``.
 
     Returns:
-        sc.objdict with keys ``sim``, ``sti``, ``nw``, ``dem``, ``unmatched``.
-        Each value is a dict.
+        sc.objdict with keys ``sim``, ``sti``, ``nw``, ``dem``, ``connector``,
+        ``unmatched``. Each value is a dict.
     """
     routed = sc.objdict(
         sim=sc.dcp(dict(sim_pars or {})),
         sti=sc.dcp(dict(sti_pars or {})),
         nw=sc.dcp(dict(nw_pars or {})),
         dem=sc.dcp(dict(dem_pars or {})),
-        connector={},
+        connector=sc.dcp(dict(connector_pars or {})),
         unmatched={},
     )
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,62 @@
+"""
+Minimal unit tests for sti.route_pars — flat-kwarg routing into per-category
+buckets (sim, sti, nw, dem, connector).
+"""
+import pytest
+import stisim as sti
+
+
+def test_basic_routing():
+    """Flat kwargs route to the correct categories."""
+    routed = sti.route_pars(start=2010, debut_f=18, init_prev=0.05, verbose=False)
+    assert routed.sim['start'] == 2010
+    assert routed.nw['debut_f'] == 18
+    assert routed.sti['init_prev'] == 0.05
+    return routed
+
+
+def test_broadcast():
+    """A key valid in 2+ categories is broadcast to all of them (e.g. dt)."""
+    routed = sti.route_pars(dt=0.5, verbose=False)
+    assert routed.sim['dt'] == 0.5
+    assert routed.sti['dt'] == 0.5
+    assert routed.connector['dt'] == 0.5
+    return routed
+
+
+def test_strict_raises_on_unknown():
+    """strict=True raises on unknown pars; non-strict stashes them."""
+    with pytest.raises(ValueError):
+        sti.route_pars(asdf=1, strict=True, verbose=False)
+    routed = sti.route_pars(asdf=1, strict=False, verbose=False)
+    assert routed.unmatched == {'asdf': 1}
+    return routed
+
+
+def test_pre_categorized():
+    """Pre-categorized dicts merge into their bucket (incl. connector_pars)."""
+    routed = sti.route_pars(
+        sim_pars=dict(start=2010),
+        nw_pars=dict(debut_f=18),
+        connector_pars=dict(rel_sus_hiv_syph=3.5),
+        verbose=False,
+    )
+    assert routed.sim['start'] == 2010
+    assert routed.nw['debut_f'] == 18
+    assert routed.connector['rel_sus_hiv_syph'] == 3.5
+    return routed
+
+
+def test_connector_bucket():
+    """Flat connector pars route into the connector bucket."""
+    routed = sti.route_pars(rel_sus_hiv_syph=3.5, verbose=False)
+    assert routed.connector['rel_sus_hiv_syph'] == 3.5
+    return routed
+
+
+if __name__ == '__main__':
+    test_basic_routing()
+    test_broadcast()
+    test_strict_raises_on_unknown()
+    test_pre_categorized()
+    test_connector_bucket()


### PR DESCRIPTION
- New `sti.route_pars` utility (in `stisim/utils.py`) that auto-discovers par categories (sim, sti, nw, dem) from the par-class registry and routes flat kwargs accordingly. Cross-category clashes (e.g. `dt` valid in both sim and sti) broadcast to all matches with a printed note; unknown keys (typos) raise when `strict=True`.
- `sti.Sim.separate_pars` shrinks from ~95 to ~30 lines by delegating routing to `route_pars`. Keeps only sti.Sim-specific concerns: legacy renames (`beta` → `beta_m2f`), nested per-module dicts (`hiv=dict(...)`), defaults, and the `_user_*_pars` stash for downstream XOR checks. Drops the `pars`-vs-`kwargs` collision raise (last-wins now) and the redundant `get_valid_pars` helper.
- hivsim demo builders (`simple`, `zimbabwe`) call `route_pars` to consume network pars from kwargs before constructing modules. Flat-kwargs API restored: `hivsim.demo('simple', debut_f=18)` and `hivsim.demo('zimbabwe', beta_m2f=0.04, prop_f0=0.7)` now work.
- `docs/examples/dynamic_debut.qmd` reverted to the flat-kwargs form the prose advertises.

Closes #451.
