### PR TITLE
PartnerNotification stratification + cycle prevention; MF coital-decay & client multiplier

### DIFF
--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -2,6 +2,8 @@
 Define interventions for STIsim
 """
 
+from collections import defaultdict
+
 import starsim as ss
 import numpy as np
 import sciris as sc
@@ -11,7 +13,7 @@ from stisim.utils import count
 
 
 # %% Base classes
-__all__ = ["STIDx", "STITest", "SymptomaticTesting", "SyndromicManagement", "ANCTest", "STITreatment", "PartnerNotification", "ProductMix"]
+__all__ = ["STIDx", "STITest", "SymptomaticTesting", "SyndromicManagement", "ANCTest", "STITreatment", "PartnerNotification", "ProductMix", "pn_rates"]
 
 
 class STIDx(ss.Product):
@@ -1133,17 +1135,51 @@ class PartnerNotification(ss.Intervention):
         partners = partners[~np.isin(partners, index_uids)]
         return ss.uids(partners)
 
+    def _build_partner_edges(self, nw, index_uids):
+        """Return dict {partner_uid: [edge_type_int, ...]} for current-channel
+        edges where one endpoint is an index case. Edges that connect two
+        index cases are excluded — index cases are not notified about
+        themselves.
+
+        Edge-type info is exposed via ``self.current_partner_edges`` so that
+        callables passed to ``p_notify_current.p`` / ``p_attends_current.p``
+        can return per-UID probabilities stratified by edge type (see the
+        :func:`stisim.pn_rates` helper).
+        """
+        in_p1 = np.isin(nw.p1, index_uids)
+        in_p2 = np.isin(nw.p2, index_uids)
+        partner_uids = np.concatenate([nw.p2[in_p1], nw.p1[in_p2]])
+        edge_types = np.concatenate([nw.edges.edge_type[in_p1],
+                                     nw.edges.edge_type[in_p2]])
+        # Drop index-from-index edges
+        keep = ~np.isin(partner_uids, index_uids)
+        partner_uids = partner_uids[keep]
+        edge_types = edge_types[keep]
+
+        partner_edges = defaultdict(list)
+        for uid, et in zip(partner_uids, edge_types):
+            partner_edges[int(uid)].append(int(et))
+        return partner_edges
+
     def step(self):
         index_uids = self.eligibility(self.sim)
         if len(index_uids) == 0:
             return
 
-        # Current-partner channel
-        cur_partners = self.find_partners(self._cur_nw, index_uids)
+        # Current-partner channel: walk edges, group edge_types by partner uid.
+        # Callables on p_notify_current.p / p_attends_current.p can read
+        # `self.current_partner_edges` to stratify by edge type.
+        self.current_partner_edges = self._build_partner_edges(self._cur_nw, index_uids)
+        cur_partners = ss.uids(np.array(sorted(self.current_partner_edges.keys()),
+                                        dtype=ss.dtypes.int)) if self.current_partner_edges else ss.uids()
+
         cur_notified = self.pars.p_notify_current.filter(cur_partners)
         cur_attending = self.pars.p_attends_current.filter(cur_notified)
 
-        # Prior-partner channel (skip partners already notified as current)
+        # Prior-partner channel (skip partners already notified as current).
+        # Edge-type stratification is not currently supported for the prior
+        # channel; pn_rates helpers passed here would see an empty
+        # current_partner_edges and return zeros.
         if self._use_previous:
             prev_partners = self.find_partners(self._prev_nw, index_uids)
             prev_partners = ss.uids(prev_partners[~np.isin(prev_partners, cur_partners)])
@@ -1165,6 +1201,88 @@ class PartnerNotification(ss.Intervention):
         self.results['new_notified'][ti] = len(cur_notified) + len(prev_notified)
         self.results['new_attending'][ti] = len(all_attending)
         return
+
+
+def pn_rates(rates):
+    """
+    Build a per-UID probability callable for :class:`PartnerNotification`.
+
+    Stratifies notification or attendance rates by partnership edge type
+    (and optionally partner sex). The returned callable is suitable as the
+    ``p`` argument of ``ss.bernoulli`` passed as ``p_notify_current`` or
+    ``p_attends_current`` on a ``PartnerNotification`` instance.
+
+    Args:
+        rates: dict mapping edge-type name to a probability OR to a per-sex
+            dict. Two supported shapes:
+
+            - ``{edge_name: prob}`` — notification or attendance rate that
+              does not depend on partner sex. Example::
+
+                  {'stable': 0.20, 'casual': 0.10}
+
+            - ``{edge_name: {'f': prob, 'm': prob}}`` — rate that depends
+              on partner sex. Example::
+
+                  {'stable': {'f': 0.80, 'm': 0.50},
+                   'casual': {'f': 0.50, 'm': 0.25}}
+
+            Edge names must match the active network's
+            ``edge_types`` keys. Edges whose type is not in ``rates`` get
+            probability 0.
+
+    Returns:
+        callable f(module, sim, uids) -> ndarray of probabilities, one per
+        UID. If a partner is reachable via multiple current-channel edges
+        (e.g. notified by two distinct index cases on the same step), the
+        per-edge probabilities are **summed and capped at 1**.
+
+    The callable looks up ``module.current_partner_edges``, populated by
+    ``PartnerNotification.step()``. It returns zeros if that mapping is
+    empty (e.g. when called from the previous-partner channel).
+    """
+    # Detect format from a sample value
+    sample = next(iter(rates.values()), None)
+    sex_dependent = isinstance(sample, dict)
+    if sex_dependent:
+        for k, v in rates.items():
+            if not isinstance(v, dict):
+                raise ValueError(
+                    f"pn_rates: inconsistent rates spec; key '{k}' has "
+                    f"non-dict value while another key is a dict."
+                )
+
+    def func(module, sim, uids):
+        partner_edges = getattr(module, 'current_partner_edges', None) or {}
+        if not partner_edges:
+            return np.zeros(len(uids))
+        # Resolve edge_type int -> name once per call.
+        nw = module._cur_nw
+        int_to_name = {int(v): k for k, v in nw.edge_types.items()}
+        if sex_dependent:
+            female = sim.people.female
+        out = np.zeros(len(uids))
+        for i, u in enumerate(uids):
+            uid = int(u)
+            edge_types = partner_edges.get(uid, ())
+            if not edge_types:
+                continue
+            total = 0.0
+            if sex_dependent:
+                sex_key = 'f' if female[uid] else 'm'
+            for et in edge_types:
+                name = int_to_name.get(int(et))
+                if name is None or name not in rates:
+                    continue
+                spec = rates[name]
+                if sex_dependent:
+                    total += float(spec.get(sex_key, 0.0))
+                else:
+                    total += float(spec)
+            out[i] = min(total, 1.0)
+        return out
+
+    return func
 
 
 class ProductMix(ss.Product):

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -1006,10 +1006,10 @@ class STITreatment(ss.Intervention):
 
 class PartnerNotification(ss.Intervention):
     """
-    Notify and follow up sexual partners of index cases.
+    Notify and follow up contacts of index cases.
 
-    Each timestep, eligible index cases (e.g. newly diagnosed agents) have their
-    partners identified across two channels:
+    Each timestep, eligible index cases (e.g. newly diagnosed agents) have
+    their contacts identified across two channels:
 
     - **Current partners**: edges in the active sexual network.
     - **Previous partners**: edges in a :class:`stisim.PriorPartners` recall
@@ -1018,15 +1018,46 @@ class PartnerNotification(ss.Intervention):
     Each contact is offered notification with probability ``p_notify_<scope>``;
     notified contacts attend follow-up with probability ``p_attends_<scope>``.
     Attendees are scheduled for the supplied ``test`` intervention on the next
-    timestep. Index cases are not notified about themselves; partners reachable
-    via both channels are not double-notified.
+    timestep. Index cases are not notified about themselves; contacts
+    reachable via both channels are not double-notified.
+
+    **Cycle prevention.** Default behaviour blocks A→B→A back-notification.
+    When agent ``A`` attends as a contact of index ``B``, ``last_notifier[A]``
+    is set to ``B``. On a later step where ``A`` becomes an index, the
+    ``(A, partner=B)`` edge is dropped (``B`` was the agent who originally
+    notified ``A`` — re-notifying them would be a redundant cycle). Set
+    ``prevent_cycles=False`` to disable.
+
+    **Diagnostic results.** If ``diseases`` is set (a list of disease module
+    names that count as "STI" for this notification cascade), a
+    ``new_attended_no_sti`` result is added: attendees who at the moment of
+    attendance had none of the listed diseases. If ``index_treatments`` is
+    also set (a list of STITreatment intervention names that, when applied
+    to an agent, make that agent an index case), a ``new_index_no_sti``
+    result is added: index cases who at the moment of treatment had none of
+    the listed diseases — i.e. all their triggering treatments were
+    over-treatment.
 
     Args:
         eligibility: Callable ``f(sim) -> uids`` returning index cases (e.g.
             agents who just tested positive).
-        test: Test intervention to schedule for attending partners. Optional
+        test: Test intervention to schedule for attending contacts. Optional
             — subclasses overriding :meth:`notify_attendees` may set this to
             ``None``.
+        prevent_cycles: If True (default), block A→B→A back-notification by
+            tracking ``last_notifier`` per agent and dropping
+            ``(index, partner)`` edges where ``last_notifier[index] ==
+            partner``. Set False for the legacy "no memory" behaviour.
+        diseases: Optional list of disease module names (e.g.
+            ``['ng', 'ct', 'tv', 'syph']``) that count as "STI" for the
+            ``new_attended_no_sti`` and ``new_index_no_sti`` diagnostic
+            results. If None, those results are not added.
+        index_treatments: Optional list of STITreatment intervention names
+            (e.g. ``['ng_tx', 'ct_tx', 'metronidazole', 'syph_tx']``) that,
+            when applied to an agent, make them an index case for this PN.
+            Used to compute the ``new_index_no_sti`` diagnostic by reading
+            ``tx.outcomes[disease].(successful|unsuccessful|unnecessary)``.
+            Requires ``diseases`` to also be set.
         pars: Optional dict of parameter overrides.
         **kwargs: Forwarded to ``ss.Intervention``.
 
@@ -1049,10 +1080,15 @@ class PartnerNotification(ss.Intervention):
           have ``recall_prior=True`` so dissolved partnerships are pushed to
           ``PriorPartners``.
         - For more elaborate downstream actions (e.g. setting treatment
-          eligibility per partnership), subclass and override :meth:`step`.
+          eligibility per partnership), subclass and override
+          :meth:`notify_attendees`.
+        - Cycle prevention applies to the current-partner channel only.
     """
 
-    def __init__(self, eligibility, test=None, pars=None, **kwargs):
+    def __init__(self, eligibility, test=None, pars=None,
+                 prevent_cycles=True,
+                 diseases=None, index_treatments=None,
+                 **kwargs):
         super().__init__()
         self.define_pars(
             p_notify_current=ss.bernoulli(p=0.5),
@@ -1066,9 +1102,28 @@ class PartnerNotification(ss.Intervention):
         self.eligibility = eligibility
         self.test = test
 
-        self.define_states(
-            ss.FloatArr('ti_notified'),
-        )
+        self.prevent_cycles = bool(prevent_cycles)
+        self.diseases = list(diseases) if diseases else None
+        self.index_treatments = list(index_treatments) if index_treatments else None
+        if self.index_treatments and not self.diseases:
+            raise ValueError(
+                'PartnerNotification: index_treatments requires diseases '
+                'to also be set (to know which disease keys to read out of '
+                'tx.outcomes).'
+            )
+
+        # Per-edge arrays from _build_partner_edges, stashed for use in
+        # step() (last_notifier update). Reset each step.
+        self._last_index_per_edge = None
+        self._last_partner_per_edge = None
+
+        states = [ss.FloatArr('ti_notified')]
+        if self.prevent_cycles:
+            states.append(
+                ss.FloatArr('last_notifier', default=np.nan,
+                            label='UID of agent who most recently notified this agent'),
+            )
+        self.define_states(*states)
         self._cur_nw = None
         self._prev_nw = None
         self._use_previous = False
@@ -1095,12 +1150,25 @@ class PartnerNotification(ss.Intervention):
 
     def init_results(self):
         super().init_results()
-        self.define_results(
-            ss.Result('new_notified', dtype=int, label='Partners notified'),
-            ss.Result('new_attending', dtype=int, label='Partners attending'),
+        results = [
+            ss.Result('new_notified', dtype=int, label='Contacts notified'),
+            ss.Result('new_attending', dtype=int, label='Contacts attending'),
             ss.Result('new_notified_current', dtype=int, label='Current partners notified', auto_plot=False),
             ss.Result('new_notified_previous', dtype=int, label='Prior partners notified', auto_plot=False),
-        )
+        ]
+        if self.diseases:
+            results.append(
+                ss.Result('new_attended_no_sti', dtype=int,
+                          label='Attendees with no current STI',
+                          auto_plot=False),
+            )
+        if self.index_treatments:
+            results.append(
+                ss.Result('new_index_no_sti', dtype=int,
+                          label='Index cases whose triggering treatment was unnecessary',
+                          auto_plot=False),
+            )
+        self.define_results(*results)
         return
 
     def notify_attendees(self, uids):
@@ -1137,33 +1205,54 @@ class PartnerNotification(ss.Intervention):
 
     def _build_partner_edges(self, nw, index_uids):
         """Return dict {partner_uid: [edge_type_int, ...]} for current-channel
-        edges where one endpoint is an index case. Edges that connect two
-        index cases are excluded — index cases are not notified about
+        edges where exactly one endpoint is an index case. Edges that connect
+        two index cases are excluded — index cases are not notified about
         themselves.
 
         Edge-type info is exposed via ``self.current_partner_edges`` so that
         callables passed to ``p_notify_current.p`` / ``p_attends_current.p``
         can return per-UID probabilities stratified by edge type (see the
         :func:`stisim.pn_rates` helper).
+
+        When ``prevent_cycles=True``, the per-pair filter drops
+        ``(index, partner)`` edges where ``last_notifier[index] == partner``
+        — i.e. the partner was the agent who originally notified this index,
+        so back-notifying them would close an A→B→A cycle. Per-edge
+        ``(index, partner)`` arrays are stashed on ``self`` for
+        :meth:`step` to use when updating ``last_notifier``.
         """
-        in_p1 = np.isin(nw.p1, index_uids)
-        in_p2 = np.isin(nw.p2, index_uids)
-        partner_uids = np.concatenate([nw.p2[in_p1], nw.p1[in_p2]])
-        edge_types = np.concatenate([nw.edges.edge_type[in_p1],
-                                     nw.edges.edge_type[in_p2]])
-        # Drop index-from-index edges
-        keep = ~np.isin(partner_uids, index_uids)
-        partner_uids = partner_uids[keep]
-        edge_types = edge_types[keep]
+        p1_is_index = np.isin(nw.p1, index_uids)
+        p2_is_index = np.isin(nw.p2, index_uids)
+        # XOR — exactly one endpoint is an index. Automatically drops
+        # both-index edges (no need for a separate ~isin filter).
+        candidate = p1_is_index ^ p2_is_index
+        partner_per_edge = np.where(p1_is_index, nw.p2, nw.p1)[candidate]
+        index_per_edge   = np.where(p1_is_index, nw.p1, nw.p2)[candidate]
+        edge_types       = nw.edges.edge_type[candidate]
+
+        # Cycle prevention: drop (I, P) edges where P was the last
+        # notifier of I.
+        if self.prevent_cycles and len(partner_per_edge):
+            ln_of_index = self.last_notifier[ss.uids(index_per_edge)]
+            keep = np.isnan(ln_of_index) | (ln_of_index != partner_per_edge.astype(float))
+            partner_per_edge = partner_per_edge[keep]
+            index_per_edge   = index_per_edge[keep]
+            edge_types       = edge_types[keep]
+
+        # Stash per-edge arrays for last_notifier update in step()
+        self._last_partner_per_edge = ss.uids(partner_per_edge)
+        self._last_index_per_edge   = ss.uids(index_per_edge)
 
         partner_edges = defaultdict(list)
-        for uid, et in zip(partner_uids, edge_types):
+        for uid, et in zip(partner_per_edge, edge_types):
             partner_edges[int(uid)].append(int(et))
         return partner_edges
 
     def step(self):
         index_uids = self.eligibility(self.sim)
         if len(index_uids) == 0:
+            self._last_partner_per_edge = None
+            self._last_index_per_edge = None
             return
 
         # Current-partner channel: walk edges, group edge_types by partner uid.
@@ -1192,6 +1281,31 @@ class PartnerNotification(ss.Intervention):
         all_attending = cur_attending | prev_attending
         if len(all_attending):
             self.ti_notified[all_attending] = self.ti
+
+            # Cycle prevention bookkeeping: for each attendee in the
+            # current-partner channel, record which index notified them.
+            # Uses the per-edge arrays stashed by _build_partner_edges.
+            # When multiple indices share an edge with the same attendee,
+            # the first (in sorted order) wins — semantics: "an index who
+            # could have notified you in this step".
+            if self.prevent_cycles and len(cur_attending) and \
+                    self._last_partner_per_edge is not None and \
+                    len(self._last_partner_per_edge):
+                partners = self._last_partner_per_edge.view(np.ndarray)
+                indices  = self._last_index_per_edge.view(np.ndarray)
+                order    = np.argsort(partners, kind='stable')
+                p_sorted = partners[order]
+                i_sorted = indices[order]
+                first = np.searchsorted(p_sorted, cur_attending, side='left')
+                in_range = first < len(p_sorted)
+                if in_range.any():
+                    safe = np.clip(first, 0, len(p_sorted) - 1)
+                    match = (p_sorted[safe] == cur_attending) & in_range
+                    if match.any():
+                        atts = cur_attending[match]
+                        notifier = i_sorted[first[match]]
+                        self.last_notifier[atts] = notifier.astype(float)
+
             self.notify_attendees(all_attending)
 
         # Record
@@ -1200,7 +1314,72 @@ class PartnerNotification(ss.Intervention):
         self.results['new_notified_previous'][ti] = len(prev_notified)
         self.results['new_notified'][ti] = len(cur_notified) + len(prev_notified)
         self.results['new_attending'][ti] = len(all_attending)
+
+        # --- Diagnostic results (opt-in via `diseases` / `index_treatments`) ---
+        if self.diseases and len(all_attending):
+            no_sti = self._attendees_with_no_sti(all_attending)
+            self.results['new_attended_no_sti'][ti] = no_sti
+
+        if self.index_treatments:
+            self.results['new_index_no_sti'][ti] = self._false_alarm_index_count()
+
+        # Reset per-edge stash
+        self._last_partner_per_edge = None
+        self._last_index_per_edge = None
         return
+
+    def _attendees_with_no_sti(self, attending):
+        """Count attendees with none of ``self.diseases`` infected right
+        now. Read directly from each disease module's ``infected``
+        attribute."""
+        if not self.diseases or not len(attending):
+            return 0
+        diseases = self.sim.diseases
+        any_inf = None
+        for dname in self.diseases:
+            d = diseases.get(dname)
+            if d is None:
+                continue
+            arr = d.infected[attending]
+            any_inf = arr if any_inf is None else (any_inf | arr)
+        if any_inf is None:
+            return 0
+        return int((~any_inf).sum())
+
+    def _false_alarm_index_count(self):
+        """Count index cases (agents whose ``index_treatments`` fired this
+        step) who had none of ``self.diseases`` at the moment of
+        treatment.
+
+        An agent appears in ``treated_any`` iff at least one of their
+        ``index_treatments`` recorded them in
+        ``outcomes[d].(successful | unsuccessful | unnecessary)`` for some
+        ``d in self.diseases``. They appear in ``had_sti`` iff at least one
+        treatment recorded them in
+        ``outcomes[d].(successful | unsuccessful)`` for some ``d`` —
+        meaning the agent was actually treatable for that disease.
+        False alarm = ``treated_any \\ had_sti``.
+        """
+        had_sti = ss.uids()
+        treated_any = ss.uids()
+        targets = set(self.diseases or ())
+        for tx_name in self.index_treatments:
+            tx = self.sim.interventions.get(tx_name)
+            if tx is None:
+                continue
+            outcomes = getattr(tx, 'outcomes', None)
+            if outcomes is None:
+                continue
+            for key, val in outcomes.items():
+                if key not in targets or not hasattr(val, 'get'):
+                    continue
+                succ   = val.get('successful',   ss.uids())
+                unsucc = val.get('unsuccessful', ss.uids())
+                unnec  = val.get('unnecessary',  ss.uids())
+                had_sti      = had_sti      | succ | unsucc
+                treated_any  = treated_any  | succ | unsucc | unnec
+        false_alarm = treated_any - had_sti
+        return int(len(false_alarm))
 
 
 def pn_rates(rates):

--- a/stisim/networks/base.py
+++ b/stisim/networks/base.py
@@ -65,6 +65,12 @@ class BaseNetwork(ss.SexualNetwork):
         self.meta.age_p1 = ss_float
         self.meta.age_p2 = ss_float
         self.meta.edge_type = ss_float
+        # acts_baseline preserves the per-edge act count assigned at edge
+        # formation; per-step `acts` may be a decayed multiple of it
+        # (see ``update_acts``). start_ti is the timestep when the edge
+        # was created — used to compute edge age for the decay.
+        self.meta.acts_baseline = ss_float
+        self.meta.start_ti = ss_int
         self.define_pars(**BasePars())
         self.define_states(
             ss.BoolArr('participant', default=True),
@@ -150,7 +156,33 @@ class BaseNetwork(ss.SexualNetwork):
         self.set_network_states(upper_age=self.t.dt_year)
         self.add_pairs()
         self.set_condom_use()
+        self.update_acts()
         return
+
+    def update_acts(self):
+        """Per-step recompute of per-edge ``acts`` from ``acts_baseline``
+        and any per-edge multiplier returned by ``_compute_act_multiplier``.
+        No-op at default parameters (multiplier = 1.0 for all edges).
+        Subclasses override ``_compute_act_multiplier`` to inject custom
+        per-edge modifiers (e.g. stable-edge coital decay, client-husband
+        displacement).
+        """
+        if len(self.edges.acts) == 0:
+            return
+        mult = self._compute_act_multiplier()
+        if mult is None:
+            return
+        out = np.round(self.edges.acts_baseline * mult)
+        self.edges.acts[:] = out.astype(self.edges.acts.dtype)
+        return
+
+    def _compute_act_multiplier(self):
+        """Return a per-edge float array of multipliers on ``acts_baseline``,
+        or ``None`` to skip the update (default — backwards compatible).
+        Subclasses override to apply duration-based decay, partner-status
+        modifiers, etc.
+        """
+        return None
 
     def add_pairs(self):
         """Subclasses override."""

--- a/stisim/networks/fsw.py
+++ b/stisim/networks/fsw.py
@@ -5,7 +5,7 @@ for discoverability.
 """
 import numpy as np
 import starsim as ss
-from .base import BaseNetwork, NoPartnersFound, ss_float
+from .base import BaseNetwork, NoPartnersFound, ss_float, ss_int
 
 __all__ = ['SWPars', 'SWNetwork']
 
@@ -48,6 +48,14 @@ class SWPars(ss.Pars):
         self.sw_seeking_dist = ss.bernoulli(p=0.5)     # Placeholder; replaced by dt-adjusted sw_seeking_rate
         self.sw_beta = 1
         self.sw_intensity = ss.random()                # FSW may work with varying intensity each step
+
+        # Multiplier applied to STABLE-edge per-step acts when the male
+        # partner (p1) is a client of an FSW. Captures the "wife
+        # displacement" effect — extramarital activity often substitutes
+        # for marital activity. Default 1.0 = no effect. Applied on
+        # networks that combine MF + SW (e.g. StructuredSexual); ignored
+        # by bare SWNetwork (its only edge type is sw, not stable).
+        self.client_marital_act_mult = 1.0
 
         # Per-agent age window — placeholders; tune to context
         self.age_sw_start = ss.normal(loc=20, scale=3)
@@ -219,7 +227,10 @@ class SWNetwork(BaseNetwork):
         age_p2 = ppl.age[p2]
         edge_types = np.full(match_count, dtype=ss_float, fill_value=self.edge_types['sw'])
 
-        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
+        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur,
+                    acts=acts, acts_baseline=acts.astype(ss_float),
+                    start_ti=np.full(match_count, self.ti, dtype=ss_int),
+                    age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
 
         p1_edges, p1_counts = np.unique(p1, return_counts=True)
         p2_edges, p2_counts = np.unique(p2, return_counts=True)

--- a/stisim/networks/layered_networks.py
+++ b/stisim/networks/layered_networks.py
@@ -74,6 +74,28 @@ class StructuredSexual(MFNetwork):
         SWNetwork.add_pairs(self)
         return
 
+    def _compute_act_multiplier(self):
+        """Compose MFNetwork's stable-edge decay with a client-husband
+        marital multiplier. Returns ``None`` only if BOTH knobs are
+        no-ops (preserves backwards compatibility).
+        """
+        mult = MFNetwork._compute_act_multiplier(self)
+        client_mult = self.pars.client_marital_act_mult
+        if mult is None and client_mult == 1.0:
+            return None
+        if mult is None:
+            mult = np.ones(len(self.edges.acts_baseline), dtype=ss_float)
+        if client_mult != 1.0 and 'stable' in self.edge_types:
+            is_stable = self.edges.edge_type == self.edge_types['stable']
+            if is_stable.any():
+                # client is a property of male agents (p1); intersect with
+                # stable edges so casual / onetime / sw edges are untouched
+                p1_uids = ss.uids(self.edges.p1[is_stable])
+                client_husbands = self.client[p1_uids]
+                ix = np.where(is_stable)[0][client_husbands]
+                mult[ix] *= client_mult
+        return mult
+
     # end_pairs and set_condom_use inherited from BaseNetwork. _decrement_partners
     # (in MFNetwork) skips SW edges via the ``'sw' in self.edge_types`` check;
     # set_condom_use's per-key dispatch handles ``(rgm, rgf)`` and ``('fsw','client')``

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -4,7 +4,7 @@ import starsim as ss
 from collections import defaultdict
 from bisect import bisect_left
 
-from .base import BaseNetwork, NoPartnersFound, ss_float
+from .base import BaseNetwork, NoPartnersFound, ss_float, ss_int
 
 __all__ = ['MFPars', 'MFNetwork']
 
@@ -63,6 +63,15 @@ class MFPars(ss.Pars):
         # Multiplier on FSW concurrency: values <1 mean that active sex workers
         # have fewer non-sex-work partners. Default 1.0 = no effect.
         self.fsw_mf_conc_mult = 1.0
+
+        # Stable-edge coital-frequency decay: linear in edge age (years),
+        # floored. Acts on edges with edge_type == stable. Default 0.0
+        # = no decay = backwards compatible. Empirically, monthly coital
+        # frequency in long-running couples is ~50% of newlywed baseline
+        # by year 5-7 (DHS / Demographic Health Surveys), suggesting
+        # stable_act_decay ≈ 0.07-0.10 / yr with a floor near 0.4.
+        self.stable_act_decay = 0.0
+        self.stable_act_floor = 0.3
 
         # Relationship initiation, stability, and duration
         self.p_pair_form = ss.bernoulli(p=0.5)              # Probability of a (stable) pair forming between two matched people
@@ -318,7 +327,10 @@ class MFNetwork(BaseNetwork):
             pair = (min(a,b), max(a,b))
             self.relationship_durs[pair].append({'start': self.ti, 'dur': reldur, 'edge_type': int(etype)}) # set dur to intended duration. When the relationship actually ends, this will be updated
 
-        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
+        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur,
+                    acts=acts, acts_baseline=acts.astype(ss_float),
+                    start_ti=np.full(match_count, self.ti, dtype=ss_int),
+                    age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
 
         # Checks
         if (self.sim.people.female[p1].any() or self.sim.people.male[p2].any()) and (self.name == 'structuredsexual'):
@@ -342,6 +354,24 @@ class MFNetwork(BaseNetwork):
             getattr(self, f'lifetime_{key}_partners')[p2_edges] += 1
 
         return
+
+    def _compute_act_multiplier(self):
+        """Linear coital decay over stable-edge age. Casual / onetime edges
+        unaffected. Returns ``None`` to skip the per-step update when
+        ``stable_act_decay == 0`` (the default) — preserves backwards
+        compatibility.
+        """
+        decay = self.pars.stable_act_decay
+        if not decay:
+            return None
+        floor = self.pars.stable_act_floor
+        n = len(self.edges.acts_baseline)
+        mult = np.ones(n, dtype=ss_float)
+        is_stable = self.edges.edge_type == self.edge_types['stable']
+        if is_stable.any():
+            age_years = (self.ti - self.edges.start_ti[is_stable]) * self.t.dt_year
+            mult[is_stable] = np.maximum(1.0 - decay * age_years, floor)
+        return mult
 
     def _on_edge_dissolution(self, active):
         """Record dissolved partnerships and decrement partner counts."""


### PR DESCRIPTION
Builds on #500 (`feat/syph-detectable-state`). **Base will retarget to `rc1.5.7` once #500 merges** — this PR's diff is the partner-notification + network delta only.

## PartnerNotification

- **Edge-type / partner-sex stratification.** `step()` walks current-channel edges preserving edge type and exposes `current_partner_edges` (`{partner_uid: [edge_type, ...]}`). New `pn_rates(rates)` helper builds a per-UID probability callable for `p_notify_current` / `p_attends_current`, stratified by edge type and (optionally) partner sex:
  - `pn_rates({'stable': 0.20, 'casual': 0.10})`
  - `pn_rates({'stable': {'f': 0.80, 'm': 0.50}, 'casual': {'f': 0.50, 'm': 0.25}})`

  Partners reachable via multiple current-channel edges have per-edge probabilities summed and capped at 1. Scalar bernoullis are unchanged (backward compatible). Edge-type stratification is current-channel only — the prior channel returns 0.
- **Cycle prevention** (`prevent_cycles=True`, default ON). A per-agent `last_notifier` blocks the A→B→A cycle while still allowing chains A→B→C. Pass `prevent_cycles=False` for the legacy no-memory behaviour.
- **Diagnostic results** (opt-in): `new_attended_no_sti` (attendees with none of the listed `diseases` infected — false-alarm clinic-time cost) and `new_index_no_sti` (indices over-treated — treated via `index_treatments` but not actually infected). `index_treatments` requires `diseases`.

## MFNetwork

- `stable_act_decay` (per year, default 0.0): linear decay of per-step acts on stable edges as the relationship ages, with a floor. Defaults preserve existing behaviour.
- `client_marital_act_mult` (default 1.0): scales stable-edge acts when the male partner is an FSW client (wife-displacement). Applies only on combined MF+SW networks (e.g. `StructuredSexual`).
- New edge meta fields `acts_baseline` / `start_ti` and an `update_acts()` step hook that recomputes per-edge acts. SW commercial edges are unaffected.

## Notes

- New RNG draws shift the seeded sequence — downstream calibration runs should re-baseline.
- `pn_rates` and the two new diagnostic results don't yet have automated test coverage (`test_pn` covers the scalar/backward-compatible path).
