### PR TITLE
Syphilis trep/non-trep serology states + configurable prevalence denominator

### DIFF
--- a/stisim/connectors/gud_syph.py
+++ b/stisim/connectors/gud_syph.py
@@ -36,9 +36,9 @@ class gud_syph(ss.Connector):
         sim.diseases.syphilis.rel_trans[sim.people.gud.infected] = self.pars.rel_trans_syph_gud
 
         # People with active syphilis are more likely to acquire GUD
-        sim.diseases.gud.rel_sus[sim.diseases.syphilis.active] = self.pars.rel_sus_gud_syph
+        sim.diseases.gud.rel_sus[sim.diseases.syphilis.symptomatic] = self.pars.rel_sus_gud_syph
 
         # People with active syphilis are more likely to transmit GUD
-        sim.diseases.gud.rel_trans[sim.diseases.syphilis.active] = self.pars.rel_trans_gud_syph
+        sim.diseases.gud.rel_trans[sim.diseases.syphilis.symptomatic] = self.pars.rel_trans_gud_syph
 
         return

--- a/stisim/connectors/hiv_sti.py
+++ b/stisim/connectors/hiv_sti.py
@@ -57,7 +57,7 @@ class hiv_syph(ss.Connector):
     def step(self):
 
         # HIV changes due to syphilis
-        syphilis = self.syphilis.active
+        syphilis = self.syphilis.symptomatic
         self.hiv.rel_sus[syphilis] *= self.rel_sus_hiv_syph[syphilis]
         self.hiv.rel_trans[syphilis] *= self.rel_trans_hiv_syph[syphilis]
 

--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -120,7 +120,7 @@ class BaseSTI(ss.Infection):
         init_prev_data: Initial prevalence data (float or DataFrame by age/sex/risk group).
         **kwargs: Additional parameters passed to ``update_pars``.
     """
-    def __init__(self, name=None, pars=None, init_prev_data=None, **kwargs):
+    def __init__(self, name=None, pars=None, init_prev_data=None, age_range=None, **kwargs):
         super().__init__(name=name)
 
         # Handle parameters
@@ -142,7 +142,7 @@ class BaseSTI(ss.Infection):
 
 
         # Results
-        self.age_range = [15, 50]  # Age range for main results e.g. prevalence
+        self.age_range = age_range if age_range is not None else [15, 50]  # Age range for main results e.g. prevalence
         self.age_bins = np.array([0, 15, 20, 25, 30, 35, 50, 65, 100])  # Age bins for results
         self.sex_keys = {'': 'alive', 'f': 'female', 'm': 'male'}
 

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -291,7 +291,8 @@ class Syphilis(BaseSTI):
 
     @property
     def active(self):
-        """ Active infection includes primary and secondary stages """
+        """ Active infection includes primary and secondary stages. Used by
+        connectors (hiv_sti, gud_syph) for coinfection coupling. """
         return self.primary | self.secondary
 
     @property
@@ -300,13 +301,30 @@ class Syphilis(BaseSTI):
         return self.active | self.latent
 
     @property
+    def sexually_transmissible(self):
+        """ Stages during which syphilis is sexually transmissible: primary,
+        secondary, and early latent. Late latent and tertiary are not
+        normally sexually transmissible (late latent can still transmit
+        congenitally at low levels). Matches WHO 'early infectious syphilis'. """
+        return self.primary | self.secondary | self.early
+
+    @property
+    def symptomatic(self):
+        """ Symptomatic stages of syphilis: primary or secondary. Distinct from
+        ``visibly_symptomatic``, which requires that the symptom actually be
+        observable (chancre at a visible site, or rash). """
+        return self.primary | self.secondary
+
+    @property
     def ulcerative(self):
         """ Has a visible genital ulcer (chancre at a visible site during primary stage) """
         return self.chancre_visible & self.primary
 
     @property
-    def symptomatic(self):
-        """ Has noticeable symptoms: visible ulcer or visible rash """
+    def visibly_symptomatic(self):
+        """ Has clinically detectable symptoms: visible ulcer or visible rash.
+        Used by care-seeking pathways. (Formerly named ``symptomatic``; renamed
+        2026-06-08 to free that name for the disease-stage definition.) """
         return self.ulcerative | (self.rash_visible & self.secondary)
 
     def init_post(self):
@@ -344,7 +362,10 @@ class Syphilis(BaseSTI):
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
-            ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
+            ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence (primary + secondary)"),
+            ss.Result('sexually_transmissible_prevalence', dtype=float, scale=False, label="Sexually transmissible (primary + secondary + early latent)"),
+            ss.Result('symptomatic_prevalence', dtype=float, scale=False, label="Symptomatic stage prevalence (primary + secondary)"),
+            ss.Result('primary_prevalence', dtype=float, scale=False, label="Primary stage prevalence"),
             ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive — matches ZIMPHIA dual-positive 'active syph'"),
             ss.Result('nontrep_prevalence_15_64', dtype=float, scale=False, label="Non-treponemal positive, ages 15-64 (household-survey denominator)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
@@ -372,15 +393,23 @@ class Syphilis(BaseSTI):
                     ss.Result(f'trep_prevalence{skk}', scale=False, label=f"Treponemal-test positive{skl}", auto_plot=False),
                     ss.Result(f'trep_prevalence_15_64{skk}', scale=False, label=f"Treponemal-test positive, ages 15-64{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
+                    ss.Result(f'sexually_transmissible_prevalence{skk}', scale=False, label=f"Sexually transmissible prevalence{skl}", auto_plot=False),
+                    ss.Result(f'symptomatic_prevalence{skk}', scale=False, label=f"Symptomatic prevalence{skl}", auto_plot=False),
+                    ss.Result(f'primary_prevalence{skk}', scale=False, label=f"Primary stage prevalence{skl}", auto_plot=False),
                     ss.Result(f'nontrep_prevalence{skk}', scale=False, label=f"Non-treponemal positive{skl}", auto_plot=False),
                     ss.Result(f'nontrep_prevalence_15_64{skk}', scale=False, label=f"Non-treponemal positive, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
                 ask = f'{skk}_{ab1}_{ab2}'
-                asl = f' ({skl}, {ab2}-{ab2})'
+                asl = f' ({skl}, {ab1}-{ab2})'
                 results += [
                     ss.Result(f'active_prevalence{ask}', scale=False, label=f"Active prevalence{asl}", auto_plot=False),
+                    ss.Result(f'sexually_transmissible_prevalence{ask}', scale=False, label=f"Sexually transmissible prevalence{asl}", auto_plot=False),
+                    ss.Result(f'symptomatic_prevalence{ask}', scale=False, label=f"Symptomatic prevalence{asl}", auto_plot=False),
+                    ss.Result(f'primary_prevalence{ask}', scale=False, label=f"Primary stage prevalence{asl}", auto_plot=False),
+                    ss.Result(f'trep_prevalence{ask}', scale=False, label=f"Treponemal positive{asl}", auto_plot=False),
+                    ss.Result(f'nontrep_prevalence{ask}', scale=False, label=f"Non-treponemal positive{asl}", auto_plot=False),
                 ]
 
         # Add FSW and clients to results:
@@ -558,6 +587,10 @@ class Syphilis(BaseSTI):
         self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
         self.results['trep_prevalence_15_64'][ti] = cond_prob(self.trep, adults_15_64)
         self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
+        self.results['active_prevalence'][ti] = cond_prob(self.active, sexually_active_adults)
+        self.results['sexually_transmissible_prevalence'][ti] = cond_prob(self.sexually_transmissible, sexually_active_adults)
+        self.results['symptomatic_prevalence'][ti] = cond_prob(self.symptomatic, sexually_active_adults)
+        self.results['primary_prevalence'][ti] = cond_prob(self.primary, sexually_active_adults)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -601,7 +634,6 @@ class Syphilis(BaseSTI):
         for pkey, pattr in self.sex_keys.items():
             skk = '' if pkey == '' else f'_{pkey}'
 
-            n_act = self.active & ppl[pattr]
             sex_denom = sexually_active_adults & ppl[pattr]
             sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
@@ -610,10 +642,21 @@ class Syphilis(BaseSTI):
                 self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
                 self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.trep, sex_denom_15_64)
                 self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
+                self.results[f'symptomatic_prevalence{skk}'][ti] = cond_prob(self.symptomatic, sex_denom)
+                self.results[f'sexually_transmissible_prevalence{skk}'][ti] = cond_prob(self.sexually_transmissible, sex_denom)
+                self.results[f'primary_prevalence{skk}'][ti] = cond_prob(self.primary, sex_denom)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
-            # Compute age results
-            age_results = dict(active_prevalence = div(self.agehist(n_act), self.agehist(ppl[pattr])))
+            # Compute age-binned prevalences (denominator = all people of that sex in each age bin)
+            ppl_pattr_hist = self.agehist(ppl[pattr])
+            age_results = dict(
+                active_prevalence = div(self.agehist(self.active & ppl[pattr]), ppl_pattr_hist),
+                sexually_transmissible_prevalence = div(self.agehist(self.sexually_transmissible & ppl[pattr]), ppl_pattr_hist),
+                symptomatic_prevalence = div(self.agehist(self.symptomatic & ppl[pattr]), ppl_pattr_hist),
+                primary_prevalence = div(self.agehist(self.primary & ppl[pattr]), ppl_pattr_hist),
+                trep_prevalence = div(self.agehist(self.trep & ppl[pattr]), ppl_pattr_hist),
+                nontrep_prevalence = div(self.agehist(self.nontrep & ppl[pattr]), ppl_pattr_hist),
+            )
 
             # Store age results
             for akey, ares in age_results.items():

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -313,6 +313,7 @@ class Syphilis(BaseSTI):
         super().init_results()
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
+            ss.Result('serological_prevalence', dtype=float, scale=False, label="Serological prevalence (ever exposed)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
@@ -339,6 +340,7 @@ class Syphilis(BaseSTI):
             skl = '' if sk == '' else f' ({sk.upper()})'
             if skk != '':
                 results += [
+                    ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
                 ]
 
@@ -496,7 +498,7 @@ class Syphilis(BaseSTI):
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
-        # self.results['active_prevalence'][ti] = cond_prob(self.active, sexually_active_adults)
+        self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -541,7 +543,11 @@ class Syphilis(BaseSTI):
             skk = '' if pkey == '' else f'_{pkey}'
 
             n_act = self.active & ppl[pattr]
-            self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, adults & ppl[pattr])
+            sex_denom = sexually_active_adults & ppl[pattr]
+            if skk != '':
+                self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
+                self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+            self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results
             age_results = dict(active_prevalence = div(self.agehist(n_act), self.agehist(ppl[pattr])))

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -323,11 +323,13 @@ class Syphilis(BaseSTI):
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
             ss.Result('serological_prevalence', dtype=float, scale=False, label="Serological prevalence (ever exposed)"),
+            ss.Result('serological_prevalence_15_64', dtype=float, scale=False, label="Serological prevalence, ages 15-64 (household-survey denominator)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
             ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
             ss.Result('detectable_prevalence', dtype=float, scale=False, label="Detectable prevalence (non-trep RDT positive)"),
+            ss.Result('detectable_prevalence_15_64', dtype=float, scale=False, label="Detectable prevalence, ages 15-64 (household-survey denominator)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -351,8 +353,10 @@ class Syphilis(BaseSTI):
             if skk != '':
                 results += [
                     ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
+                    ss.Result(f'serological_prevalence_15_64{skk}', scale=False, label=f"Serological prevalence, ages 15-64{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
                     ss.Result(f'detectable_prevalence{skk}', scale=False, label=f"Detectable prevalence{skl}", auto_plot=False),
+                    ss.Result(f'detectable_prevalence_15_64{skk}', scale=False, label=f"Detectable prevalence, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
@@ -515,11 +519,15 @@ class Syphilis(BaseSTI):
         n_active = res['n_primary'][ti] + res['n_secondary'][ti]
         adults = (ppl.age >= 15) & (ppl.age < 50)
         sexually_active_adults = adults & self.sim.networks.structuredsexual.active(self.sim.people)
+        # Household-survey denominator (ZIMPHIA, etc.): all alive 15-64, no debut/network filter.
+        adults_15_64 = (ppl.age >= 15) & (ppl.age < 65) & ppl.alive
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
         self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
         self.results['detectable_prevalence'][ti] = cond_prob(self.detectable, sexually_active_adults)
+        self.results['serological_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
+        self.results['detectable_prevalence_15_64'][ti] = cond_prob(self.detectable, adults_15_64)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -565,10 +573,13 @@ class Syphilis(BaseSTI):
 
             n_act = self.active & ppl[pattr]
             sex_denom = sexually_active_adults & ppl[pattr]
+            sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
                 self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
                 self.results[f'detectable_prevalence{skk}'][ti] = cond_prob(self.detectable, sex_denom)
+                self.results[f'serological_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
+                self.results[f'detectable_prevalence_15_64{skk}'][ti] = cond_prob(self.detectable, sex_denom_15_64)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -642,10 +642,18 @@ class Syphilis(BaseSTI):
 
     def set_latent_trans(self, ti=None):
         if ti is None: ti = self.ti
+        # Latent rel_trans starts at the secondary-stage level and decays
+        # exponentially with half-life rel_trans_latent_half_life. Using
+        # rel_trans_secondary as the starting value ensures any increase in
+        # secondary transmissibility propagates smoothly into latent (no
+        # discontinuity at the secondary->latent boundary). The
+        # rel_trans_latent parameter is retained for backward compat as a
+        # multiplier on the secondary starting level.
         dur_latent = ti - self.ti_latent[self.latent]
         hl = self.pars.rel_trans_latent_half_life
         decay_rate = np.log(2) / hl if ~np.isnan(hl) else 0.
-        latent_trans = self.pars.rel_trans_latent * np.exp(-decay_rate * dur_latent)
+        starting = self.pars.rel_trans_secondary * self.pars.rel_trans_latent
+        latent_trans = starting * np.exp(-decay_rate * dur_latent)
         self.rel_trans[self.latent] = latent_trans
         return
 

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -31,6 +31,11 @@ class SyphilisPlaceholder(ss.Disease):
 
         return
 
+    @property
+    def symptomatic(self):
+        """ Alias for the active state, so connectors share an interface with the full Syphilis module """
+        return self.active
+
     def init_pre(self, sim):
         super().init_pre(sim)
         if not isinstance(self.pars.prevalence, sti.TimeSeries):
@@ -84,13 +89,10 @@ class SyphPars(BaseSTIPars):
         self.time_to_death = ss.lognorm_ex(ss.years(5), ss.years(5))  # Time to death
 
         # Time from late-latent onset until non-treponemal titre falls below
-        # detection threshold on serological tests (WHO 2021 fig 7: late latent
-        # described as "maybe positive but lower titres, possibly negative").
-        # Wide default prior; expected to be tuned in calibration. Expert input
-        # pending.
-        self.time_to_undetectable = ss.lognorm_ex(ss.years(5), ss.years(5))
+        # detection threshold on serological tests
+        self.time_to_undetectable = ss.lognorm_ex(ss.years(15), ss.years(5))
 
-        # Treponemal-test seroconversion + persistence (WHO report):
+        # Treponemal-test seroconversion + persistence
         #   - dur_to_trep: time from infection to trep antibody detection
         #     (window period during which the agent is infected but the
         #     trep test is still negative; ~2-3 weeks for IgM/IgG)
@@ -109,7 +111,6 @@ class SyphPars(BaseSTIPars):
         self.eff_condom = 0.0
         self.rel_trans_primary = 1
         self.rel_trans_secondary = 1
-        self.rel_trans_latent = 1  # Baseline level; this decays exponentially with duration of latent infection
         self.rel_trans_tertiary = 0.0
         self.rel_trans_latent_half_life = ss.years(1)
 
@@ -152,8 +153,8 @@ class SyphPars(BaseSTIPars):
 
 class Syphilis(BaseSTI):
 
-    def __init__(self, pars=None, name='syph', init_prev_data=None, init_prev_latent_data=None, **kwargs):
-        super().__init__(name=name)
+    def __init__(self, pars=None, name='syph', init_prev_data=None, init_prev_latent_data=None, age_range=None, **kwargs):
+        super().__init__(name=name, age_range=age_range)
 
         # Define default parameters
         default_pars = SyphPars()
@@ -180,7 +181,7 @@ class Syphilis(BaseSTI):
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
             ss.BoolState('ever_exposed'), # Biological: ever infected (lifetime); used for is_naive/sus_not_naive logic
             ss.BoolState('trep'),         # Treponemal test positive (matches what a real trep RDT would detect: 80% persist for life, 20% sero-revert eventually)
-            ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive — would be flagged dual-positive in ZIMPHIA's "active infection" category
+            ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
             # Symptom visibility — determined at infection/stage entry, reflects anatomical site
@@ -290,15 +291,9 @@ class Syphilis(BaseSTI):
         return self.exposed | self.primary | self.secondary
 
     @property
-    def active(self):
-        """ Active infection includes primary and secondary stages. Used by
-        connectors (hiv_sti, gud_syph) for coinfection coupling. """
-        return self.primary | self.secondary
-
-    @property
     def infectious(self):
         """ Infectious """
-        return self.active | self.latent
+        return self.symptomatic | self.latent
 
     @property
     def sexually_transmissible(self):
@@ -323,8 +318,7 @@ class Syphilis(BaseSTI):
     @property
     def visibly_symptomatic(self):
         """ Has clinically detectable symptoms: visible ulcer or visible rash.
-        Used by care-seeking pathways. (Formerly named ``symptomatic``; renamed
-        2026-06-08 to free that name for the disease-stage definition.) """
+        Used by care-seeking pathways. """
         return self.ulcerative | (self.rash_visible & self.secondary)
 
     def init_post(self):
@@ -357,17 +351,14 @@ class Syphilis(BaseSTI):
         super().init_results()
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
-            ss.Result('trep_prevalence', dtype=float, scale=False, label="Treponemal-test positive (ever-exposed proxy; matches ZIMPHIA total seroprev)"),
-            ss.Result('trep_prevalence_15_64', dtype=float, scale=False, label="Treponemal-test positive, ages 15-64 (household-survey denominator)"),
+            ss.Result('trep_prevalence', dtype=float, scale=False, label="Treponemal-test positive (ever-exposed proxy)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
-            ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence (primary + secondary)"),
             ss.Result('sexually_transmissible_prevalence', dtype=float, scale=False, label="Sexually transmissible (primary + secondary + early latent)"),
             ss.Result('symptomatic_prevalence', dtype=float, scale=False, label="Symptomatic stage prevalence (primary + secondary)"),
             ss.Result('primary_prevalence', dtype=float, scale=False, label="Primary stage prevalence"),
-            ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive — matches ZIMPHIA dual-positive 'active syph'"),
-            ss.Result('nontrep_prevalence_15_64', dtype=float, scale=False, label="Non-treponemal positive, ages 15-64 (household-survey denominator)"),
+            ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -391,20 +382,16 @@ class Syphilis(BaseSTI):
             if skk != '':
                 results += [
                     ss.Result(f'trep_prevalence{skk}', scale=False, label=f"Treponemal-test positive{skl}", auto_plot=False),
-                    ss.Result(f'trep_prevalence_15_64{skk}', scale=False, label=f"Treponemal-test positive, ages 15-64{skl}", auto_plot=False),
-                    ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
                     ss.Result(f'sexually_transmissible_prevalence{skk}', scale=False, label=f"Sexually transmissible prevalence{skl}", auto_plot=False),
                     ss.Result(f'symptomatic_prevalence{skk}', scale=False, label=f"Symptomatic prevalence{skl}", auto_plot=False),
                     ss.Result(f'primary_prevalence{skk}', scale=False, label=f"Primary stage prevalence{skl}", auto_plot=False),
                     ss.Result(f'nontrep_prevalence{skk}', scale=False, label=f"Non-treponemal positive{skl}", auto_plot=False),
-                    ss.Result(f'nontrep_prevalence_15_64{skk}', scale=False, label=f"Non-treponemal positive, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
                 ask = f'{skk}_{ab1}_{ab2}'
                 asl = f' ({skl}, {ab1}-{ab2})'
                 results += [
-                    ss.Result(f'active_prevalence{ask}', scale=False, label=f"Active prevalence{asl}", auto_plot=False),
                     ss.Result(f'sexually_transmissible_prevalence{ask}', scale=False, label=f"Sexually transmissible prevalence{asl}", auto_plot=False),
                     ss.Result(f'symptomatic_prevalence{ask}', scale=False, label=f"Symptomatic prevalence{asl}", auto_plot=False),
                     ss.Result(f'primary_prevalence{ask}', scale=False, label=f"Primary stage prevalence{asl}", auto_plot=False),
@@ -576,18 +563,13 @@ class Syphilis(BaseSTI):
         ppl = self.sim.people
 
         n_active = res['n_primary'][ti] + res['n_secondary'][ti]
-        adults = (ppl.age >= 15) & (ppl.age < 50)
+        adults = (ppl.age >= self.age_range[0]) & (ppl.age < self.age_range[1])
         sexually_active_adults = adults & self.sim.networks.structuredsexual.active(self.sim.people)
-        # Household-survey denominator (ZIMPHIA, etc.): all alive 15-64, no debut/network filter.
-        adults_15_64 = (ppl.age >= 15) & (ppl.age < 65) & ppl.alive
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
         self.results['trep_prevalence'][ti] = cond_prob(self.trep, sexually_active_adults)
         self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
-        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.trep, adults_15_64)
-        self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
-        self.results['active_prevalence'][ti] = cond_prob(self.active, sexually_active_adults)
         self.results['sexually_transmissible_prevalence'][ti] = cond_prob(self.sexually_transmissible, sexually_active_adults)
         self.results['symptomatic_prevalence'][ti] = cond_prob(self.symptomatic, sexually_active_adults)
         self.results['primary_prevalence'][ti] = cond_prob(self.primary, sexually_active_adults)
@@ -635,22 +617,17 @@ class Syphilis(BaseSTI):
             skk = '' if pkey == '' else f'_{pkey}'
 
             sex_denom = sexually_active_adults & ppl[pattr]
-            sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
                 self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.trep, sex_denom)
                 self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
-                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.trep, sex_denom_15_64)
-                self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
                 self.results[f'symptomatic_prevalence{skk}'][ti] = cond_prob(self.symptomatic, sex_denom)
                 self.results[f'sexually_transmissible_prevalence{skk}'][ti] = cond_prob(self.sexually_transmissible, sex_denom)
                 self.results[f'primary_prevalence{skk}'][ti] = cond_prob(self.primary, sex_denom)
-            self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age-binned prevalences (denominator = all people of that sex in each age bin)
             ppl_pattr_hist = self.agehist(ppl[pattr])
             age_results = dict(
-                active_prevalence = div(self.agehist(self.active & ppl[pattr]), ppl_pattr_hist),
                 sexually_transmissible_prevalence = div(self.agehist(self.sexually_transmissible & ppl[pattr]), ppl_pattr_hist),
                 symptomatic_prevalence = div(self.agehist(self.symptomatic & ppl[pattr]), ppl_pattr_hist),
                 primary_prevalence = div(self.agehist(self.primary & ppl[pattr]), ppl_pattr_hist),
@@ -685,17 +662,10 @@ class Syphilis(BaseSTI):
 
     def set_latent_trans(self, ti=None):
         if ti is None: ti = self.ti
-        # Latent rel_trans starts at the secondary-stage level and decays
-        # exponentially with half-life rel_trans_latent_half_life. Using
-        # rel_trans_secondary as the starting value ensures any increase in
-        # secondary transmissibility propagates smoothly into latent (no
-        # discontinuity at the secondary->latent boundary). The
-        # rel_trans_latent parameter is retained for backward compat as a
-        # multiplier on the secondary starting level.
         dur_latent = ti - self.ti_latent[self.latent]
         hl = self.pars.rel_trans_latent_half_life
         decay_rate = np.log(2) / hl if ~np.isnan(hl) else 0.
-        starting = self.pars.rel_trans_secondary * self.pars.rel_trans_latent
+        starting = self.pars.rel_trans_secondary
         latent_trans = starting * np.exp(-decay_rate * dur_latent)
         self.rel_trans[self.latent] = latent_trans
         return
@@ -763,7 +733,7 @@ class Syphilis(BaseSTI):
         dur_secondary = self.pars.dur_secondary.rvs(uids)
         self.ti_latent[uids] = self.ti_secondary[uids] + rr(dur_secondary)
         # Non-treponemal titre rises by secondary; RPR becomes positive.
-        # Also covers reactivation from late latent (titre climbs again — Fig 7).
+        # Also covers reactivation from late latent (titre climbs again).
         self.nontrep[uids] = True
         return
 

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -83,6 +83,13 @@ class SyphPars(BaseSTIPars):
         self.p_death = ss.bernoulli(p=0.05)  # probability of dying of tertiary syphilis
         self.time_to_death = ss.lognorm_ex(ss.years(5), ss.years(5))  # Time to death
 
+        # Time from late-latent onset until non-treponemal titre falls below
+        # detection threshold on serological tests (WHO 2021 fig 7: late latent
+        # described as "maybe positive but lower titres, possibly negative").
+        # Wide default prior; expected to be tuned in calibration. Expert input
+        # pending.
+        self.time_to_undetectable = ss.lognorm_ex(ss.years(5), ss.years(5))
+
         # Transmission by stage
         self.beta_m2f = 0.1
         self.eff_condom = 0.0
@@ -158,6 +165,7 @@ class Syphilis(BaseSTI):
             ss.BoolState('tertiary'),     # Includes complications (cardio/neuro/disfigurement)
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
             ss.BoolState('ever_exposed'), # Anyone ever exposed - stays true after treatment
+            ss.BoolState('detectable'),   # Non-treponemal serology positive (dual-RDT 'active syph' would detect)
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
             # Symptom visibility — determined at infection/stage entry, reflects anatomical site
@@ -175,6 +183,7 @@ class Syphilis(BaseSTI):
             ss.FloatArr('ti_latent'),
             ss.FloatArr('dur_early'),
             ss.FloatArr('ti_tertiary'),
+            ss.FloatArr('ti_detectable_end'),  # When non-trep titre drops below detection
             ss.FloatArr('ti_dead'),
             ss.FloatArr('ti_immune'),
             ss.FloatArr('ti_miscarriage'),
@@ -318,6 +327,7 @@ class Syphilis(BaseSTI):
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
             ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
+            ss.Result('detectable_prevalence', dtype=float, scale=False, label="Detectable prevalence (non-trep RDT positive)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -342,6 +352,7 @@ class Syphilis(BaseSTI):
                 results += [
                     ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
+                    ss.Result(f'detectable_prevalence{skk}', scale=False, label=f"Detectable prevalence{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
@@ -456,6 +467,14 @@ class Syphilis(BaseSTI):
             self.late[is_early] = False
             self.late[is_late] = True
 
+        # Serology detectability: non-trep titre falls below detection at
+        # the per-agent ti_detectable_end (drawn from time_to_undetectable in
+        # set_latent_prognoses). Reactivation back to secondary re-sets
+        # detectable=True in set_secondary_prognoses.
+        becomes_undetectable = self.detectable & (self.ti_detectable_end <= ti)
+        if len(becomes_undetectable.uids) > 0:
+            self.detectable[becomes_undetectable] = False
+
         return
 
     def step_die(self, uids):
@@ -473,6 +492,7 @@ class Syphilis(BaseSTI):
         self.immune[uids] = False
         self.congenital[uids] = False
         self.ever_exposed[uids] = False
+        self.detectable[uids] = False
         self.n_infections[uids] = 0
         self.chancre_visible[uids] = False
         self.rash_visible[uids] = False
@@ -499,6 +519,7 @@ class Syphilis(BaseSTI):
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
         self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
+        self.results['detectable_prevalence'][ti] = cond_prob(self.detectable, sexually_active_adults)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -547,6 +568,7 @@ class Syphilis(BaseSTI):
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
                 self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+                self.results[f'detectable_prevalence{skk}'][ti] = cond_prob(self.detectable, sex_denom)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results
@@ -636,9 +658,18 @@ class Syphilis(BaseSTI):
         """ Set prognoses for people who have just progressed to secondary infection """
         dur_secondary = self.pars.dur_secondary.rvs(uids)
         self.ti_latent[uids] = self.ti_secondary[uids] + rr(dur_secondary)
+        # Non-treponemal titre rises by secondary; serology becomes detectable.
+        # Also covers reactivation from late latent (titre climbs again — Fig 7).
+        self.detectable[uids] = True
         return
 
     def set_latent_prognoses(self, uids):
+        # Late-latent serology: draw the time at which non-trep titre is
+        # expected to fall below detection. ti_detectable_end is measured
+        # from the *start of late latent* = ti_latent + dur_early.
+        late_start = self.ti_latent[uids] + self.dur_early[uids]
+        self.ti_detectable_end[uids] = late_start + rr(self.pars.time_to_undetectable.rvs(uids))
+
         # Reactivators
         will_reactivate = self.pars.p_reactivate.rvs(uids)
         reactivate_uids = uids[will_reactivate]

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -75,7 +75,7 @@ class SyphPars(BaseSTIPars):
         self.dur_exposed = ss.normal(ss.days(50), ss.days(10))  # https://pubmed.ncbi.nlm.nih.gov/9101629/
         self.dur_primary = ss.normal(ss.weeks(6), ss.weeks(1))  # https://pubmed.ncbi.nlm.nih.gov/9101629/
         self.dur_secondary = ss.lognorm_ex(ss.months(3.6), ss.months(1.5))  # https://pubmed.ncbi.nlm.nih.gov/9101629/
-        self.dur_early = ss.uniform(ss.months(12), ss.months(14))  # Assumption
+        self.dur_early = ss.uniform(ss.months(22), ss.months(24))  # Early-latent boundary matches WHO Europe definition (≤2 years post-infection)
         self.p_reactivate = ss.bernoulli(p=0.35)  # Probability of reactivating from latent to secondary
         self.time_to_reactivate = ss.lognorm_ex(ss.years(1), ss.years(1))  # Time to reactivation
         self.p_tertiary = ss.bernoulli(p=0.35)  # https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4917057/
@@ -89,6 +89,20 @@ class SyphPars(BaseSTIPars):
         # Wide default prior; expected to be tuned in calibration. Expert input
         # pending.
         self.time_to_undetectable = ss.lognorm_ex(ss.years(5), ss.years(5))
+
+        # Treponemal-test seroconversion + persistence (WHO report):
+        #   - dur_to_trep: time from infection to trep antibody detection
+        #     (window period during which the agent is infected but the
+        #     trep test is still negative; ~2-3 weeks for IgM/IgG)
+        #   - p_trep_persists: 80% of trep-positive agents remain trep+
+        #     for life. The other 20% sero-revert eventually.
+        #   - time_to_trep_revert: timing for the 20% who do sero-revert
+        #     (slow, variable; mean ~10y post-seroconversion)
+        # Agents treated BEFORE ti_trep_start (window-period treatment)
+        # never become trep+ — SyphTx handles that case in change_states.
+        self.dur_to_trep = ss.normal(ss.weeks(3), ss.weeks(1))
+        self.p_trep_persists = ss.bernoulli(p=0.80)
+        self.time_to_trep_revert = ss.normal(ss.years(10), ss.years(5))
 
         # Transmission by stage
         self.beta_m2f = 0.1
@@ -164,7 +178,8 @@ class Syphilis(BaseSTI):
             ss.BoolState('latent'),       # Can relapse to secondary, remain in latent, or progress to tertiary,
             ss.BoolState('tertiary'),     # Includes complications (cardio/neuro/disfigurement)
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
-            ss.BoolState('ever_exposed'), # Anyone ever exposed - proxy for treponemal-test positive (antibodies persist for life)
+            ss.BoolState('ever_exposed'), # Biological: ever infected (lifetime); used for is_naive/sus_not_naive logic
+            ss.BoolState('trep'),         # Treponemal test positive (matches what a real trep RDT would detect: 80% persist for life, 20% sero-revert eventually)
             ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive — would be flagged dual-positive in ZIMPHIA's "active infection" category
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
@@ -184,6 +199,8 @@ class Syphilis(BaseSTI):
             ss.FloatArr('dur_early'),
             ss.FloatArr('ti_tertiary'),
             ss.FloatArr('ti_nontrep_end'),  # When non-trep titre drops below test threshold (sero-reversion on RPR/VDRL)
+            ss.FloatArr('ti_trep_start'),   # When trep antibodies appear (post-seroconversion); NaN if treated in window period
+            ss.FloatArr('ti_trep_end'),     # When trep test reverts to negative (NaN for the 80% who persist for life)
             ss.FloatArr('ti_dead'),
             ss.FloatArr('ti_immune'),
             ss.FloatArr('ti_miscarriage'),
@@ -479,6 +496,15 @@ class Syphilis(BaseSTI):
         if len(becomes_nontrep_neg.uids) > 0:
             self.nontrep[becomes_nontrep_neg] = False
 
+        # Treponemal seroconversion (post-window-period appearance of trep+)
+        becomes_trep_pos = (~self.trep) & (self.ti_trep_start <= ti)
+        if len(becomes_trep_pos.uids) > 0:
+            self.trep[becomes_trep_pos] = True
+        # Treponemal sero-reversion (for the 20% with ti_trep_end set)
+        becomes_trep_neg = self.trep & (self.ti_trep_end <= ti)
+        if len(becomes_trep_neg.uids) > 0:
+            self.trep[becomes_trep_neg] = False
+
         return
 
     def step_die(self, uids):
@@ -496,6 +522,7 @@ class Syphilis(BaseSTI):
         self.immune[uids] = False
         self.congenital[uids] = False
         self.ever_exposed[uids] = False
+        self.trep[uids] = False
         self.nontrep[uids] = False
         self.n_infections[uids] = 0
         self.chancre_visible[uids] = False
@@ -509,6 +536,9 @@ class Syphilis(BaseSTI):
         self.ti_latent[uids] = np.nan
         self.ti_tertiary[uids] = np.nan
         self.ti_congenital[uids] = np.nan
+        self.ti_nontrep_end[uids] = np.nan
+        self.ti_trep_start[uids] = np.nan
+        self.ti_trep_end[uids] = np.nan
 
     def update_results(self):
         super().update_results()
@@ -524,9 +554,9 @@ class Syphilis(BaseSTI):
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
-        self.results['trep_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
+        self.results['trep_prevalence'][ti] = cond_prob(self.trep, sexually_active_adults)
         self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
-        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
+        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.trep, adults_15_64)
         self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
         self.results['n_active'][ti] = n_active
 
@@ -576,9 +606,9 @@ class Syphilis(BaseSTI):
             sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
-                self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+                self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.trep, sex_denom)
                 self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
-                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
+                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.trep, sex_denom_15_64)
                 self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
@@ -645,6 +675,18 @@ class Syphilis(BaseSTI):
         self.infected[uids] = True
         self.ti_exposed[uids] = ti
         self.ti_infected[uids] = ti
+
+        # Treponemal seroconversion: trep+ appears ~3 weeks post-infection,
+        # so during the window period agents are infected but trep-negative.
+        # 80% remain trep+ for life; the other 20% sero-revert ~10y later.
+        dur_to_trep = self.pars.dur_to_trep.rvs(uids)
+        self.ti_trep_start[uids] = self.ti_exposed[uids] + rr(dur_to_trep)
+        persists = self.pars.p_trep_persists.rvs(uids)
+        reverters = uids[~persists]
+        if len(reverters) > 0:
+            revert_delay = self.pars.time_to_trep_revert.rvs(reverters)
+            self.ti_trep_end[reverters] = self.ti_trep_start[reverters] + rr(revert_delay)
+        # Persisters keep ti_trep_end at default NaN (never reverts)
 
         # Exposed to primary
         dur_exposed = self.pars.dur_exposed.rvs(uids)

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -164,8 +164,8 @@ class Syphilis(BaseSTI):
             ss.BoolState('latent'),       # Can relapse to secondary, remain in latent, or progress to tertiary,
             ss.BoolState('tertiary'),     # Includes complications (cardio/neuro/disfigurement)
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
-            ss.BoolState('ever_exposed'), # Anyone ever exposed - stays true after treatment
-            ss.BoolState('detectable'),   # Non-treponemal serology positive (dual-RDT 'active syph' would detect)
+            ss.BoolState('ever_exposed'), # Anyone ever exposed - proxy for treponemal-test positive (antibodies persist for life)
+            ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive — would be flagged dual-positive in ZIMPHIA's "active infection" category
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
             # Symptom visibility — determined at infection/stage entry, reflects anatomical site
@@ -183,7 +183,7 @@ class Syphilis(BaseSTI):
             ss.FloatArr('ti_latent'),
             ss.FloatArr('dur_early'),
             ss.FloatArr('ti_tertiary'),
-            ss.FloatArr('ti_detectable_end'),  # When non-trep titre drops below detection
+            ss.FloatArr('ti_nontrep_end'),  # When non-trep titre drops below test threshold (sero-reversion on RPR/VDRL)
             ss.FloatArr('ti_dead'),
             ss.FloatArr('ti_immune'),
             ss.FloatArr('ti_miscarriage'),
@@ -322,14 +322,14 @@ class Syphilis(BaseSTI):
         super().init_results()
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
-            ss.Result('serological_prevalence', dtype=float, scale=False, label="Serological prevalence (ever exposed)"),
-            ss.Result('serological_prevalence_15_64', dtype=float, scale=False, label="Serological prevalence, ages 15-64 (household-survey denominator)"),
+            ss.Result('trep_prevalence', dtype=float, scale=False, label="Treponemal-test positive (ever-exposed proxy; matches ZIMPHIA total seroprev)"),
+            ss.Result('trep_prevalence_15_64', dtype=float, scale=False, label="Treponemal-test positive, ages 15-64 (household-survey denominator)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
             ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
-            ss.Result('detectable_prevalence', dtype=float, scale=False, label="Detectable prevalence (non-trep RDT positive)"),
-            ss.Result('detectable_prevalence_15_64', dtype=float, scale=False, label="Detectable prevalence, ages 15-64 (household-survey denominator)"),
+            ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive — matches ZIMPHIA dual-positive 'active syph'"),
+            ss.Result('nontrep_prevalence_15_64', dtype=float, scale=False, label="Non-treponemal positive, ages 15-64 (household-survey denominator)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -352,11 +352,11 @@ class Syphilis(BaseSTI):
             skl = '' if sk == '' else f' ({sk.upper()})'
             if skk != '':
                 results += [
-                    ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
-                    ss.Result(f'serological_prevalence_15_64{skk}', scale=False, label=f"Serological prevalence, ages 15-64{skl}", auto_plot=False),
+                    ss.Result(f'trep_prevalence{skk}', scale=False, label=f"Treponemal-test positive{skl}", auto_plot=False),
+                    ss.Result(f'trep_prevalence_15_64{skk}', scale=False, label=f"Treponemal-test positive, ages 15-64{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
-                    ss.Result(f'detectable_prevalence{skk}', scale=False, label=f"Detectable prevalence{skl}", auto_plot=False),
-                    ss.Result(f'detectable_prevalence_15_64{skk}', scale=False, label=f"Detectable prevalence, ages 15-64{skl}", auto_plot=False),
+                    ss.Result(f'nontrep_prevalence{skk}', scale=False, label=f"Non-treponemal positive{skl}", auto_plot=False),
+                    ss.Result(f'nontrep_prevalence_15_64{skk}', scale=False, label=f"Non-treponemal positive, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
@@ -471,13 +471,13 @@ class Syphilis(BaseSTI):
             self.late[is_early] = False
             self.late[is_late] = True
 
-        # Serology detectability: non-trep titre falls below detection at
-        # the per-agent ti_detectable_end (drawn from time_to_undetectable in
+        # Non-trep sero-reversion: non-trep titre falls below test threshold at
+        # the per-agent ti_nontrep_end (drawn from time_to_undetectable in
         # set_latent_prognoses). Reactivation back to secondary re-sets
-        # detectable=True in set_secondary_prognoses.
-        becomes_undetectable = self.detectable & (self.ti_detectable_end <= ti)
-        if len(becomes_undetectable.uids) > 0:
-            self.detectable[becomes_undetectable] = False
+        # nontrep=True in set_secondary_prognoses.
+        becomes_nontrep_neg = self.nontrep & (self.ti_nontrep_end <= ti)
+        if len(becomes_nontrep_neg.uids) > 0:
+            self.nontrep[becomes_nontrep_neg] = False
 
         return
 
@@ -496,7 +496,7 @@ class Syphilis(BaseSTI):
         self.immune[uids] = False
         self.congenital[uids] = False
         self.ever_exposed[uids] = False
-        self.detectable[uids] = False
+        self.nontrep[uids] = False
         self.n_infections[uids] = 0
         self.chancre_visible[uids] = False
         self.rash_visible[uids] = False
@@ -524,10 +524,10 @@ class Syphilis(BaseSTI):
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
-        self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
-        self.results['detectable_prevalence'][ti] = cond_prob(self.detectable, sexually_active_adults)
-        self.results['serological_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
-        self.results['detectable_prevalence_15_64'][ti] = cond_prob(self.detectable, adults_15_64)
+        self.results['trep_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
+        self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
+        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
+        self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -576,10 +576,10 @@ class Syphilis(BaseSTI):
             sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
-                self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
-                self.results[f'detectable_prevalence{skk}'][ti] = cond_prob(self.detectable, sex_denom)
-                self.results[f'serological_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
-                self.results[f'detectable_prevalence_15_64{skk}'][ti] = cond_prob(self.detectable, sex_denom_15_64)
+                self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+                self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
+                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
+                self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results
@@ -669,17 +669,18 @@ class Syphilis(BaseSTI):
         """ Set prognoses for people who have just progressed to secondary infection """
         dur_secondary = self.pars.dur_secondary.rvs(uids)
         self.ti_latent[uids] = self.ti_secondary[uids] + rr(dur_secondary)
-        # Non-treponemal titre rises by secondary; serology becomes detectable.
+        # Non-treponemal titre rises by secondary; RPR becomes positive.
         # Also covers reactivation from late latent (titre climbs again — Fig 7).
-        self.detectable[uids] = True
+        self.nontrep[uids] = True
         return
 
     def set_latent_prognoses(self, uids):
-        # Late-latent serology: draw the time at which non-trep titre is
-        # expected to fall below detection. ti_detectable_end is measured
-        # from the *start of late latent* = ti_latent + dur_early.
+        # Late-latent non-trep sero-reversion: draw the time at which
+        # non-trep titre is expected to fall below test threshold.
+        # ti_nontrep_end is measured from the *start of late latent* =
+        # ti_latent + dur_early.
         late_start = self.ti_latent[uids] + self.dur_early[uids]
-        self.ti_detectable_end[uids] = late_start + rr(self.pars.time_to_undetectable.rvs(uids))
+        self.ti_nontrep_end[uids] = late_start + rr(self.pars.time_to_undetectable.rvs(uids))
 
         # Reactivators
         will_reactivate = self.pars.p_reactivate.rvs(uids)

--- a/stisim/interventions/syphilis_interventions.py
+++ b/stisim/interventions/syphilis_interventions.py
@@ -54,12 +54,11 @@ class SyphTx(STITreatment):
             fetus_treat_eff=ss.bernoulli(p=.98),
             fetus_age_cutoff_treat_eff=-0.25,  # Reduced treatment efficacy for fetuses in the last trimester
             treat_eff_reduced=ss.bernoulli(p=.75),  # Reduced efficacy for fetuses older than cut off
-            # Non-trep sero-reversion after early-stage treatment.
-            # WHO 2021 fig 7: RPR titre drops 4-fold within ~6 months
-            # of adequate treatment of primary/secondary/early-latent
-            # syphilis, with most patients becoming RPR-negative
-            # within 6-12 months. Late-latent treatment does NOT
-            # produce reliable RPR sero-reversion and is excluded
+            # Non-trep sero-reversion after early-stage treatment: RPR titre
+            # drops 4-fold within ~6 months of adequate treatment of
+            # primary/secondary/early-latent syphilis, with most patients
+            # becoming RPR-negative within 6-12 months. Late-latent treatment
+            # does NOT produce reliable RPR sero-reversion and is excluded
             # in change_states below.
             nontrep_revert_months=ss.uniform(low=6, high=12),
         )
@@ -71,9 +70,9 @@ class SyphTx(STITreatment):
         d = self.sim.diseases[disease]
 
         # Identify early-stage treated agents BEFORE clearing stage flags.
-        # Per WHO 2021 fig 7, treatment in primary, secondary, or early
-        # latent yields RPR sero-reversion within 6-12 months; late-latent
-        # treatment does not reliably clear the non-trep test.
+        # Treatment in primary, secondary, or early latent yields RPR
+        # sero-reversion within 6-12 months; late-latent treatment does not
+        # reliably clear the non-trep test.
         early_stage_mask = (d.primary[treat_succ]
                              | d.secondary[treat_succ]
                              | d.early[treat_succ])
@@ -109,10 +108,10 @@ class SyphTx(STITreatment):
         # ti_trep_start fires (i.e. before trep antibodies appear, ~3 weeks
         # post-infection), the trep test also stays negative — they never
         # seroconvert. Clear ti_trep_start so step_state doesn't flip
-        # trep=True later. (User instruction 2026-06-07.)
+        # trep=True later.
         window_period_treated = treat_succ[
             (~d.trep[treat_succ]) &
-            (~np.isnan(d.ti_trep_start[treat_succ])) &
+            (d.ti_trep_start.notnan[treat_succ]) &
             (d.ti + 1 < d.ti_trep_start[treat_succ])
         ]
         if len(window_period_treated) > 0:

--- a/stisim/interventions/syphilis_interventions.py
+++ b/stisim/interventions/syphilis_interventions.py
@@ -53,7 +53,15 @@ class SyphTx(STITreatment):
             treat_eff=ss.bernoulli(p=.98),
             fetus_treat_eff=ss.bernoulli(p=.98),
             fetus_age_cutoff_treat_eff=-0.25,  # Reduced treatment efficacy for fetuses in the last trimester
-            treat_eff_reduced=ss.bernoulli(p=.75)  # Reduced efficacy for fetuses older than cut off
+            treat_eff_reduced=ss.bernoulli(p=.75),  # Reduced efficacy for fetuses older than cut off
+            # Non-trep sero-reversion after early-stage treatment.
+            # WHO 2021 fig 7: RPR titre drops 4-fold within ~6 months
+            # of adequate treatment of primary/secondary/early-latent
+            # syphilis, with most patients becoming RPR-negative
+            # within 6-12 months. Late-latent treatment does NOT
+            # produce reliable RPR sero-reversion and is excluded
+            # in change_states below.
+            nontrep_revert_months=ss.uniform(low=6, high=12),
         )
         self.update_pars(pars, **kwargs)
         return
@@ -61,6 +69,16 @@ class SyphTx(STITreatment):
     def change_states(self, disease, treat_succ):
         """ Change the states of people who are treated """
         d = self.sim.diseases[disease]
+
+        # Identify early-stage treated agents BEFORE clearing stage flags.
+        # Per WHO 2021 fig 7, treatment in primary, secondary, or early
+        # latent yields RPR sero-reversion within 6-12 months; late-latent
+        # treatment does not reliably clear the non-trep test.
+        early_stage_mask = (d.primary[treat_succ]
+                             | d.secondary[treat_succ]
+                             | d.early[treat_succ])
+        early_stage_treated = treat_succ[early_stage_mask]
+
         d.primary[treat_succ] = False
         d.secondary[treat_succ] = False
         d.early[treat_succ] = False
@@ -75,6 +93,30 @@ class SyphTx(STITreatment):
         d.ti_tertiary[treat_succ] = np.nan
         d.susceptible[treat_succ] = True
         d.infected[treat_succ] = False
+
+        # Schedule post-treatment non-trep sero-reversion for early-stage
+        # treated agents currently RPR-positive. Without this, treated
+        # patients stayed nontrep=True for life (ti_nontrep_end was only
+        # set when entering late latent, never for early-stage treated).
+        nontrep_treated = early_stage_treated[d.nontrep[early_stage_treated]]
+        if len(nontrep_treated) > 0:
+            months = self.pars.nontrep_revert_months.rvs(nontrep_treated)
+            steps_to_revert = np.maximum(
+                1, np.round(months / (12.0 * d.t.dt_year)).astype(int))
+            d.ti_nontrep_end[nontrep_treated] = d.ti + steps_to_revert
+
+        # Window-period treatment: if treated BEFORE the agent's
+        # ti_trep_start fires (i.e. before trep antibodies appear, ~3 weeks
+        # post-infection), the trep test also stays negative — they never
+        # seroconvert. Clear ti_trep_start so step_state doesn't flip
+        # trep=True later. (User instruction 2026-06-07.)
+        window_period_treated = treat_succ[
+            (~d.trep[treat_succ]) &
+            (~np.isnan(d.ti_trep_start[treat_succ])) &
+            (d.ti + 1 < d.ti_trep_start[treat_succ])
+        ]
+        if len(window_period_treated) > 0:
+            d.ti_trep_start[window_period_treated] = np.nan
 
     def treat_fetus(self, sim, mother_uids):
         """

--- a/stisim/networks/layered_networks.py
+++ b/stisim/networks/layered_networks.py
@@ -41,6 +41,11 @@ class StructuredSexual(MFNetwork):
         super().__init__(name=name)
         # SW layer
         self.define_pars(**SWPars())
+        # Multiplier on FSW non-sex-work (MF) concurrency: values <1 mean
+        # active sex workers have fewer non-sex-work partners. Default 1.0 =
+        # no effect. Lives here rather than on MFNetwork because StructuredSexual
+        # (MF + SW combined) is the only consumer.
+        self.define_pars(fsw_mf_conc_mult=1.0)
         self.define_states(*_sw_states())
         self.edge_types['sw'] = max(self.edge_types.values()) + 1
         # Apply user pars/kwargs against the full pars dict
@@ -59,8 +64,10 @@ class StructuredSexual(MFNetwork):
     def set_network_states(self, upper_age=None):
         super().set_network_states(upper_age=upper_age)
         self.set_sex_work(upper_age=upper_age)
-        # Apply FSW-specific MF concurrency multiplier post-hoc, now that
-        # self.fsw is populated. No-op at default 1.0.
+        # Scale FSW agents' MF (non-sex-work) concurrency, now that self.fsw is
+        # populated. This affects only sex workers' non-commercial partnerships;
+        # their sex-work edges come from SWNetwork.add_pairs and are untouched.
+        # No-op at default 1.0.
         mult = self.pars.fsw_mf_conc_mult
         if mult != 1.0:
             fsw_uids = self.fsw.uids

--- a/stisim/networks/layered_networks.py
+++ b/stisim/networks/layered_networks.py
@@ -59,6 +59,14 @@ class StructuredSexual(MFNetwork):
     def set_network_states(self, upper_age=None):
         super().set_network_states(upper_age=upper_age)
         self.set_sex_work(upper_age=upper_age)
+        # Apply FSW-specific MF concurrency multiplier post-hoc, now that
+        # self.fsw is populated. No-op at default 1.0.
+        mult = self.pars.fsw_mf_conc_mult
+        if mult != 1.0:
+            fsw_uids = self.fsw.uids
+            if len(fsw_uids) > 0:
+                scaled = np.maximum(1, np.round(self.concurrency[fsw_uids] * mult)).astype(int)
+                self.concurrency[fsw_uids] = scaled
         return
 
     def add_pairs(self):

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -60,9 +60,6 @@ class MFPars(ss.Pars):
         self.m0_conc = 0.0001
         self.m1_conc = 0.2
         self.m2_conc = 0.5
-        # Multiplier on FSW concurrency: values <1 mean that active sex workers
-        # have fewer non-sex-work partners. Default 1.0 = no effect.
-        self.fsw_mf_conc_mult = 1.0
 
         # Relationship initiation, stability, and duration
         self.p_pair_form = ss.bernoulli(p=0.5)              # Probability of a (stable) pair forming between two matched people
@@ -217,6 +214,13 @@ class MFNetwork(BaseNetwork):
         # StructuredSexual.set_network_states post-hoc, because set_sex_work
         # populates self.fsw AFTER set_concurrency runs in the MF flow.
 
+        # `mu` is the target *mean* concurrency, but the two supported dists
+        # are parameterized differently: ss.poisson takes the mean directly as
+        # `lam`, whereas ss.nbinom takes (n, p) and must be reparameterized from
+        # the mean at fixed dispersion n via p = n/(n+mu). Calling .set(lam=...)
+        # on an nbinom is silently ignored (it has no `lam` parameter), so we
+        # branch on the dist type to avoid a no-op that would leave the dist at
+        # its construction default.
         dist = self.pars.concurrency_dist
         if isinstance(dist, ss.nbinom):
             n = dist.pars['n']

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -60,10 +60,8 @@ class MFPars(ss.Pars):
         self.m0_conc = 0.0001
         self.m1_conc = 0.2
         self.m2_conc = 0.5
-        # Multiplier applied to FSW's MF concurrency (non-commercial
-        # partnerships). Default 1.0 = no effect. Used on networks that
-        # combine MF + SW (e.g. StructuredSexual); ignored when the network
-        # doesn't expose a `fsw` boolean.
+        # Multiplier on FSW concurrency: values <1 mean that active sex workers
+        # have fewer non-sex-work partners. Default 1.0 = no effect.
         self.fsw_mf_conc_mult = 1.0
 
         # Relationship initiation, stability, and duration

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -199,7 +199,7 @@ class MFNetwork(BaseNetwork):
         in_age_lim = (people.age < upper_age)
         uids = in_age_lim.uids
 
-        lam = np.full(uids.shape, fill_value=np.nan, dtype=ss_float)
+        mu = np.full(uids.shape, fill_value=np.nan, dtype=ss_float)
         for rg in range(self.pars.n_risk_groups):
             f_conc = self.pars[f'f{rg}_conc']
             m_conc = self.pars[f'm{rg}_conc']
@@ -207,11 +207,17 @@ class MFNetwork(BaseNetwork):
             in_group = in_risk_group & in_age_lim
             f_in = (people.female & in_group)[uids]
             m_in = (people.male   & in_group)[uids]
-            if f_in.any(): lam[f_in] = f_conc
-            if m_in.any(): lam[m_in] = m_conc
+            if f_in.any(): mu[f_in] = f_conc
+            if m_in.any(): mu[m_in] = m_conc
 
-        self.pars.concurrency_dist.set(lam=lam)
-        self.concurrency[uids] = self.pars.concurrency_dist.rvs(uids) + 1
+        dist = self.pars.concurrency_dist
+        if isinstance(dist, ss.nbinom):
+            n = dist.pars['n']
+            p = n / (n + mu)
+            dist.set(n=n, p=p)
+        else:
+            dist.set(lam=mu)
+        self.concurrency[uids] = dist.rvs(uids) + 1
 
         return
 

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -60,6 +60,11 @@ class MFPars(ss.Pars):
         self.m0_conc = 0.0001
         self.m1_conc = 0.2
         self.m2_conc = 0.5
+        # Multiplier applied to FSW's MF concurrency (non-commercial
+        # partnerships). Default 1.0 = no effect. Used on networks that
+        # combine MF + SW (e.g. StructuredSexual); ignored when the network
+        # doesn't expose a `fsw` boolean.
+        self.fsw_mf_conc_mult = 1.0
 
         # Relationship initiation, stability, and duration
         self.p_pair_form = ss.bernoulli(p=0.5)              # Probability of a (stable) pair forming between two matched people
@@ -209,6 +214,10 @@ class MFNetwork(BaseNetwork):
             m_in = (people.male   & in_group)[uids]
             if f_in.any(): mu[f_in] = f_conc
             if m_in.any(): mu[m_in] = m_conc
+
+        # Note: the FSW-specific multiplier (fsw_mf_conc_mult) is applied in
+        # StructuredSexual.set_network_states post-hoc, because set_sex_work
+        # populates self.fsw AFTER set_concurrency runs in the MF flow.
 
         dist = self.pars.concurrency_dist
         if isinstance(dist, ss.nbinom):


### PR DESCRIPTION
Syphilis serology dynamics for survey-comparable prevalence, plus two network concurrency knobs that emerged during the Zimbabwe STI calibration.

## Syphilis

- **Treponemal / non-treponemal states.** New `trep` (treponemal RDT positive) and `nontrep` (RPR/VDRL positive) `BoolState`s with realistic dynamics: ~3-week window period before seroconversion, 80% lifelong trep persistence (20% sero-revert), non-trep titre rise at secondary, decline through late latent, and reversion after early-stage treatment. `SyphTx` schedules post-treatment non-trep reversion and clears window-period trep seroconversion.
- **Results.** `trep_prevalence` and `nontrep_prevalence` (overall, by sex, by age×sex), plus disease-stage prevalences: `sexually_transmissible` (primary | secondary | early latent), `symptomatic` (primary | secondary), and `primary`.
- **State consolidation.** Renamed the old `symptomatic` property → `visibly_symptomatic` (a care-seeking concept: requires a visible chancre/rash), and consolidated the duplicative `active` property into `symptomatic`. `active_prevalence` removed; connectors (`hiv_sti`, `gud_syph`) and `SyphilisPlaceholder` now use `symptomatic`.
- **Configurable denominator.** The prevalence denominator (sexually-active adults in an age band) now reads `age_range`, exposed on `BaseSTI`. Set `age_range=[15, 65]` for a 15–64 household-survey denominator — this replaces the earlier hardcoded `*_prevalence_15_64` result variants.
- `dur_early` default 22–24 months (WHO Europe early-latent boundary); latent `rel_trans` decays from the secondary-stage level.

## Network

- `fsw_mf_conc_mult`: scales FSW non-sex-work (MF) concurrency; values <1 mean active sex workers have fewer non-sex-work partners. Default 1.0 = no effect.
- NB-aware per-risk-group concurrency assignment — previously only `lam` was set, which silently no-oped when `concurrency_dist` was `ss.nbinom`.

## Notes

- New RNG draws shift the seeded sequence; downstream calibration runs should re-baseline.
