### PR TITLE
Add dur_dx2tx on HIVTest for delay from diagnosis to ART start (#398)

### DIFF
--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -511,8 +511,7 @@ class HIV(BaseSTI):
         self.results['cum_deaths'][ti] = np.sum(self.results['new_deaths'][:ti + 1])
         self.results['new_diagnoses'][ti] = np.count_nonzero(self.ti_diagnosed == ti)
         self.results['cum_diagnoses'][ti] = np.sum(self.results['new_diagnoses'][:ti + 1])
-        # ti_art may also hold a scheduled future start; gate on on_art for actual starts
-        self.results['new_agents_on_art'][ti] = sum((self.ti_art == ti) & self.on_art)
+        self.results['new_agents_on_art'][ti] = sum((self.ti_art == ti) & self.on_art)  # gate on on_art; ti_art may also hold a scheduled future start
         if self.include_mtct:
             pregnant = self.sim.people.pregnancy.pregnant
             self.results['n_on_art_pregnant'][ti] = np.count_nonzero(self.on_art & pregnant)

--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -211,6 +211,8 @@ class HIV(BaseSTI):
         initial_cases_diagnosed = self.pars.init_diagnosed.filter(initial_cases)
         self.diagnosed[initial_cases_diagnosed] = True
         self.ti_diagnosed[initial_cases_diagnosed] = 0
+        # Schedule ART start at ti=0 (no delay) so an ART intervention picks them up immediately
+        self.ti_art[initial_cases_diagnosed] = 0
         return
 
     # CD4 functions
@@ -509,7 +511,8 @@ class HIV(BaseSTI):
         self.results['cum_deaths'][ti] = np.sum(self.results['new_deaths'][:ti + 1])
         self.results['new_diagnoses'][ti] = np.count_nonzero(self.ti_diagnosed == ti)
         self.results['cum_diagnoses'][ti] = np.sum(self.results['new_diagnoses'][:ti + 1])
-        self.results['new_agents_on_art'][ti] = np.count_nonzero(self.ti_art == ti)
+        # ti_art may also hold a scheduled future start; gate on on_art for actual starts
+        self.results['new_agents_on_art'][ti] = np.count_nonzero((self.ti_art == ti) & self.on_art)
         if self.include_mtct:
             pregnant = self.sim.people.pregnancy.pregnant
             self.results['n_on_art_pregnant'][ti] = np.count_nonzero(self.on_art & pregnant)

--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -512,7 +512,7 @@ class HIV(BaseSTI):
         self.results['new_diagnoses'][ti] = np.count_nonzero(self.ti_diagnosed == ti)
         self.results['cum_diagnoses'][ti] = np.sum(self.results['new_diagnoses'][:ti + 1])
         # ti_art may also hold a scheduled future start; gate on on_art for actual starts
-        self.results['new_agents_on_art'][ti] = np.count_nonzero((self.ti_art == ti) & self.on_art)
+        self.results['new_agents_on_art'][ti] = sum((self.ti_art == ti) & self.on_art)
         if self.include_mtct:
             pregnant = self.sim.people.pregnancy.pregnant
             self.results['n_on_art_pregnant'][ti] = np.count_nonzero(self.on_art & pregnant)

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -773,9 +773,12 @@ class ANCTest(ss.Intervention):
             self.results[f'n_{dname}_positive'][ti] += len(pos_uids)
 
             if dname == 'hiv':
-                # Set diagnosed flag so ART picks up automatically
+                # Set diagnosed flag and schedule ART start (no delay by default)
+                # so an ART intervention picks them up automatically
                 disease.diagnosed[pos_uids]    = True
                 disease.ti_diagnosed[pos_uids] = ti
+                to_schedule = pos_uids[~disease.on_art[pos_uids]]
+                disease.ti_art[to_schedule] = ti
             elif dname in self.disease_treatment_map:
                 tx = self.disease_treatment_map[dname]
                 tx.eligibility = tx.eligibility | pos_uids

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -55,16 +55,24 @@ class HIVTest(STITest):
         5. If coverage data is provided, ART corrects to match targets
 
     Args:
-        test_prob_data: annual testing probability (if dt_scale=True, the default).
+        product: diagnostic product (default: :class:`HIVDx`).
+        pars (dict): override default pars (``rel_test``, ``dt_scale``, ``dur_dx2tx``).
+        test_prob_data: annual testing probability (if ``dt_scale=True``, the default).
             A value of 0.1 means ~10% of eligible agents tested per year. To
-            specify a per-timestep probability instead, set dt_scale=False.
+            specify a per-timestep probability instead, set ``dt_scale=False``.
+        years (array): years over which testing is active (mutually exclusive with ``start``).
+        start (float): calendar year when testing begins.
         eligibility (func): who can be tested. Default: undiagnosed agents.
-        start (float): calendar year when testing begins
-        dt_scale (bool): if True (default), test_prob_data is an annual probability.
-            Set to False for per-timestep probability.
-        dur_dx2tx: delay from diagnosis to ART start, as a distribution
-            (default: ``ss.constant(0)``, no delay).
-            Example: ``ss.constant(ss.years(0.5))`` for a 6-month delay.
+        name, label: standard module identifiers.
+        newborn_test (:class:`InfantHIVTest`): if supplied, schedules an infant
+            HIV test at delivery for unborn children of mothers who test
+            positive (requires ``ss.MaternalNet`` and ``ss.Pregnancy`` in the sim).
+        dur_dx2tx (ss.Dist): delay from diagnosis to scheduled ART start
+            (default: ``ss.constant(0)``, no delay). May be passed directly
+            or via the ``pars`` dict. Example: ``ss.constant(ss.years(0.5))``
+            for a 6-month delay.
+        dt_scale (bool): if ``True`` (default), ``test_prob_data`` is an annual probability.
+            Set to ``False`` for per-timestep probability.
 
     Example::
 
@@ -93,7 +101,9 @@ class HIVTest(STITest):
     """
     def __init__(self, product=None, pars=None, test_prob_data=None, years=None, start=None,
                  eligibility=None, name=None, label=None, newborn_test=None, **kwargs):
-        if product is None: product = HIVDx(name=f'HIVDx_{name}')
+        if product is None:
+            suffix = f'_{name}' if name else ''
+            product = HIVDx(name=f'HIVDx{suffix}')
 
         # Super init
         super().__init__(product=product, test_prob_data=test_prob_data, years=years,

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -92,15 +92,25 @@ class HIVTest(STITest):
         )
     """
     def __init__(self, product=None, pars=None, test_prob_data=None, years=None, start=None,
-                 eligibility=None, name=None, label=None, newborn_test=None, dur_dx2tx=None, **kwargs):
+                 eligibility=None, name=None, label=None, newborn_test=None, **kwargs):
         if product is None: product = HIVDx(name=f'HIVDx_{name}')
-        super().__init__(product=product, pars=pars, test_prob_data=test_prob_data, years=years,
-                         start=start, eligibility=eligibility, name=name, label=label, **kwargs)
+
+        # Super init
+        super().__init__(product=product, test_prob_data=test_prob_data, years=years,
+                         start=start, eligibility=eligibility, name=name, label=label)
+
+        # Deal with eligibility - default is undiagnosed people
         if self.eligibility is None:
             self.eligibility = lambda sim: ~sim.diseases.hiv.diagnosed
+
+        # Newborn test
         self.newborn_test = newborn_test
-        # Per-pathway delay from diagnosis to scheduled ART start
-        self.dur_dx2tx = dur_dx2tx if dur_dx2tx is not None else ss.constant(0)
+        
+        # Deal with pars
+        self.define_pars(
+            dur_dx2tx=ss.constant(0),
+        )
+        self.update_pars(pars, **kwargs)
 
     def step(self, uids=None):
         sim = self.sim
@@ -112,7 +122,7 @@ class HIVTest(STITest):
         # Schedule ART start for those not already on ART
         to_schedule = pos_uids[~hiv.on_art[pos_uids]]
         if len(to_schedule):
-            delay = np.asarray(self.dur_dx2tx.rvs(to_schedule)).astype(int)
+            delay = self.pars.dur_dx2tx.rvs(to_schedule, round=True)
             hiv.ti_art[to_schedule] = self.ti + delay
 
         # Schedule infant HIV test for unborn children of newly diagnosed mothers

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -49,8 +49,9 @@ class HIVTest(STITest):
 
         1. HIVTest tests eligible agents each timestep (annual probability, converted via ss.probperyear)
         2. Positive results set hiv.diagnosed=True and hiv.ti_diagnosed
-        3. ART checks for newly diagnosed agents (ti_diagnosed == current ti)
-        4. Newly diagnosed agents initiate ART with probability art_initiation
+        3. HIVTest samples dur_dx2tx and sets hiv.ti_art = ti + delay (scheduled start)
+        4. ART picks up agents whose ti_art == current ti (and not yet on_art),
+           filters by art_initiation, and puts them on ART
         5. If coverage data is provided, ART corrects to match targets
 
     Args:
@@ -61,6 +62,9 @@ class HIVTest(STITest):
         start (float): calendar year when testing begins
         dt_scale (bool): if True (default), test_prob_data is an annual probability.
             Set to False for per-timestep probability.
+        dur_dx2tx: delay from diagnosis to ART start, as a distribution
+            (default: ``ss.constant(0)``, no delay).
+            Example: ``ss.constant(ss.years(0.5))`` for a 6-month delay.
 
     Example::
 
@@ -88,20 +92,28 @@ class HIVTest(STITest):
         )
     """
     def __init__(self, product=None, pars=None, test_prob_data=None, years=None, start=None,
-                 eligibility=None, name=None, label=None, newborn_test=None, **kwargs):
+                 eligibility=None, name=None, label=None, newborn_test=None, dur_dx2tx=None, **kwargs):
         if product is None: product = HIVDx(name=f'HIVDx_{name}')
         super().__init__(product=product, pars=pars, test_prob_data=test_prob_data, years=years,
                          start=start, eligibility=eligibility, name=name, label=label, **kwargs)
         if self.eligibility is None:
             self.eligibility = lambda sim: ~sim.diseases.hiv.diagnosed
         self.newborn_test = newborn_test
+        # Per-pathway delay from diagnosis to scheduled ART start
+        self.dur_dx2tx = dur_dx2tx if dur_dx2tx is not None else ss.constant(0)
 
     def step(self, uids=None):
         sim = self.sim
         outcomes = super().step(uids=uids)
         pos_uids = outcomes['positive']
-        sim.diseases.hiv.diagnosed[pos_uids] = True
-        sim.diseases.hiv.ti_diagnosed[pos_uids] = self.ti
+        hiv = sim.diseases.hiv
+        hiv.diagnosed[pos_uids] = True
+        hiv.ti_diagnosed[pos_uids] = self.ti
+        # Schedule ART start for those not already on ART
+        to_schedule = pos_uids[~hiv.on_art[pos_uids]]
+        if len(to_schedule):
+            delay = np.asarray(self.dur_dx2tx.rvs(to_schedule)).astype(int)
+            hiv.ti_art[to_schedule] = self.ti + delay
 
         # Schedule infant HIV test for unborn children of newly diagnosed mothers
         if self.newborn_test is not None and len(pos_uids):
@@ -154,14 +166,18 @@ class ART(ss.Intervention):
 
     Processing flow each timestep:
         1. Agents scheduled to stop ART are removed
-        2. Newly diagnosed agents (ti_diagnosed == this timestep) are filtered
-           by art_initiation probability
+        2. Agents whose scheduled ART start has arrived (ti_art == this timestep
+           and not on_art) are filtered by art_initiation probability
         3. If coverage is specified: agents are added/removed to match the target
            number, prioritized by CD4 count and care-seeking propensity
-        4. If no coverage is specified: all newly diagnosed who pass art_initiation
-           go directly on ART (no capacity constraint)
+        4. If no coverage is specified: all who pass art_initiation go on ART
+           (no capacity constraint)
         5. Mothers on ART reduce infant susceptibility (prenatal via MaternalNet,
            postnatal via BreastfeedingNet) by pmtct_efficacy
+
+    The scheduling (setting ti_art) is owned by the testing intervention that
+    diagnoses the agent (HIVTest, ANCTest). ART here is passive: it picks up
+    whoever is ready to start.
 
     Coverage is parsed by :func:`parse_coverage` and accepts:
         - ``None``: no coverage target; treat all who initiate (default)
@@ -280,10 +296,10 @@ class ART(ss.Intervention):
                     errormsg = f'Error stopping ART for {stopping.uids}'
                     raise ValueError(errormsg)
 
-        # Initiate ART for newly diagnosed
-        diagnosed = hiv.ti_diagnosed == self.ti
-        if len(diagnosed.uids):
-            dx_to_treat = self.pars.art_initiation.filter(diagnosed.uids)
+        # Initiate ART for agents whose scheduled start time has arrived
+        ready = ((hiv.ti_art == self.ti) & ~hiv.on_art).uids
+        if len(ready):
+            dx_to_treat = self.pars.art_initiation.filter(ready)
 
             if n_to_treat is None:
                 # No coverage target — treat all who initiate
@@ -329,7 +345,8 @@ class ART(ss.Intervention):
         """ Prioritize ART to n agents among those awaiting treatment """
         hiv = sim.diseases.hiv
         if awaiting_art_uids is None:
-            awaiting_art_uids = (hiv.diagnosed & ~hiv.on_art).uids
+            # Agents whose scheduled ART start has arrived but who aren't on ART yet
+            awaiting_art_uids = ((hiv.ti_art <= self.ti) & ~hiv.on_art).uids
 
         # Enough spots for everyone
         if n > len(awaiting_art_uids):
@@ -364,10 +381,10 @@ class ART(ss.Intervention):
             hiv.ti_stop_art[stop_uids] = self.ti
             hiv.stop_art(stop_uids)
 
-        # Not enough on treatment → add
+        # Not enough on treatment → add (only those whose scheduled start has arrived)
         elif len(on_art.uids) < target_coverage:
             n_to_add = target_coverage - len(on_art.uids)
-            awaiting_art_uids = (hiv.diagnosed & ~hiv.on_art).uids
+            awaiting_art_uids = ((hiv.ti_art <= self.ti) & ~hiv.on_art).uids
             self.prioritize_art(sim, n=n_to_add, awaiting_art_uids=awaiting_art_uids)
 
         return

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -449,6 +449,59 @@ def test_art_duration(do_plot=do_plot):
 
 
 @sc.timer()
+def test_art_dx2tx_delay(do_plot=do_plot):
+    """ Check dur_dx2tx on HIVTest enforces a delay between diagnosis and ART start """
+    sc.heading('Testing dur_dx2tx (diagnosis → treatment) delay...')
+
+    # Build two sims that only differ in the dx→tx delay
+    delay_years = 2
+    sim_kwargs = dict(n_agents=200, dur=delay_years + 2, start=1990, verbose=-1)
+    hiv_pars = dict(init_prev=1.0, dur_on_art=ss.constant(v=ss.years(10)))
+
+    def make_sim(delay):
+        return hivsim.demo(
+            'simple', plot=False,
+            demographics=[ss.Deaths(death_rate=0)],
+            interventions=[
+                sti.HIVTest(test_prob_data=1.0, dt_scale=False,
+                            dur_dx2tx=ss.constant(ss.years(delay))),
+                sti.ART(art_initiation=1.0),
+            ],
+            **hiv_pars, **sim_kwargs,
+        )
+
+    # With delay: agents diagnosed at ti=0 should start ART at ti = delay_ti
+    sim = make_sim(delay_years)
+    hiv = sim.diseases.hiv
+    dx_uids = hiv.diagnosed.uids
+    n_alive = len(sim.people.alive.uids)
+    assert len(dx_uids) == n_alive, 'Expected all living agents diagnosed'
+
+    delay_ti = int(round(delay_years / float(sim.pars.dt)))
+    expected = hiv.ti_diagnosed[dx_uids] + delay_ti
+    on_art_uids = hiv.on_art.uids
+    assert np.allclose(hiv.ti_art[on_art_uids], expected[np.isin(dx_uids, on_art_uids)]), \
+        f'Expected ti_art == ti_diagnosed + {delay_ti} for on-ART agents'
+
+    # No-one should be on ART before the delay elapses
+    # The sim runs (delay_years + 2) years; check n_on_art ramp
+    n_on_art = sim.results.hiv.n_on_art
+    early_ti = max(0, delay_ti - 1)
+    assert n_on_art[early_ti] == 0, f'No agents should be on ART before ti={delay_ti}, got {n_on_art[early_ti]}'
+    assert n_on_art[delay_ti] > 0, f'Agents should be on ART by ti={delay_ti}'
+
+    # Default (no delay): agents diagnosed at ti=0 should be on ART at ti=0
+    sim2 = make_sim(0)
+    hiv2 = sim2.diseases.hiv
+    dx2 = hiv2.diagnosed.uids
+    assert np.allclose(hiv2.ti_art[dx2], hiv2.ti_diagnosed[dx2]), \
+        'Default dur_dx2tx=0 should leave ti_art == ti_diagnosed'
+    assert sim2.results.hiv.n_on_art[0] > 0, 'With no delay, agents should be on ART from ti=0'
+
+    return sim, sim2
+
+
+@sc.timer()
 def test_pn():
     """ PartnerNotification: with PN, more HIV diagnoses occur than without """
     sc.heading('Testing PartnerNotification...')


### PR DESCRIPTION
## Summary
- Adds `dur_dx2tx` to `HIVTest` (default `ss.constant(0)`) for a per-pathway delay between diagnosis and ART start.
- `HIVTest` schedules `hiv.ti_art = ti + delay` for positive results; `ART` becomes passive and starts agents whose `ti_art == ti & ~on_art`. Coverage pool uses `ti_art <= ti & ~on_art`.
- `ANCTest` and initially-diagnosed cases (`init_post`) schedule with no delay — backward compatible.
- `new_agents_on_art` result is gated on `on_art` (since `ti_art` may now hold a future scheduled time).

Closes #398.

## Test plan
- [x] `tests/test_hiv_interventions.py` — all 13 tests pass, including new `test_art_dx2tx_delay` verifying:
  - With `dur_dx2tx=ss.constant(ss.years(2))`, no agents on ART before the delay elapses.
  - `ti_art == ti_diagnosed + delay` for on-ART agents.
  - Default (`ss.constant(0)`) is backward compatible (`ti_art == ti_diagnosed`, agents on ART from ti=0).
- [x] Full repo test suite (66 tests) passes.

Usage:
```python
sti.HIVTest(test_prob_data=0.3, dur_dx2tx=ss.constant(ss.years(0.5)))  # 6-month delay
```