### PR TITLE
Fix MSM network participation filter + init crashes (#496–#499)

### DIFF
--- a/docs/user_guide/networks/msm.md
+++ b/docs/user_guide/networks/msm.md
@@ -9,10 +9,10 @@ STIsim provides two networks for modeling sexual contact between men. Both exten
 
 ## Participation
 
-Both networks expose an `msm_share` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
+Both networks expose an `p_msm` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
 
 ```python
-msm = sti.AgeMatchedMSM(msm_share=ss.bernoulli(p=0.05))  # 5% of males
+msm = sti.AgeMatchedMSM(p_msm=ss.bernoulli(p=0.05))  # 5% of males
 ```
 
 ## Combining with the heterosexual network

--- a/stisim/networks/base.py
+++ b/stisim/networks/base.py
@@ -67,6 +67,10 @@ class BaseNetwork(ss.SexualNetwork):
         self.meta.edge_type = ss_float
         self.define_pars(**BasePars())
         self.define_states(
+            # Whether the agent takes part in this network's partnerships.
+            # Default True (all agents). Subclasses may restrict it in
+            # set_network_states — e.g. the MSM networks flag only the `p_msm`
+            # fraction of males via set_msm(), and gate the pool/matching on it.
             ss.BoolArr('participant', default=True),
             ss.FloatArr('debut', default=0),
             reset=True,

--- a/stisim/networks/msm.py
+++ b/stisim/networks/msm.py
@@ -19,7 +19,7 @@ __all__ = ['AgeMatchedMSM', 'AgeApproxMSM', 'MSMScaleFreeNetwork']
 class AgeMatchedMSM(MFNetwork):
     """Men-who-have-sex-with-men network using exact age-sorted matching.
 
-    Extends :class:`StructuredSexual` for MSM partnerships. Eligible males
+    Extends :class:`MFNetwork` for MSM partnerships. Eligible males
     are sorted by age and paired sequentially so that partners have similar
     ages. The ``msm_share`` parameter controls what fraction of males
     participate.
@@ -40,6 +40,7 @@ class AgeMatchedMSM(MFNetwork):
         return
 
     def set_network_states(self, upper_age=None):
+        super().set_network_states(upper_age=upper_age)  # debut, risk groups, concurrency
         self.set_msm(upper_age=upper_age)
         return
 
@@ -55,7 +56,7 @@ class AgeMatchedMSM(MFNetwork):
         # Find people eligible for a relationship
         active = self.over_debut
         underpartnered = self.partners < self.concurrency
-        m_eligible = active & ppl.male & underpartnered
+        m_eligible = active & ppl.male & underpartnered & self.participant
         m_looking = self.pars.p_pair_form.filter(m_eligible.uids)
 
         if len(m_looking) == 0:
@@ -123,6 +124,7 @@ class MSMScaleFreeNetwork(BaseNetwork):
     def __init__(self, pars=None, name=None, **kwargs):
         super().__init__(name=name)
         self.define_pars(
+            msm_share=ss.bernoulli(p=0.015),  # fraction of males in the MSM pool
             target_mean_degree=2.0,
             target_mean_dur=ss.years(2),
             max_edge_dur=ss.years(10),
@@ -162,6 +164,16 @@ class MSMScaleFreeNetwork(BaseNetwork):
             )
         return
 
+    def set_network_states(self, upper_age=None):
+        super().set_network_states(upper_age=upper_age)  # set debut
+        self.set_msm(upper_age=upper_age)
+        return
+
+    def set_msm(self, upper_age=None):
+        _, m_uids = self._get_uids(upper_age=upper_age)
+        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        return
+
     def _get_rng(self):
         """Step-local numpy Generator. Not CRN — see class docstring."""
         seed = int(self.sim.pars.rand_seed) + 2003 + int(self.ti)
@@ -169,8 +181,8 @@ class MSMScaleFreeNetwork(BaseNetwork):
 
     # ---- Subclass extension points -----------------------------------------
     def _get_pool(self):
-        """Eligible agents the kernel operates on. Default: post-debut males."""
-        return self.over_debut & self.sim.people.male
+        """Eligible agents the kernel operates on. Default: post-debut MSM males."""
+        return self.over_debut & self.sim.people.male & self.participant
 
     def _mix_node_arrays(self):
         """Per-node arrays consumed by ``_mix_weights_row``.
@@ -461,29 +473,49 @@ class MSMScaleFreeNetwork(BaseNetwork):
 class AgeApproxMSM(MFNetwork):
     """Men-who-have-sex-with-men network using approximate age-preference matching.
 
-    Extends :class:`StructuredSexual` for MSM partnerships. Unlike
+    Extends :class:`MFNetwork` for MSM partnerships. Unlike
     :class:`AgeMatchedMSM`, this variant splits eligible males into two
-    arbitrary groups and matches them using the standard age-difference
-    preference distributions rather than exact age sorting.
+    groups and matches them using the standard age-difference preference
+    distributions rather than exact age sorting.
 
     Args:
-        **kwargs: Parameter overrides forwarded to :class:`StructuredSexual`.
+        pars (dict): Parameter overrides; key parameter is ``msm_share``
+            (default ``ss.bernoulli(p=0.015)``).
+        **kwargs: Additional parameter overrides.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(name='msm', **kwargs)
+    def __init__(self, pars=None, **kwargs):
+        super().__init__(name='msm')
+        self.define_pars(
+            msm_share=ss.bernoulli(p=0.015),
+        )
+        self.update_pars(pars=pars, **kwargs)
+        return
 
-    def match_pairs(self, ppl):
+    def set_network_states(self, upper_age=None):
+        super().set_network_states(upper_age=upper_age)  # debut, risk groups, concurrency
+        self.set_msm(upper_age=upper_age)
+        return
+
+    def set_msm(self, upper_age=None):
+        _, m_uids = self._get_uids(upper_age=upper_age)
+        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        return
+
+    def match_pairs(self):
         """ Match pairs using age preferences """
+        ppl = self.sim.people
 
-        # Find people eligible for a relationship
-        active = self.over_debut()
+        # Find males eligible for a relationship
+        active = self.over_debut
         underpartnered = self.partners < self.concurrency
-        m_eligible = active & ppl.male & underpartnered
+        m_eligible = active & ppl.male & underpartnered & self.participant
         m_looking = self.pars.p_pair_form.filter(m_eligible.uids)
+        if len(m_looking) < 2:
+            raise NoPartnersFound()
 
-        # Split the total number of males looking for partners into 2 groups
-        # The first group will be matched with the second group
+        # Split the males looking for partners into two groups, then pair
+        # group1 with group2 by age preference (closest-age matching).
         group1 = m_looking[::2]
         group2 = m_looking[1::2]
         loc, scale = self.get_age_risk_pars(group1, self.pars.age_diff_pars)
@@ -491,12 +523,7 @@ class AgeApproxMSM(MFNetwork):
         age_gaps = self.pars.age_diffs.rvs(group1)
         desired_ages = ppl.age[group1] + age_gaps
         g2_ages = ppl.age[group2]
-        ind_p1 = np.argsort(g2_ages)
-        ind_p2 = np.argsort(desired_ages)
-        p1 = m_eligible.uids[ind_p1]
-        p2 = group2[ind_p2]
+        p1 = group1[np.argsort(desired_ages)]
+        p2 = group2[np.argsort(g2_ages)]
         maxlen = min(len(p1), len(p2))
-        p1 = p1[:maxlen]
-        p2 = p2[:maxlen]
-
-        return p1, p2
+        return p1[:maxlen], p2[:maxlen]

--- a/stisim/networks/msm.py
+++ b/stisim/networks/msm.py
@@ -21,11 +21,11 @@ class AgeMatchedMSM(MFNetwork):
 
     Extends :class:`MFNetwork` for MSM partnerships. Eligible males
     are sorted by age and paired sequentially so that partners have similar
-    ages. The ``msm_share`` parameter controls what fraction of males
+    ages. The ``p_msm`` parameter controls what fraction of males
     participate.
 
     Args:
-        pars (dict): Parameter overrides; key parameter is ``msm_share``
+        pars (dict): Parameter overrides; key parameter is ``p_msm``
             (default ``ss.bernoulli(p=0.015)``).
         **kwargs: Additional parameter overrides.
     """
@@ -33,7 +33,7 @@ class AgeMatchedMSM(MFNetwork):
     def __init__(self, pars=None, **kwargs):
         super().__init__(name='msm')
         self.define_pars(
-            msm_share=ss.bernoulli(p=0.015),
+            p_msm=ss.bernoulli(p=0.015),
         )
         self.update_pars(pars=pars, **kwargs)
 
@@ -45,8 +45,15 @@ class AgeMatchedMSM(MFNetwork):
         return
 
     def set_msm(self, upper_age=None):
+        """Flag the ``p_msm`` fraction of post-debut males as MSM participants.
+
+        Writes the shared ``participant`` state (True for the sampled fraction,
+        False for the rest), which gates the MSM pool/matching. Called from
+        ``set_network_states``, so it runs at init and re-samples for
+        newly-entered males each step.
+        """
         _, m_uids = self._get_uids(upper_age=upper_age)
-        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        self.participant[m_uids] = self.pars.p_msm.rvs(m_uids)
         return
 
     def match_pairs(self):
@@ -124,7 +131,7 @@ class MSMScaleFreeNetwork(BaseNetwork):
     def __init__(self, pars=None, name=None, **kwargs):
         super().__init__(name=name)
         self.define_pars(
-            msm_share=ss.bernoulli(p=0.015),  # fraction of males in the MSM pool
+            p_msm=ss.bernoulli(p=0.015),  # fraction of males in the MSM pool
             target_mean_degree=2.0,
             target_mean_dur=ss.years(2),
             max_edge_dur=ss.years(10),
@@ -170,8 +177,15 @@ class MSMScaleFreeNetwork(BaseNetwork):
         return
 
     def set_msm(self, upper_age=None):
+        """Flag the ``p_msm`` fraction of post-debut males as MSM participants.
+
+        Writes the shared ``participant`` state (True for the sampled fraction,
+        False for the rest), which gates the MSM pool/matching. Called from
+        ``set_network_states``, so it runs at init and re-samples for
+        newly-entered males each step.
+        """
         _, m_uids = self._get_uids(upper_age=upper_age)
-        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        self.participant[m_uids] = self.pars.p_msm.rvs(m_uids)
         return
 
     def _get_rng(self):
@@ -479,7 +493,7 @@ class AgeApproxMSM(MFNetwork):
     distributions rather than exact age sorting.
 
     Args:
-        pars (dict): Parameter overrides; key parameter is ``msm_share``
+        pars (dict): Parameter overrides; key parameter is ``p_msm``
             (default ``ss.bernoulli(p=0.015)``).
         **kwargs: Additional parameter overrides.
     """
@@ -487,7 +501,7 @@ class AgeApproxMSM(MFNetwork):
     def __init__(self, pars=None, **kwargs):
         super().__init__(name='msm')
         self.define_pars(
-            msm_share=ss.bernoulli(p=0.015),
+            p_msm=ss.bernoulli(p=0.015),
         )
         self.update_pars(pars=pars, **kwargs)
         return
@@ -498,8 +512,15 @@ class AgeApproxMSM(MFNetwork):
         return
 
     def set_msm(self, upper_age=None):
+        """Flag the ``p_msm`` fraction of post-debut males as MSM participants.
+
+        Writes the shared ``participant`` state (True for the sampled fraction,
+        False for the rest), which gates the MSM pool/matching. Called from
+        ``set_network_states``, so it runs at init and re-samples for
+        newly-entered males each step.
+        """
         _, m_uids = self._get_uids(upper_age=upper_age)
-        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        self.participant[m_uids] = self.pars.p_msm.rvs(m_uids)
         return
 
     def match_pairs(self):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -14,7 +14,7 @@ def test_msm_network(n_agents=500):
     hiv = sti.HIV(beta_m2m=0.1, init_prev=0.05)
     pregnancy = ss.Pregnancy(fertility_rate=10)
     death = ss.Deaths(death_rate=10)
-    msm = sti.AgeMatchedMSM(msm_share=ss.bernoulli(p=0.3))
+    msm = sti.AgeMatchedMSM(p_msm=ss.bernoulli(p=0.3))
     sim = sti.Sim(
         start=1990,
         dur=10,

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -14,13 +14,13 @@ def test_msm_network(n_agents=500):
     hiv = sti.HIV(beta_m2m=0.1, init_prev=0.05)
     pregnancy = ss.Pregnancy(fertility_rate=10)
     death = ss.Deaths(death_rate=10)
-    msm = sti.AgeMatchedMSM()
+    msm = sti.AgeMatchedMSM(msm_share=ss.bernoulli(p=0.3))
     sim = sti.Sim(
         start=1990,
         dur=10,
         n_agents=n_agents,
         diseases=hiv,
-        networks=msm,
+        networks=[msm],
         demographics=[pregnancy, death],
     )
     sim.run(verbose=1/12)

--- a/tests/test_scalefree_network.py
+++ b/tests/test_scalefree_network.py
@@ -6,9 +6,16 @@ import starsim as ss
 import stisim as sti
 
 
+def _make_net(**kw):
+    """Network with full male participation, so kernel-mechanics tests see the
+    whole post-debut male pool regardless of the default ``msm_share``."""
+    kw.setdefault('msm_share', ss.bernoulli(p=1.0))
+    return sti.MSMScaleFreeNetwork(**kw)
+
+
 def _make_sim(net=None, n_agents=1_000, dur=2, rand_seed=1):
     if net is None:
-        net = sti.MSMScaleFreeNetwork()
+        net = _make_net()
     return sti.Sim(
         diseases=[sti.HIV(init_prev=0.05, beta_m2f=0.05)],
         networks=[net, ss.MaternalNet()],
@@ -20,7 +27,7 @@ def _make_sim(net=None, n_agents=1_000, dur=2, rand_seed=1):
 @sc.timer()
 def test_class_instantiates_with_defaults():
     """Bare instantiation: defaults are set; no sim required."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     assert net.pars.target_mean_degree == 2.0
     assert float(net.pars.phi) == 1.0
     assert net._target_mean_dur_steps is None  # not yet converted
@@ -29,7 +36,7 @@ def test_class_instantiates_with_defaults():
 @sc.timer()
 def test_init_pre_converts_durs_to_steps():
     """After sim init, dur params are converted to integer step counts."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -40,7 +47,7 @@ def test_init_pre_converts_durs_to_steps():
 @sc.timer()
 def test_init_pre_raises_when_max_below_target():
     """``max_edge_dur < target_mean_dur`` is rejected at init."""
-    net = sti.MSMScaleFreeNetwork(target_mean_dur=ss.years(5), max_edge_dur=ss.years(2))
+    net = _make_net(target_mean_dur=ss.years(5), max_edge_dur=ss.years(2))
     sim = _make_sim(net=net)
     with pytest.raises(ValueError, match='max_edge_dur'):
         sim.init()
@@ -49,7 +56,7 @@ def test_init_pre_raises_when_max_below_target():
 @sc.timer()
 def test_get_pool_filters_to_post_debut_males():
     """``_get_pool`` returns only post-debut male agents."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -61,9 +68,22 @@ def test_get_pool_filters_to_post_debut_males():
 
 
 @sc.timer()
+def test_msm_share_filters_pool():
+    """``msm_share`` controls the fraction of post-debut males in the pool."""
+    full = _make_sim(net=_make_net(msm_share=ss.bernoulli(p=1.0)), n_agents=2_000)
+    part = _make_sim(net=sti.MSMScaleFreeNetwork(msm_share=ss.bernoulli(p=0.2)), n_agents=2_000)
+    full.init(); part.init()
+    n_full = full.networks[0]._get_pool().count()
+    n_part = part.networks[0]._get_pool().count()
+    assert n_full > 0, 'full-participation pool is empty — fixture failure'
+    assert 0.1 < n_part / n_full < 0.35, \
+        f'msm_share=0.2 pool fraction {n_part / n_full:.2f} not near 0.2 (full={n_full}, part={n_part})'
+
+
+@sc.timer()
 def test_mix_node_arrays_log1p_deg_invariant():
     """``log1p_deg`` is ``1 + log1p(deg)`` and bounded below by 1.0."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -75,7 +95,7 @@ def test_mix_node_arrays_log1p_deg_invariant():
 @sc.timer()
 def test_mix_weights_row_returns_correct_length():
     """``_mix_weights_row(i, ...)`` returns ``n - 1 - i`` weights."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -91,7 +111,7 @@ def test_mix_weights_row_returns_correct_length():
 @sc.timer()
 def test_build_kernel_populates_artefacts():
     """``_build_kernel`` populates all the caches after init."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     sim_net = sim.networks[0]
@@ -107,7 +127,7 @@ def test_build_kernel_populates_artefacts():
 @sc.timer()
 def test_build_kernel_pair_indices_upper_triangle():
     """``pairs_i < pairs_j`` for every entry (upper triangle only)."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     sim_net = sim.networks[0]
@@ -119,7 +139,7 @@ def test_build_kernel_pair_indices_upper_triangle():
 @sc.timer()
 def test_build_kernel_degenerate_pool_returns_zero():
     """Empty pool produces zero-sized kernel artefacts and n=0."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=100)
     sim.init()
     sim_net = sim.networks[0]
@@ -132,7 +152,7 @@ def test_build_kernel_degenerate_pool_returns_zero():
 @sc.timer()
 def test_sample_pair_index_in_range_and_weighted():
     """``_sample_pair_index`` returns valid indices weighted by sel_w."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     sim_net = sim.networks[0]
@@ -147,7 +167,7 @@ def test_sample_pair_index_in_range_and_weighted():
 @sc.timer()
 def test_sample_pair_index_returns_neg_on_empty_kernel():
     """Empty kernel → sentinel -1 from ``_sample_pair_index``."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=100)
     sim.init()
     sim_net = sim.networks[0]
@@ -163,7 +183,7 @@ def test_sample_pair_index_returns_neg_on_empty_kernel():
 @sc.timer()
 def test_initial_network_q0_non_empty():
     """``init_post`` samples a non-empty initial edge set for a large pool."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=2_000)
     sim.init()
     sim_net = sim.networks[0]
@@ -173,7 +193,7 @@ def test_initial_network_q0_non_empty():
 @sc.timer()
 def test_initial_edges_post_debut_males_only():
     """Every endpoint of every initial edge is a post-debut male."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=2_000)
     sim.init()
     sim_net = sim.networks[0]
@@ -188,7 +208,7 @@ def test_initial_edges_post_debut_males_only():
 @sc.timer()
 def test_max_edge_dur_cap_respected():
     """No edge persists past ``max_edge_dur_steps``."""
-    net = sti.MSMScaleFreeNetwork(max_edge_dur=ss.years(1), target_mean_dur=ss.months(6))
+    net = _make_net(max_edge_dur=ss.years(1), target_mean_dur=ss.months(6))
     sim = _make_sim(net=net, n_agents=1_500, dur=3)
     sim.run()
     sim_net = sim.networks[0]
@@ -201,7 +221,7 @@ def test_max_edge_dur_cap_respected():
 @sc.timer()
 def test_network_initialises_and_steps():
     """End-to-end: a 2yr sim with the new network completes and forms edges."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=2_000, dur=2)
     sim.run()
     sim_net = sim.networks[0]
@@ -215,7 +235,7 @@ def test_network_initialises_and_steps():
 def test_target_mean_degree_honoured():
     """After burn-in, realised mean degree is within ±30% of target."""
     target = 2.0
-    net = sti.MSMScaleFreeNetwork(target_mean_degree=target, target_mean_dur=ss.years(1))
+    net = _make_net(target_mean_degree=target, target_mean_dur=ss.years(1))
     sim = _make_sim(net=net, n_agents=2_500, dur=5)
     sim.run()
     sim_net = sim.networks[0]
@@ -234,7 +254,7 @@ def test_target_mean_dur_honoured():
     so the lower bound is half the target rather than the full target.
     """
     target_yrs = 1.0
-    net = sti.MSMScaleFreeNetwork(target_mean_dur=ss.years(target_yrs))
+    net = _make_net(target_mean_dur=ss.years(target_yrs))
     sim = _make_sim(net=net, n_agents=2_500, dur=5)
     sim.run()
     sim_net = sim.networks[0]
@@ -269,7 +289,7 @@ def test_subclass_mix_weights_override_is_used():
             # Sentinel: row i returns weights = (i+1) uniformly.
             return np.full(mix_arrays['log1p_deg'].size - 1 - i, float(i + 1))
 
-    net = SentinelMSM()
+    net = SentinelMSM(msm_share=ss.bernoulli(p=1.0))
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     assert SentinelMSM.call_count > 0, 'subclass _mix_weights_row was never called'

--- a/tests/test_scalefree_network.py
+++ b/tests/test_scalefree_network.py
@@ -8,8 +8,8 @@ import stisim as sti
 
 def _make_net(**kw):
     """Network with full male participation, so kernel-mechanics tests see the
-    whole post-debut male pool regardless of the default ``msm_share``."""
-    kw.setdefault('msm_share', ss.bernoulli(p=1.0))
+    whole post-debut male pool regardless of the default ``p_msm``."""
+    kw.setdefault('p_msm', ss.bernoulli(p=1.0))
     return sti.MSMScaleFreeNetwork(**kw)
 
 
@@ -68,16 +68,16 @@ def test_get_pool_filters_to_post_debut_males():
 
 
 @sc.timer()
-def test_msm_share_filters_pool():
-    """``msm_share`` controls the fraction of post-debut males in the pool."""
-    full = _make_sim(net=_make_net(msm_share=ss.bernoulli(p=1.0)), n_agents=2_000)
-    part = _make_sim(net=sti.MSMScaleFreeNetwork(msm_share=ss.bernoulli(p=0.2)), n_agents=2_000)
+def test_p_msm_filters_pool():
+    """``p_msm`` controls the fraction of post-debut males in the pool."""
+    full = _make_sim(net=_make_net(p_msm=ss.bernoulli(p=1.0)), n_agents=2_000)
+    part = _make_sim(net=_make_net(p_msm=ss.bernoulli(p=0.2)), n_agents=2_000)
     full.init(); part.init()
     n_full = full.networks[0]._get_pool().count()
     n_part = part.networks[0]._get_pool().count()
     assert n_full > 0, 'full-participation pool is empty — fixture failure'
     assert 0.1 < n_part / n_full < 0.35, \
-        f'msm_share=0.2 pool fraction {n_part / n_full:.2f} not near 0.2 (full={n_full}, part={n_part})'
+        f'p_msm=0.2 pool fraction {n_part / n_full:.2f} not near 0.2 (full={n_full}, part={n_part})'
 
 
 @sc.timer()
@@ -289,7 +289,7 @@ def test_subclass_mix_weights_override_is_used():
             # Sentinel: row i returns weights = (i+1) uniformly.
             return np.full(mix_arrays['log1p_deg'].size - 1 - i, float(i + 1))
 
-    net = SentinelMSM(msm_share=ss.bernoulli(p=1.0))
+    net = SentinelMSM(p_msm=ss.bernoulli(p=1.0))
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     assert SentinelMSM.call_count > 0, 'subclass _mix_weights_row was never called'


### PR DESCRIPTION
Fixes four MSM-network issues (milestone v1.5.7): #496, #497, #498, #499.

## #496 — `AgeApproxMSM` doesn't accept `msm_share`
- `__init__` now defines `msm_share` and `update_pars`, mirroring `AgeMatchedMSM`; adds `set_network_states` + `set_msm`.
- While here, fixed `match_pairs` so the network actually runs: it had a `(self, ppl)` signature (called by `add_pairs` with no args), called `self.over_debut()` on a property, and used `p1 = m_eligible.uids[ind_p1]` / `group2[ind_p2]` which mismatched the split groups and could `IndexError` on odd counts. It now pairs `group1`↔`group2` by age preference and raises `NoPartnersFound` when fewer than two males are looking.

## #497 — `AgeMatchedMSM` crashes at sim init
- Root cause: `set_network_states` overrode the base to call *only* `set_msm`, so `set_risk_groups` never ran and `risk_group` stayed NaN, tripping the NaN check in `get_age_risk_pars` during `init_post`.
- Fix: `set_network_states` now calls `super().set_network_states()` (debut, risk groups, concurrency) before `set_msm`.

## #498 — `MSMScaleFreeNetwork` has no participation filter
- Added `msm_share` (default `ss.bernoulli(p=0.015)`, matching `AgeMatchedMSM`), a `set_network_states`/`set_msm` pair, and `_get_pool` now filters on `self.participant`.

## #499 — docstrings
- `AgeMatchedMSM` and `AgeApproxMSM` now correctly say they extend `MFNetwork` (not `StructuredSexual`).

## Beyond the literal issues
- **`match_pairs` now filters on `self.participant`** in both MF-based MSM variants — previously `msm_share`/`set_msm` set `participant` but matching ignored it, so the knob was inert.
- **Tests:** `test_msm_network` passed `networks=msm` (a lone instance), which `sti.Sim.process_networks` silently replaced with the default `StructuredSexual` — so it wasn't testing MSM at all. Now uses `networks=[msm]` with a non-trivial `msm_share`. The scalefree kernel/dynamics tests route through a full-participation helper (the new 0.015 default would otherwise leave a degenerate pool at small `n_agents`); added `test_msm_share_filters_pool`.

All `test_scalefree_network.py`, `test_networks.py`, `test_mfnetwork.py`, `test_match_methods.py` pass.
