### PR TITLE
Fix ART stratified coverage to allocate per-(age,sex) stratum

### DIFF
--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -7,7 +7,7 @@ import starsim as ss
 import numpy as np
 from stisim.interventions.base_interventions import STITest
 from stisim.interventions.utils import (
-    parse_coverage, compute_coverage_target,
+    parse_coverage, compute_coverage_target, compute_stratum_targets, age_sex_mask,
 )
 from stisim.utils import count
 
@@ -252,23 +252,41 @@ class ART(ss.Intervention):
         return
 
     def _get_n_to_treat(self, eligible_uids):
-        """Get the target number of people on ART this timestep."""
-        return compute_coverage_target(
+        """
+        Get the target number of people on ART this timestep.
+
+        Returns ``(total, stratum_targets)`` where:
+            - ``total`` is the aggregate target (or ``None`` if no coverage)
+            - ``stratum_targets`` is a dict ``{(age_bin, sex): n}`` for
+              stratified coverage, else ``None``.
+
+        When ``stratum_targets`` is not ``None``, callers should correct
+        coverage *within each stratum* rather than against the aggregate
+        total — otherwise allocation by global CD4 priority will wash out
+        the age/sex differentials in the input data.
+        """
+        total = compute_coverage_target(
             self.coverage, self.coverage_format, self.age_bins, self.sex_keys,
             self.ti, eligible_uids, self.sim,
         )
+        stratum_targets = compute_stratum_targets(
+            self.coverage, self.coverage_format, self.age_bins, self.sex_keys,
+            self.ti, eligible_uids, self.sim,
+        )
+        return total, stratum_targets
 
     def step(self):
         """
         Apply ART at each timestep: stop ART for those scheduled, initiate for newly diagnosed,
-        and correct overall coverage to match targets.
+        and correct coverage to match targets (per-stratum when stratified data is supplied,
+        otherwise against the aggregate total).
         """
         sim = self.sim
         hiv = sim.diseases.hiv
         inf_uids = hiv.infected.uids
 
         # Determine treatment target (None = no capacity constraint)
-        n_to_treat = self._get_n_to_treat(inf_uids)
+        n_to_treat, stratum_targets = self._get_n_to_treat(inf_uids)
 
         # Check who is stopping ART
         if hiv.on_art.any():
@@ -295,9 +313,11 @@ class ART(ss.Intervention):
                 if n_available_spots > 0:
                     self.prioritize_art(sim, n=n_available_spots, awaiting_art_uids=dx_to_treat)
 
-        # Correct coverage to match target (only if target is set)
+        # Correct coverage to match target (only if target is set).
+        # Stratified targets get per-stratum correction; aggregate gets global.
         if n_to_treat is not None:
-            self.art_coverage_correction(sim, target_coverage=n_to_treat)
+            self.art_coverage_correction(sim, target_coverage=n_to_treat,
+                                         stratum_targets=stratum_targets)
 
         # PMTCT: reduce susceptibility of infants whose mothers are on ART.
         # This applies to both prenatal (MaternalNet) and postnatal (BreastfeedingNet)
@@ -347,8 +367,23 @@ class ART(ss.Intervention):
 
         return
 
-    def art_coverage_correction(self, sim, target_coverage=None):
-        """ Adjust ART coverage to match data """
+    def art_coverage_correction(self, sim, target_coverage=None, stratum_targets=None):
+        """
+        Adjust ART coverage to match data.
+
+        If ``stratum_targets`` is supplied, correction is done independently
+        within each ``(age_bin, sex)`` stratum so that age/sex differentials
+        in the input data are preserved. Otherwise, correction is done
+        globally against ``target_coverage``.
+        """
+        if stratum_targets is not None:
+            self._art_coverage_correction_stratified(sim, stratum_targets)
+        else:
+            self._art_coverage_correction_global(sim, target_coverage)
+        return
+
+    def _art_coverage_correction_global(self, sim, target_coverage):
+        """ Adjust ART coverage globally to match an aggregate target """
         hiv = sim.diseases.hiv
         on_art = hiv.on_art
 
@@ -369,6 +404,50 @@ class ART(ss.Intervention):
             n_to_add = target_coverage - len(on_art.uids)
             awaiting_art_uids = (hiv.diagnosed & ~hiv.on_art).uids
             self.prioritize_art(sim, n=n_to_add, awaiting_art_uids=awaiting_art_uids)
+
+        return
+
+    def _art_coverage_correction_stratified(self, sim, stratum_targets):
+        """
+        Adjust ART coverage independently within each (age_bin, sex) stratum.
+
+        This preserves the age/sex differentials in the stratified coverage
+        input — e.g. young men and older women each reach their own target
+        rather than being averaged out by a global CD4-priority allocation.
+        Within a stratum, removals still drop the highest-CD4 agents first
+        and additions still prioritize the lowest-CD4 agents (same priority
+        rule as the global path).
+        """
+        hiv = sim.diseases.hiv
+        ppl = sim.people
+
+        for key, target_n in stratum_targets.items():
+            # key is (age_bin, sex) when sex-stratified, else age_bin only
+            if isinstance(key, tuple):
+                ab, sex = key
+            else:
+                ab, sex = key, None
+
+            in_stratum = age_sex_mask(ab, sex, ppl) & ppl.alive & hiv.infected
+            on_art_in_stratum = (in_stratum & hiv.on_art).uids
+            n_on_art = len(on_art_in_stratum)
+
+            # Too many on treatment in this stratum → remove highest-CD4
+            if n_on_art > target_n:
+                n_to_stop    = n_on_art - target_n
+                cd4_counts   = hiv.cd4[on_art_in_stratum]
+                care_seeking = hiv.care_seeking[on_art_in_stratum]
+                weights      = cd4_counts / care_seeking
+                choices      = np.argsort(-weights)[:n_to_stop]
+                stop_uids    = on_art_in_stratum[choices]
+                hiv.ti_stop_art[stop_uids] = self.ti
+                hiv.stop_art(stop_uids)
+
+            # Not enough in this stratum → add from diagnosed in same stratum
+            elif n_on_art < target_n:
+                n_to_add = target_n - n_on_art
+                awaiting_art_uids = (in_stratum & hiv.diagnosed & ~hiv.on_art).uids
+                self.prioritize_art(sim, n=n_to_add, awaiting_art_uids=awaiting_art_uids)
 
         return
 

--- a/stisim/interventions/utils.py
+++ b/stisim/interventions/utils.py
@@ -436,3 +436,37 @@ def compute_coverage_target(coverage, coverage_format, age_bins, sex_keys,
     n_eligible = len(eligible_uids)
     return coverage_to_number(cov_val, fmt,
                               pop_scale=sim.pars.pop_scale, n_eligible=n_eligible)
+
+
+def compute_stratum_targets(coverage, coverage_format, age_bins, sex_keys,
+                            ti, eligible_uids, sim):
+    """
+    Compute per-(age_bin, sex) target counts for stratified coverage.
+
+    Returns a dict keyed by ``(age_bin, sex)`` (or ``age_bin`` if there is no
+    sex stratification) mapping to the integer target count for that stratum.
+    Returns ``None`` if coverage is absent or not stratified — in that case
+    callers should fall back to the aggregate target from
+    :func:`compute_coverage_target`.
+
+    The sum of the values matches the total returned by
+    :func:`compute_coverage_target` for the same inputs, but keeping the
+    per-stratum granularity lets callers allocate within each stratum
+    independently (preserving the age/sex differentials in the input data).
+    """
+    if coverage is None or not isinstance(coverage, dict):
+        return None
+
+    fmt = coverage_format[ti] if isinstance(coverage_format, np.ndarray) else coverage_format
+
+    targets = {}
+    for ab in age_bins:
+        for sex in (sex_keys or [None]):
+            key = (ab, sex) if sex is not None else ab
+            cov = coverage.get(key, np.zeros(1))
+            cov_val = cov[ti] if len(cov) > ti else cov[-1]
+
+            n = (age_sex_mask(ab, sex, sim.people) & eligible_uids).count()
+            targets[key] = coverage_to_number(cov_val, fmt,
+                                              pop_scale=sim.pars.pop_scale, n_eligible=n)
+    return targets

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -264,20 +264,24 @@ def test_art_stratified_coverage_matching(do_plot=do_plot):
     """ Check that age-stratified ART coverage approximately matches supplied targets """
     sc.heading('Testing stratified ART coverage matching...')
 
-    # Build stratified coverage data: higher coverage for older age groups and women
-    age_bins = [15, 25, 35, 45]
+    # Build stratified coverage data: higher coverage for older age groups and women.
+    # 4 strata (2 age bins × 2 sexes) keeps enough infected agents per stratum at
+    # n_agents=1k for the per-stratum assertion to be meaningful.
+    age_bins = [15, 30, 100]
     targets = {}
     rows = []
-    for year in [2005, 2015]:
+    # Use constant coverage across the sim window (start=2000, dur=5) — this avoids
+    # ramp-up artefacts and lets the assertion compare the final state directly to
+    # the target. Both years carry the same per-stratum target.
+    for year in [2000, 2005]:
         for gender in [0, 1]:
             for lo, hi in zip(age_bins[:-1], age_bins[1:]):
                 ab = f'[{lo},{hi})'
-                base_p = 0.3 if year == 2005 else 0.7
                 age_factor = 1 + (lo - 15) * 0.01  # Slightly higher for older
                 sex_factor = 1.1 if gender == 0 else 1.0  # Higher for women (0=female)
-                p = min(base_p * age_factor * sex_factor, 0.95)
+                p = min(0.7 * age_factor * sex_factor, 0.95)
                 rows.append(dict(Year=year, Gender=gender, AgeBin=ab, coverage=p))
-                if year == 2015:
+                if year == 2005:
                     targets[(ab, gender)] = p
 
     strat_df = pd.DataFrame(rows)
@@ -297,7 +301,7 @@ def test_art_stratified_coverage_matching(do_plot=do_plot):
 
     # Per-stratum coverage should approximately match the supplied targets — this is the
     # whole point of stratified input. Tolerance is generous to allow for finite-population
-    # noise (1k agents split across 6 strata) and for diagnosis lag (newly-eligible agents
+    # noise (1k agents split across 4 strata) and for diagnosis lag (newly-eligible agents
     # must first be diagnosed by HIVTest before ART can initiate them).
     tol = 0.20
     for (ab, gender), target_p in targets.items():

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -291,18 +291,25 @@ def test_art_stratified_coverage_matching(do_plot=do_plot):
 
     ac = sim.results.art_coverage
 
-    # Check aggregate coverage is nonzero (stratified data produces a global target)
+    # Check aggregate coverage is nonzero (stratified data also produces a meaningful total)
     final_p = np.mean(ac.p_art[-24:])
     assert final_p > 0.1, f'Expected meaningful aggregate ART coverage with stratified data, got {final_p:.2f}'
 
-    # Print per-stratum coverage for inspection (not asserted — current implementation
-    # computes a global target from stratified data, not per-stratum force-fitting)
+    # Per-stratum coverage should approximately match the supplied targets — this is the
+    # whole point of stratified input. Tolerance is generous to allow for finite-population
+    # noise (1k agents split across 6 strata) and for diagnosis lag (newly-eligible agents
+    # must first be diagnosed by HIVTest before ART can initiate them).
+    tol = 0.20
     for (ab, gender), target_p in targets.items():
         lo, hi = ss.parse_age_range(ab)
         sex = 'f' if gender == 0 else 'm'
         key = f'p_art_{sex}_{int(lo)}_{int(hi)}'
         measured_p = np.mean(ac[key][-24:])
         print(f'  {key}: target={target_p:.2f}, measured={measured_p:.2f}')
+        assert abs(measured_p - target_p) < tol, (
+            f'Stratum {key}: measured {measured_p:.2f} vs target {target_p:.2f} '
+            f'(tol {tol}). Stratified ART correction is not preserving per-stratum targets.'
+        )
 
     if do_plot:
         fig, axes = pl.subplots(1, 2, figsize=(14, 5))


### PR DESCRIPTION
Stratified ART coverage data was being parsed correctly but then collapsed to a single aggregate target before correction, with `art_coverage_correction` allocating ART globally by CD4 priority across the whole population. This washed out the age/sex differentials in the input: older/sicker agents were over-treated at the expense of younger groups, and male/female gaps were smoothed away. The model could not reproduce its own stratified inputs.

Changes:
- Add `compute_stratum_targets()` in `interventions/utils.py`: parallel to `compute_coverage_target` but returns the per-stratum dict instead of the summed total. Returns None for absent/aggregate coverage.
- `ART._get_n_to_treat` now returns `(total, stratum_targets)`.
- `ART.art_coverage_correction` dispatches: stratified targets get per-stratum correction; aggregate targets keep the existing global behaviour.
- New `_art_coverage_correction_stratified` adjusts each (age_bin, sex) stratum independently using the same CD4/care-seeking priority rules as the global path, applied within-stratum.
- Strengthen `test_art_stratified_coverage_matching` to assert per-stratum matching (previously only printed). Tolerance is generous to accommodate finite-population noise and the diagnosis lag from HIVTest.