### PR TITLE
SyndromicManagement/SymptomaticTesting: take disease names; fix has_cerv_symp state

### DIFF
--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -60,7 +60,7 @@ Syndromic management: test symptomatic care-seekers and route them to treatment 
 
 ```python
 syndromic = sti.SymptomaticTesting(
-    diseases=[ng, ct, tv],
+    diseases=['ng', 'ct', 'tv'],
     treatments=[ng_tx, ct_tx, metro],
     disease_treatment_map={'ng': ng_tx, 'ct': ct_tx, 'tv': metro},
 )

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -259,6 +259,9 @@ class SymptomaticTesting(STITest):
     Unlike other test classes, this doesn't return positive/negative outcomes, since
     syndromic management doesn't involve reaching a diagnosis.
     Rather, the testing intervention itself contains a linked treatment intervention.
+
+    ``diseases`` is a list of disease names (e.g. ``['ng', 'ct', 'tv']``),
+    resolved against ``sim.diseases`` at init.
     """
 
     def __init__(self, pars=None, treatments=None, diseases=None, disease_treatment_map=None, negative_treatments=None,
@@ -282,9 +285,9 @@ class SymptomaticTesting(STITest):
         )
         self.update_pars(pars, **kwargs)
 
-        # Store treatments and diseases
+        # Store treatments and diseases (diseases are names, resolved in init_pre)
         self.treatments = sc.tolist(treatments)
-        self.diseases = diseases
+        self.diseases = sc.tolist(diseases)
         if disease_treatment_map is None:
             disease_treatment_map = {t.disease: t for t in self.treatments}
         self.disease_treatment_map = disease_treatment_map
@@ -303,6 +306,11 @@ class SymptomaticTesting(STITest):
 
     def init_pre(self, sim):
         super().init_pre(sim)
+        # diseases are passed as names; resolve to the live sim modules. Sim
+        # deep-copies modules, so constructor-passed objects would be orphans
+        # the sim never steps — state reads and result writes below would hit
+        # dead copies.
+        self.diseases = [sim.diseases[name] for name in self.diseases]
         if self.treat_prob_data is not None:
             self.treat_prob = sc.smoothinterp(sim.yearvec, self.treat_prob_data.year.values, self.treat_prob_data.treat_prob.values, smoothness=0)
         return

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -513,6 +513,7 @@ class SyndromicManagement(STITest):
         self.define_states(
             ss.FloatArr('ti_referred'),
             ss.FloatArr('ti_dismissed'),
+            ss.BoolArr('has_cerv_symp'),
         )
         self.treat_prob_data = treat_prob_data
         self.treated_by_uid = None
@@ -524,9 +525,13 @@ class SyndromicManagement(STITest):
         self.pars.tx_cerv_m.set(p=self.mvals_cerv)
         self.pars.tx_noncerv_f.set(p=self.fvals_noncerv)
         self.pars.tx_noncerv_m.set(p=self.mvals_noncerv)
-        # Resolve cervical diseases: use explicit list, else find 'ng'/'ct' in diseases
-        if not self._cervical_diseases:
-            self._cervical_diseases = [d for d in self.diseases if d.name in ('ng', 'ct')]
+        # Resolve diseases via sim.diseases so state/result references are linked
+        self.diseases = [sim.diseases[d.name] for d in self.diseases]
+        if self._cervical_diseases:
+            names = [d.name for d in self._cervical_diseases]
+        else:
+            names = [d.name for d in self.diseases if d.name in ('ng', 'ct')]
+        self._cervical_diseases = [sim.diseases[n] for n in names]
         return
 
     def init_results(self):
@@ -565,13 +570,12 @@ class SyndromicManagement(STITest):
                 m_uids = uids[ppl.male[uids]]
 
                 # Cervical symptomatic flag: OR over user-specified cervical disease modules
-                has_cerv_symp = ss.BoolArr('has_cerv_symp')
-                has_cerv_symp.initialize(sim.people)
+                self.has_cerv_symp[:] = False
                 for d in self._cervical_diseases:
-                    has_cerv_symp = has_cerv_symp | d.symptomatic
+                    self.has_cerv_symp |= d.symptomatic
 
-                f_cerv_uids    = f_uids[has_cerv_symp[f_uids]]
-                f_noncerv_uids = f_uids[~has_cerv_symp[f_uids]]
+                f_cerv_uids    = f_uids[self.has_cerv_symp[f_uids]]
+                f_noncerv_uids = f_uids[~self.has_cerv_symp[f_uids]]
 
                 ofc  = self.pars.tx_cerv_f.rvs(f_cerv_uids)
                 ofnc = self.pars.tx_noncerv_f.rvs(f_noncerv_uids)

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -448,8 +448,9 @@ class SyndromicManagement(STITest):
 
     Args:
         treatments (list):        treatment module instances
-        diseases (list):          disease modules to track accuracy for
-        cervical_diseases (list): disease modules whose symptomatic flag
+        diseases (list):          names of diseases to track accuracy for
+                                  (resolved against ``sim.diseases`` at init)
+        cervical_diseases (list): names of diseases whose symptomatic flag
                                   indicates cervical infection; defaults to
                                   any disease named 'ng' or 'ct' in ``diseases``
         outcome_tx_map (dict):    maps outcome name → list of treatment modules;
@@ -460,7 +461,7 @@ class SyndromicManagement(STITest):
     Examples::
 
         syndromic = sti.SyndromicManagement(
-            diseases=[ng, ct, tv, bv],
+            diseases=['ng', 'ct', 'tv', 'bv'],
             treatments=[ng_tx, ct_tx, metronidazole],
             eligibility=seeking_care_vds,
         )
@@ -525,13 +526,15 @@ class SyndromicManagement(STITest):
         self.pars.tx_cerv_m.set(p=self.mvals_cerv)
         self.pars.tx_noncerv_f.set(p=self.fvals_noncerv)
         self.pars.tx_noncerv_m.set(p=self.mvals_noncerv)
-        # Resolve diseases via sim.diseases so state/result references are linked
-        self.diseases = [sim.diseases[d.name] for d in self.diseases]
+        # diseases/cervical_diseases are passed as names, not module objects:
+        # Sim deep-copies modules, so a constructor-passed object would be an
+        # orphan copy the sim never steps. Resolve names to the live modules.
+        self.diseases = [sim.diseases[name] for name in self.diseases]
         if self._cervical_diseases:
-            names = [d.name for d in self._cervical_diseases]
+            cerv_names = list(self._cervical_diseases)
         else:
-            names = [d.name for d in self.diseases if d.name in ('ng', 'ct')]
-        self._cervical_diseases = [sim.diseases[n] for n in names]
+            cerv_names = [d.name for d in self.diseases if d.name in ('ng', 'ct')]
+        self._cervical_diseases = [sim.diseases[name] for name in cerv_names]
         return
 
     def init_results(self):

--- a/tests/devtests/devtest_amr.py
+++ b/tests/devtests/devtest_amr.py
@@ -48,7 +48,7 @@ def test_gon(n_agents=500, dt=1/12, start=2000, dur=40):
     ct_tx = sti.STITreatment(diseases='ct', name='ct_tx', label='ct_tx')
     metro = sti.STITreatment(diseases=['tv', 'bv'], name='metro', label='metro')
     syndromic = sti.SymptomaticTesting(
-        diseases=[ng, tv, ct, vd],
+        diseases=['ng', 'tv', 'ct', 'bv'],
         eligibility=seeking_care_discharge,
         treatments=[ng_tx, ct_tx, metro],
         disease_treatment_map={'ng': ng_tx, 'ct': ct_tx, 'tv': metro, 'bv': metro}


### PR DESCRIPTION
Fixes disease-reference handling in the two STITest-symptomatic interventions, plus a `has_cerv_symp` state bug in `SyndromicManagement`.

## Root cause: deep-copied disease refs

`Sim` deep-copies the diseases and interventions lists in **separate** operations, so a disease object stashed in an intervention at construction is copied independently of the one in `sim.diseases` (deepcopy only preserves shared identity *within* a single call). The intervention's `self.diseases` end up pointing to **orphan copies the sim never initializes or steps**:

- `SyndromicManagement` / `SymptomaticTesting` read `d.symptomatic` / `d.treatable` / `d.susceptible` off the orphans → stale, all-False state.
- `SymptomaticTesting` *also* writes diagnostic results (`new_true_pos`, `new_false_pos`, …) onto the disease module → on orphans those writes are **silently dropped** from the sim output.

## Fix

Both classes now take disease **names** (e.g. `diseases=['ng', 'ct', 'tv']`) and resolve them to the live modules via `sim.diseases[name]` in `init_pre` — consistent with the `STITreatment` / `gonorrhea` / `syphilis` convention. The object was only ever a name-carrier; passing a name makes the (non-)linkage honest.

Also in `SyndromicManagement`: `has_cerv_symp` is now a persistent `BoolState` reset each step, instead of a transient `ss.BoolArr` re-created and re-initialized every step.

## Verification

Smoke-tested both: disease names resolve to the live sim modules, cervical defaults to `['ng','ct']`, runs produce care seekers, and `SymptomaticTesting`'s diagnostic results now land on the live disease (`sim.results.ng.new_true_pos > 0`). STI + intervention suites green.

Docs example and `devtest_amr` updated to the string API.
