### PR TITLE
fix: restore docs/CNAME to unblock rc1.5.6 → main merge

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.stisim.org


### PR DESCRIPTION
## Summary

Restores `docs/CNAME` with content `docs.stisim.org` to match main.

## Why

PR #471 deleted `docs/CNAME` on the reasoning that gh-pages already carries the correct CNAME (`docs.stisim.org`) and the files in this repo were redundant. Two issues:

1. **Merge conflict on PR #467** (rc1.5.6 → main): main has `docs/CNAME = docs.stisim.org` (added in commit `8ec2ec3 "update cname"`, after PR #471 was reviewed but before it was merged). This produces a modify/delete conflict that blocks the release merge.
2. **Defensive**: keeping the file present with the correct value protects against future Quarto-publish changes silently dropping the live custom domain.

## Test plan
- [x] `cat docs/CNAME` → `docs.stisim.org`
- [x] No code changes; tests untouched
- [ ] After merge: PR #467 (`rc1.5.6 → main`) should auto-resolve to MERGEABLE