### PR TITLE
Fix auto-connector when user passes a single connector instance

### DIFF
--- a/stisim/sim.py
+++ b/stisim/sim.py
@@ -403,7 +403,10 @@ class Sim(ss.Sim):
         """
         user_pars = self._user_connector_pars
 
-        if len(self.pars['connectors']) > 0:
+        # Normalize before length check: pars['connectors'] may be a single
+        # Connector instance (whose own __len__ can return 0), a list, or an ndict.
+        existing = sc.tolist(self.pars['connectors'])
+        if len(existing) > 0:
             if user_pars:
                 raise ValueError(
                     f'Got flat connector pars {sorted(user_pars)} but `connectors=` '

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -48,12 +48,33 @@ def test_hiv_syph():
     return s0, s1
 
 
+def test_single_connector_instance():
+    """
+    Regression: passing a single connector instance (not a list) via
+    ``connectors=`` should not trigger the auto-add machinery — previously
+    ``len(connector_instance)`` returned 0 and a duplicate was added,
+    causing ndict to raise on init.
+    """
+    hiv  = sti.HIV(init_prev=0.05, beta_m2f=0.05)
+    syph = sti.Syphilis(init_prev=0.05, beta_m2f=0.05)
+    sim = sti.Sim(
+        diseases=[hiv, syph],
+        connectors=sti.hiv_syph(hiv, syph),  # single instance, not a list
+        n_agents=200, dur=2, verbose=-1,
+    )
+    sim.run()
+    assert len(sim.pars['connectors']) == 1, \
+        f'Expected exactly one connector, got {len(sim.pars["connectors"])}'
+    return sim
+
+
 # %% Run as a script
 if __name__ == '__main__':
 
     T = sc.tic()
 
     s0, s1 = test_hiv_syph()
+    test_single_connector_instance()
 
     pl.plot(s0.results.hiv.timevec, s0.results.hiv.prevalence, label='No connector')
     pl.plot(s1.results.hiv.timevec, s1.results.hiv.prevalence, label='With connector')


### PR DESCRIPTION
## Summary
Docs build failed on main after merging rc1.5.5 ([failed run](https://github.com/starsimhub/stisim/actions/runs/25941903373)) on the cotransmission tutorial:

```python
sti.Sim(diseases=[hiv, syph], connectors=sti.hiv_syph(hiv, syph), ...)
```

\`ValueError: Cannot add object "hiv_syph" since already present in ndict with keys: hiv_syph\`

**Root cause:** `process_connectors` checks `len(self.pars['connectors']) > 0` to decide whether to skip auto-adding. When the user supplies a single connector instance (not a list), `len(connector_instance)` returns 0 (from the Module's own `__len__`), so the check is bypassed and a second `hiv_syph` is auto-added.

**Fix:** normalize via `sc.tolist(...)` before the length check.

## Test plan
- [x] Reproducer (cotransmission tutorial snippet) now runs cleanly.
- [x] New regression test `test_single_connector_instance` in `test_connectors.py`.
- [x] Full `test_connectors.py` and `test_sim.py` green (12 tests).