### PR TITLE
Auto-add coinfection connectors; route flat connector pars (#442)

### DIFF
--- a/stisim/parameters.py
+++ b/stisim/parameters.py
@@ -6,7 +6,8 @@ import starsim as ss
 import stisim as sti
 
 
-__all__ = ['SimPars', 'sti_aliases', 'sti_register', 'merged_sti_pars', 'make_sti', 'mergepars', 'dem_pars']
+__all__ = ['SimPars', 'sti_aliases', 'sti_register', 'merged_sti_pars', 'make_sti', 'mergepars',
+           'dem_pars', 'connector_register', 'merged_connector_pars']
 
 
 class SimPars(ss.SimPars):
@@ -130,6 +131,28 @@ def mergepars(*args):
     dicts = [dict(sc.dcp(arg)) for arg in args if arg is not None]
     merged_pars = sc.objdict(sc.mergedicts(*dicts))
     return merged_pars
+
+
+def connector_register():
+    """Auto-discoverable connectors keyed by ``<d1>_<d2>``. Only includes
+    connectors that follow the ``(disease1_module, disease2_module, ...)`` constructor
+    convention, so ``sti.Sim`` can build them automatically from a disease list."""
+    from stisim.connectors.hiv_sti import hiv_syph, hiv_tv, hiv_ng, hiv_ct, hiv_bv
+    return sc.objdict(
+        hiv_syph=hiv_syph,
+        hiv_tv=hiv_tv,
+        hiv_ng=hiv_ng,
+        hiv_ct=hiv_ct,
+        hiv_bv=hiv_bv,
+    )
+
+
+def merged_connector_pars():
+    """Merge all parameters from auto-discoverable connectors."""
+    merged = {}
+    for cls in connector_register().values():
+        merged.update(cls(None, None).pars)
+    return merged
 
 
 # Demographic pars

--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -143,6 +143,7 @@ class Sim(ss.Sim):
         self._user_sti_pars = {**routed.sti, **nested_sti}
         self._user_nw_pars  = dict(routed.nw)
         self._user_dem_pars = dict(routed.dem)
+        self._user_connector_pars = dict(routed.connector)
 
         return routed.sim
 
@@ -382,36 +383,39 @@ class Sim(ss.Sim):
         Auto-add coinfection connectors for disease pairs that have a registered
         ``sti.<d1>_<d2>`` class (e.g. ``hiv_syph``, ``hiv_ng``). Skipped if the
         user already supplied any connectors — pass your own list to take full
-        control.
+        control. Flat connector pars (e.g. ``rel_sus_hiv_syph=3.5``) are routed
+        to whichever auto-added connector accepts them.
         """
+        user_pars = self._user_connector_pars
+
         if len(self.pars['connectors']) > 0:
+            if user_pars:
+                raise ValueError(
+                    f'Got flat connector pars {sorted(user_pars)} but `connectors=` '
+                    f'was also supplied. Pass pars to the connector constructor directly.'
+                )
             return []
 
         connectors = []
+        consumed = set()
         diseases = [(m.name, m) for m in self.pars['diseases']]
         for (k1, m1), (k2, m2) in itertools.combinations(diseases, 2):
-            cls = getattr(sti, f'{k1}_{k2}', None)
-            if cls is not None:
-                connectors.append(cls(m1, m2))
+            if (cls := getattr(sti, f'{k1}_{k2}', None)) is not None:
+                args = (m1, m2)
+            elif (cls := getattr(sti, f'{k2}_{k1}', None)) is not None:
+                args = (m2, m1)  # reversed to match class name
+            else:
                 continue
-            cls = getattr(sti, f'{k2}_{k1}', None)
-            if cls is not None:
-                connectors.append(cls(m2, m1))  # reversed to match class name
+            accepted = set(cls(None, None).pars.keys())
+            kwargs = {k: v for k, v in user_pars.items() if k in accepted}
+            consumed.update(kwargs)
+            connectors.append(cls(*args, **kwargs))
+
+        if (unused := set(user_pars) - consumed):
+            raise ValueError(
+                f'Unused connector par(s): {sorted(unused)}. The matching '
+                f'connector(s) were not auto-added because the required disease '
+                f'pair is not in the sim.'
+            )
         return connectors
 
-    def case_insensitive_getattr(self, searchspace, attrname):
-        """
-        Find a class in the given package that matches the name, ignoring case.
-
-        Args:
-            searchspace (list): A list of classes or modules to search through.
-            attrname (str): The name of the attribute to find, case-insensitive.
-        """
-        if not isinstance(searchspace, list):
-            searchspace = [searchspace]
-
-        for classname in searchspace:
-            for attr in dir(classname):
-                if attr.lower() == attrname.lower():
-                    return getattr(classname, attr)
-        return None

--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -2,6 +2,7 @@
 User API for creating an STI simulation
 """
 
+import itertools
 import starsim as ss
 import stisim as sti
 import sciris as sc
@@ -378,43 +379,24 @@ class Sim(ss.Sim):
 
     def process_connectors(self):
         """
-        Get the default connectors for the diseases in the simulation.
-        Connectors are loaded based on the disease names or modules provided in the format <d1>_<d2>.
+        Auto-add coinfection connectors for disease pairs that have a registered
+        ``sti.<d1>_<d2>`` class (e.g. ``hiv_syph``, ``hiv_ng``). Skipped if the
+        user already supplied any connectors — pass your own list to take full
+        control.
         """
+        if len(self.pars['connectors']) > 0:
+            return []
+
         connectors = []
-        parsed_diseases = []
-        add_connectors = False
-
-        if isinstance(self.pars.connectors, bool) and self.pars.connectors:
-            errormsg = ('STIsim does not currently support automatically adding connectors. This feature'
-                        ' will be added in a future release. For the time being, please add connectors '
-                        'manually, e.g. by passing sti.hiv_syph(hiv, syphilis) to the sim.')
-            raise NotImplementedError(errormsg)
-
-            # TODO: The remaining code will be re-enabled once debugged
-        #     self.pars['connectors'] = ss.ndict()  # Reset
-        #     add_connectors = True
-        #
-        # if add_connectors:
-        #     for disease in self.pars['diseases']:
-        #         if isinstance(disease, str):
-        #             parsed_diseases.append(disease.lower())
-        #         if isinstance(disease, ss.Module):
-        #             parsed_diseases.append(disease.name.lower())
-        #
-        #     # sort the diseases and then get all combinations of their pairs
-        #     disease_pairs = combinations(parsed_diseases, 2)
-        #
-        #     # TODO: this does not quite work as intended because the ordering matters...
-        #     for (d1, d2) in disease_pairs:
-        #         try:
-        #             connector = getattr(sti, f'{d1}_{d2}')
-        #         except:
-        #             try:
-        #                 connector = getattr(sti, f'{d2}_{d1}')
-        #             except:
-        #                 continue
-        #         connectors.append(connector(d1, d2))
+        diseases = [(m.name, m) for m in self.pars['diseases']]
+        for (k1, m1), (k2, m2) in itertools.combinations(diseases, 2):
+            cls = getattr(sti, f'{k1}_{k2}', None)
+            if cls is not None:
+                connectors.append(cls(m1, m2))
+                continue
+            cls = getattr(sti, f'{k2}_{k1}', None)
+            if cls is not None:
+                connectors.append(cls(m2, m1))  # reversed to match class name
         return connectors
 
     def case_insensitive_getattr(self, searchspace, attrname):

--- a/stisim/utils.py
+++ b/stisim/utils.py
@@ -21,10 +21,11 @@ def _par_registry():
     circular imports at module load time."""
     import stisim as sti
     return {
-        'sim': set(sti.SimPars()),
-        'sti': set(sti.merged_sti_pars()),
-        'nw':  set(sti.NetworkPars()),
-        'dem': set(sti.dem_pars()),
+        'sim':       set(sti.SimPars()),
+        'sti':       set(sti.merged_sti_pars()),
+        'nw':        set(sti.NetworkPars()),
+        'dem':       set(sti.dem_pars()),
+        'connector': set(sti.merged_connector_pars()),
     }
 
 
@@ -56,6 +57,7 @@ def route_pars(pars=None, sim_pars=None, sti_pars=None, nw_pars=None,
         sti=sc.dcp(dict(sti_pars or {})),
         nw=sc.dcp(dict(nw_pars or {})),
         dem=sc.dcp(dict(dem_pars or {})),
+        connector={},
         unmatched={},
     )
 


### PR DESCRIPTION
**Auto-add connectors.** `sti.Sim(diseases=['hiv', 'syph'])` now auto-instantiates `sti.hiv_syph` (and any other registered `<d1>_<d2>` connector for the disease pairs in the sim). Lookup tries `sti.<d1>_<d2>` then `sti.<d2>_<d1>` (reversing the constructor arg order to match). Pairs with no registered class are silently skipped. Replaces the `NotImplementedError`-on-`connectors=True` stub.

**Flat connector pars.** `sti.Sim(diseases=['hiv','syph'], rel_sus_hiv_syph=3.5)` routes the par into the auto-added `hiv_syph` connector. Each auto-added connector receives only the kwargs it accepts. Pars that match no built connector raise (catches typos and config errors like passing `rel_sus_hiv_syph` without syph in the disease list).

Skipped if the user supplies their own connectors via `connectors=[...]` — pass an explicit list to take full control. Mixing flat connector pars with `connectors=[...]` raises rather than silently dropping the flat pars.

**Cleanup.** Removes `sti.Sim.case_insensitive_getattr` — no callers across stisim, hivsim, or any localization repo.

Closes #442.
