### PR TITLE
docs(changelog): correct v1.5.6 default matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to the codebase are documented in this file.
 ## Version 1.5.6 (2026-06-02)
 
 ### Networks
-- **Breaking — default behaviour change.** Split `stisim/networks.py` into a `stisim/networks/` sub-package (`base.py`, `mf.py`, `fsw.py`, `msm.py`, `layered_networks.py`, `matchers.py`). Add a `match_method` string parameter on `MFNetwork`, dispatched through a `MATCHERS` registry of pair-formation algorithms (accepts string or callable). The default match method changes from `sort_bisect` to `kdtree_nn`: the previous default collapsed the M-F age gap to ~0 (didn't honour `age_diff_pars`); `kdtree_nn` does. See [tests/devtests/PFA_RESULTS.md](tests/devtests/PFA_RESULTS.md). Downstream calibrated models will need recalibration: HIV prevalence shifts ~18% in Zimbabwe and ~59% in Eswatini at default settings. Removes `stisim/pfa_variants.py` and the seven `MFNetwork_*` subclasses. (#472)
-- New `MFNetwork.match_pairs()` algorithm reduces the negative/growing bias in modelled age gap at relationship formation. Realised mean age gap is now within <5% of target (slight residual downward bias) with the target stddev preserved. Optimised via batch binary search on male ages. (#477)
+- **Breaking — default behaviour change.** Split `stisim/networks.py` into a `stisim/networks/` sub-package (`base.py`, `mf.py`, `fsw.py`, `msm.py`, `layered_networks.py`, `matchers.py`). Add a `match_method` string parameter on `MFNetwork`, dispatched through a `MATCHERS` registry of pair-formation algorithms (accepts string or callable). The previous default (`sort_bisect`) collapsed the M-F age gap to ~0 because it didn't honour `age_diff_pars`. Eight matchers ship in the registry. Removes `stisim/pfa_variants.py` and the seven `MFNetwork_*` subclasses. (#472)
+- New `closest_age_tapered_seeking` matcher, **now the default**. Orders females by `desired_age = age + normal(target_gap, stddev)` (drawn each step for under-partnered females) and males by age; uses batch-binary-search to find each female's closest available match, with a taper that reduces seeking for older females to bring mean age gaps into data alignment. Realised mean age gap is now within <5% of target (was negatively biased and growing); target stddev preserved. Downstream calibrated models will need recalibration: HIV prevalence shifts ~18% in Zimbabwe and ~59% in Eswatini at default settings. (#477)
 - Add `sti.MSMScaleFreeNetwork`: a preferential-attachment MSM sexual network with continuous-time formation/Markovian deletion (Whittles-2019 S2 kernel). Restricted to post-debut males in this first port; subclass hooks (`_get_pool`, `_mix_node_arrays`, `_mix_weights_row`) let you plug in age-/risk-/λ-weighted variants. Documented as not branching-stable under starsim CRN (global weighted-categorical sampling over a pair catalog). Ported from `starsim_x/BespokeNet`, contributed by Stephen Attwood (Oxford). (#488)
 
 ### Interventions
@@ -16,7 +16,7 @@ All notable changes to the codebase are documented in this file.
 - New ART state diagram in the docs illustrating how ART intersects the HIV mortality cascade. (#471)
 
 ### Tests
-- Regenerate `tests/baseline.yaml` for the new default match method and match_pairs algorithm.
+- Regenerate `tests/baseline.yaml` for the new default matcher.
 - Add `tests/update_baseline` script (mirroring hpvsim's pattern) to regenerate both `baseline.yaml` and `benchmark.yaml` in one command.
 
 ## Version 1.5.5 (2026-05-15)


### PR DESCRIPTION
## Summary

The released v1.5.6 CHANGELOG entry described the new default `match_method` as `kdtree_nn`. That was the intermediate state after #472, but PR #477 then introduced `closest_age_tapered_seeking` and made it the actual default. The downstream-recalibration warning still applies — the calibration shift is driven by the same root issue (the old default not honouring `age_diff_pars`) — but the named matcher was wrong.

This PR corrects the 1.5.6 entry to:
- describe `closest_age_tapered_seeking` and what it does (Clark's algorithm: female desired-age ordering + male age-sort + batch-binary-search + older-female seeking taper)
- drop the now-redundant "new match_pairs algorithm" bullet, since it's the same change

No code changes. Just CHANGELOG text.

## Test plan
- N/A (documentation-only)