### PR TITLE
PartnerNotification: edge-type / partner-sex stratification (pn_rates)

### DIFF
--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -1033,8 +1033,9 @@ class PartnerNotification(ss.Intervention):
     Each contact is offered notification with probability ``p_notify_<scope>``;
     notified contacts attend follow-up with probability ``p_attends_<scope>``.
     Attendees are scheduled for the supplied ``test`` intervention on the next
-    timestep. Index cases are not notified about themselves; partners reachable
-    via both channels are not double-notified.
+    timestep. Index cases partnered with each other are not notified as
+    partners — they are already in the cascade, so re-notifying is redundant.
+    Partners reachable via both channels are not double-notified.
 
     Args:
         eligibility: Callable ``f(sim) -> uids`` returning index cases (e.g.
@@ -1138,8 +1139,11 @@ class PartnerNotification(ss.Intervention):
 
     def find_partners(self, nw, index_uids):
         """
-        UIDs of partners of `index_uids` on network `nw`, deduplicated and
-        excluding any index case from being notified about themselves.
+        Unique UIDs of partners of ``index_uids`` on network ``nw``. Partner
+        UIDs that are themselves index cases are dropped: index cases
+        partnered with each other are not notified as partners (they are
+        already in the cascade). Used for the prior-partner channel, which
+        does not stratify by edge type.
         """
         in_p1 = np.isin(nw.p1, index_uids)
         in_p2 = np.isin(nw.p2, index_uids)
@@ -1151,29 +1155,34 @@ class PartnerNotification(ss.Intervention):
         return ss.uids(partners)
 
     def _build_partner_edges(self, nw, index_uids):
-        """Return dict {partner_uid: [edge_type_int, ...]} for current-channel
-        edges where one endpoint is an index case. Edges that connect two
-        index cases are excluded — index cases are not notified about
-        themselves.
+        """Return ``{partner_uid: [edge_type_int, ...]}`` for current-channel
+        edges with one endpoint in ``index_uids``. Partner UIDs that are
+        themselves index cases are dropped: index cases partnered with each
+        other are not notified as partners (they are already in the cascade).
+        A partner reachable via several index cases gets one list entry per
+        edge, so the :func:`stisim.pn_rates` helper can sum per-edge rates.
 
-        Edge-type info is exposed via ``self.current_partner_edges`` so that
-        callables passed to ``p_notify_current.p`` / ``p_attends_current.p``
-        can return per-UID probabilities stratified by edge type (see the
-        :func:`stisim.pn_rates` helper).
+        Every stisim network carries an ``edge_type`` column (set on the
+        network base ``meta``), so this is safe for any current network; the
+        edge-type ints map to names via ``nw.edge_types``.
+
+        The result is exposed via ``self.current_partner_edges`` so callables
+        passed to ``p_notify_current.p`` / ``p_attends_current.p`` can return
+        per-UID probabilities stratified by edge type.
         """
         in_p1 = np.isin(nw.p1, index_uids)
         in_p2 = np.isin(nw.p2, index_uids)
         partner_uids = np.concatenate([nw.p2[in_p1], nw.p1[in_p2]])
         edge_types = np.concatenate([nw.edges.edge_type[in_p1],
                                      nw.edges.edge_type[in_p2]])
-        # Drop index-from-index edges
+        # Drop partners that are themselves index cases (index-index edges).
         keep = ~np.isin(partner_uids, index_uids)
         partner_uids = partner_uids[keep]
         edge_types = edge_types[keep]
 
         partner_edges = defaultdict(list)
-        for uid, et in zip(partner_uids, edge_types):
-            partner_edges[int(uid)].append(int(et))
+        for uid, edge_type in zip(partner_uids, edge_types):
+            partner_edges[int(uid)].append(int(edge_type))
         return partner_edges
 
     def step(self):
@@ -1181,19 +1190,21 @@ class PartnerNotification(ss.Intervention):
         if len(index_uids) == 0:
             return
 
-        # Current-partner channel: walk edges, group edge_types by partner uid.
-        # Callables on p_notify_current.p / p_attends_current.p can read
-        # `self.current_partner_edges` to stratify by edge type.
+        # Current-partner channel: walk edges, grouping edge types by partner
+        # uid. A callable on p_notify_current.p / p_attends_current.p (e.g. one
+        # built by the pn_rates helper) can read `self.current_partner_edges`
+        # to stratify the probability by edge type.
         self.current_partner_edges = self._build_partner_edges(self._cur_nw, index_uids)
         cur_partners = ss.uids(sorted(self.current_partner_edges))
 
         cur_notified = self.pars.p_notify_current.filter(cur_partners)
         cur_attending = self.pars.p_attends_current.filter(cur_notified)
 
-        # Prior-partner channel (skip partners already notified as current).
-        # Edge-type stratification is not currently supported for the prior
-        # channel; pn_rates helpers passed here would see an empty
-        # current_partner_edges and return zeros.
+        # Prior-partner channel. Partners already in the current channel this
+        # step are removed first, so no one is notified twice in a single step
+        # (this is within-step cross-channel dedup, not across timesteps).
+        # Edge-type stratification is current-channel only: a pn_rates callable
+        # passed here sees an empty current_partner_edges and returns zeros.
         if self._use_previous:
             prev_partners = self.find_partners(self._prev_nw, index_uids)
             prev_partners = ss.uids(prev_partners[~np.isin(prev_partners, cur_partners)])
@@ -1267,34 +1278,31 @@ def pn_rates(rates):
                 )
 
     def func(module, sim, uids):
+        # current_partner_edges is populated by PartnerNotification.step() for
+        # the current channel only; absent/empty on the prior channel -> all 0.
         partner_edges = getattr(module, 'current_partner_edges', None) or {}
         if not partner_edges:
             return np.zeros(len(uids))
-        # Resolve edge_type int -> name once per call.
-        nw = module._cur_nw
-        int_to_name = {int(v): k for k, v in nw.edge_types.items()}
+        # Map edge-type int -> name once per call (rates is keyed by name).
+        edge_type_to_name = {int(v): k for k, v in module._cur_nw.edge_types.items()}
         if sex_dependent:
             female = sim.people.female
-        out = np.zeros(len(uids))
-        for i, u in enumerate(uids):
-            uid = int(u)
-            edge_types = partner_edges.get(uid, ())
-            if not edge_types:
-                continue
-            total = 0.0
-            if sex_dependent:
-                sex_key = 'f' if female[uid] else 'm'
-            for et in edge_types:
-                name = int_to_name.get(int(et))
+        probs = np.zeros(len(uids))
+        for i, uid in enumerate(uids):
+            uid = int(uid)
+            partner_edge_types = partner_edges.get(uid, ())
+            if not partner_edge_types:
+                continue  # not reached on the current channel this step -> 0
+            sex_key = ('f' if female[uid] else 'm') if sex_dependent else None
+            prob = 0.0
+            for edge_type in partner_edge_types:
+                name = edge_type_to_name.get(int(edge_type))
                 if name is None or name not in rates:
-                    continue
-                spec = rates[name]
-                if sex_dependent:
-                    total += float(spec.get(sex_key, 0.0))
-                else:
-                    total += float(spec)
-            out[i] = min(total, 1.0)
-        return out
+                    continue  # edge type not in `rates` contributes 0
+                rate = rates[name]
+                prob += float(rate.get(sex_key, 0.0)) if sex_dependent else float(rate)
+            probs[i] = min(prob, 1.0)  # cap summed multi-edge probability at 1
+        return probs
 
     return func
 

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -2,6 +2,8 @@
 Define interventions for STIsim
 """
 
+from collections import defaultdict
+
 import starsim as ss
 import numpy as np
 import sciris as sc
@@ -11,7 +13,7 @@ from stisim.utils import count
 
 
 # %% Base classes
-__all__ = ["STIDx", "STITest", "SymptomaticTesting", "SyndromicManagement", "ANCTest", "STITreatment", "PartnerNotification", "ProductMix"]
+__all__ = ["STIDx", "STITest", "SymptomaticTesting", "SyndromicManagement", "ANCTest", "STITreatment", "PartnerNotification", "ProductMix", "pn_rates"]
 
 
 class STIDx(ss.Product):
@@ -1133,17 +1135,50 @@ class PartnerNotification(ss.Intervention):
         partners = partners[~np.isin(partners, index_uids)]
         return ss.uids(partners)
 
+    def _build_partner_edges(self, nw, index_uids):
+        """Return dict {partner_uid: [edge_type_int, ...]} for current-channel
+        edges where one endpoint is an index case. Edges that connect two
+        index cases are excluded — index cases are not notified about
+        themselves.
+
+        Edge-type info is exposed via ``self.current_partner_edges`` so that
+        callables passed to ``p_notify_current.p`` / ``p_attends_current.p``
+        can return per-UID probabilities stratified by edge type (see the
+        :func:`stisim.pn_rates` helper).
+        """
+        in_p1 = np.isin(nw.p1, index_uids)
+        in_p2 = np.isin(nw.p2, index_uids)
+        partner_uids = np.concatenate([nw.p2[in_p1], nw.p1[in_p2]])
+        edge_types = np.concatenate([nw.edges.edge_type[in_p1],
+                                     nw.edges.edge_type[in_p2]])
+        # Drop index-from-index edges
+        keep = ~np.isin(partner_uids, index_uids)
+        partner_uids = partner_uids[keep]
+        edge_types = edge_types[keep]
+
+        partner_edges = defaultdict(list)
+        for uid, et in zip(partner_uids, edge_types):
+            partner_edges[int(uid)].append(int(et))
+        return partner_edges
+
     def step(self):
         index_uids = self.eligibility(self.sim)
         if len(index_uids) == 0:
             return
 
-        # Current-partner channel
-        cur_partners = self.find_partners(self._cur_nw, index_uids)
+        # Current-partner channel: walk edges, group edge_types by partner uid.
+        # Callables on p_notify_current.p / p_attends_current.p can read
+        # `self.current_partner_edges` to stratify by edge type.
+        self.current_partner_edges = self._build_partner_edges(self._cur_nw, index_uids)
+        cur_partners = ss.uids(sorted(self.current_partner_edges))
+
         cur_notified = self.pars.p_notify_current.filter(cur_partners)
         cur_attending = self.pars.p_attends_current.filter(cur_notified)
 
-        # Prior-partner channel (skip partners already notified as current)
+        # Prior-partner channel (skip partners already notified as current).
+        # Edge-type stratification is not currently supported for the prior
+        # channel; pn_rates helpers passed here would see an empty
+        # current_partner_edges and return zeros.
         if self._use_previous:
             prev_partners = self.find_partners(self._prev_nw, index_uids)
             prev_partners = ss.uids(prev_partners[~np.isin(prev_partners, cur_partners)])
@@ -1165,6 +1200,88 @@ class PartnerNotification(ss.Intervention):
         self.results['new_notified'][ti] = len(cur_notified) + len(prev_notified)
         self.results['new_attending'][ti] = len(all_attending)
         return
+
+
+def pn_rates(rates):
+    """
+    Build a per-UID probability callable for :class:`PartnerNotification`.
+
+    Stratifies notification or attendance rates by partnership edge type
+    (and optionally partner sex). The returned callable is suitable as the
+    ``p`` argument of ``ss.bernoulli`` passed as ``p_notify_current`` or
+    ``p_attends_current`` on a ``PartnerNotification`` instance.
+
+    Args:
+        rates: dict mapping edge-type name to a probability OR to a per-sex
+            dict. Two supported shapes:
+
+            - ``{edge_name: prob}`` — notification or attendance rate that
+              does not depend on partner sex. Example::
+
+                  {'stable': 0.20, 'casual': 0.10}
+
+            - ``{edge_name: {'f': prob, 'm': prob}}`` — rate that depends
+              on partner sex. Example::
+
+                  {'stable': {'f': 0.80, 'm': 0.50},
+                   'casual': {'f': 0.50, 'm': 0.25}}
+
+            Edge names must match the active network's
+            ``edge_types`` keys. Edges whose type is not in ``rates`` get
+            probability 0.
+
+    Returns:
+        callable f(module, sim, uids) -> ndarray of probabilities, one per
+        UID. If a partner is reachable via multiple current-channel edges
+        (e.g. notified by two distinct index cases on the same step), the
+        per-edge probabilities are **summed and capped at 1**.
+
+    The callable looks up ``module.current_partner_edges``, populated by
+    ``PartnerNotification.step()``. It returns zeros if that mapping is
+    empty (e.g. when called from the previous-partner channel).
+    """
+    # Detect format from a sample value
+    sample = next(iter(rates.values()), None)
+    sex_dependent = isinstance(sample, dict)
+    if sex_dependent:
+        for k, v in rates.items():
+            if not isinstance(v, dict):
+                raise ValueError(
+                    f"pn_rates: inconsistent rates spec; key '{k}' has "
+                    f"non-dict value while another key is a dict."
+                )
+
+    def func(module, sim, uids):
+        partner_edges = getattr(module, 'current_partner_edges', None) or {}
+        if not partner_edges:
+            return np.zeros(len(uids))
+        # Resolve edge_type int -> name once per call.
+        nw = module._cur_nw
+        int_to_name = {int(v): k for k, v in nw.edge_types.items()}
+        if sex_dependent:
+            female = sim.people.female
+        out = np.zeros(len(uids))
+        for i, u in enumerate(uids):
+            uid = int(u)
+            edge_types = partner_edges.get(uid, ())
+            if not edge_types:
+                continue
+            total = 0.0
+            if sex_dependent:
+                sex_key = 'f' if female[uid] else 'm'
+            for et in edge_types:
+                name = int_to_name.get(int(et))
+                if name is None or name not in rates:
+                    continue
+                spec = rates[name]
+                if sex_dependent:
+                    total += float(spec.get(sex_key, 0.0))
+                else:
+                    total += float(spec)
+            out[i] = min(total, 1.0)
+        return out
+
+    return func
 
 
 class ProductMix(ss.Product):

--- a/tests/baseline.yaml
+++ b/tests/baseline.yaml
@@ -188,7 +188,7 @@ low_cd4_testing_new_diagnoses: 124.24480082987552
 low_cd4_testing_new_tests: 124.24480082987552
 maternalnet_n_edges: 359398.7938672199
 n_alive: 12736727.974939832
-n_female: 0.0
+n_female: 6580480.923686722
 new_deaths: 14867.961165975103
 new_emigrants: 0.0
 other_testing_n_diagnosed: 0.0

--- a/tests/benchmark.yaml
+++ b/tests/benchmark.yaml
@@ -1,4 +1,4 @@
-cpu_performance: 1.4614108328040583
+cpu_performance: 1.480138550334404
 parameters:
   dt:
     python_class: <class 'starsim.time.years'>
@@ -8,5 +8,5 @@ parameters:
     value: 20.0
   n_agents: 2000
 time:
-  initialize: 0.352
-  run: 2.598
+  initialize: 0.349
+  run: 2.58

--- a/tests/benchmark.yaml
+++ b/tests/benchmark.yaml
@@ -1,4 +1,4 @@
-cpu_performance: 1.3324339077559093
+cpu_performance: 1.4614108328040583
 parameters:
   dt:
     python_class: <class 'starsim.time.years'>
@@ -8,5 +8,5 @@ parameters:
     value: 20.0
   n_agents: 2000
 time:
-  initialize: 0.374
-  run: 2.297
+  initialize: 0.352
+  run: 2.598

--- a/tests/test_hiv_interventions.py
+++ b/tests/test_hiv_interventions.py
@@ -556,6 +556,93 @@ def test_pn():
     return n_dx_no_pn, n_dx_with_pn
 
 
+def test_pn_rates():
+    """ pn_rates: edge-type and partner-sex stratification of the probability callable """
+    sc.heading('Testing pn_rates stratification...')
+
+    def evaluate(rates, partner_edges, edge_types, uids, female=None):
+        """ Run a pn_rates callable against stubbed module/sim state. """
+        nw = sc.dictobj(edge_types=edge_types)
+        module = sc.dictobj(current_partner_edges=partner_edges, _cur_nw=nw)
+        sim = sc.dictobj(people=sc.dictobj(female=female))
+        return sti.pn_rates(rates)(module, sim, ss.uids(uids))
+
+    # Single edge type: matched partner gets its rate, non-partner gets 0
+    one = {'stable': 0}
+    assert np.allclose(evaluate({'stable': 0.2}, {1: [0]}, one, [1, 2]), [0.2, 0.0])
+
+    # Two edge types, incl. a partner reachable via both edges (rates summed)
+    two = {'stable': 0, 'casual': 1}
+    assert np.allclose(evaluate({'stable': 0.2, 'casual': 0.1}, {1: [0], 2: [1], 3: [0, 1]}, two, [1, 2, 3]),
+                       [0.2, 0.1, 0.3])
+
+    # Multi-edge probabilities sum but cap at 1
+    assert np.allclose(evaluate({'stable': 0.8}, {1: [0, 0]}, one, [1]), [1.0])
+
+    # Edge type absent from `rates` contributes 0 (the "pn_rates 0" case)
+    assert np.allclose(evaluate({'stable': 0.5}, {1: [2]}, {'stable': 0, 'onetime': 2}, [1]), [0.0])
+
+    # Empty current_partner_edges (e.g. the prior channel) -> all zeros
+    assert np.allclose(evaluate({'stable': 0.5}, {}, one, [1, 2]), [0.0, 0.0])
+
+    # Per-sex rates resolve by partner sex (uid 1 female, uid 2 male)
+    female = np.array([False, True, False])
+    assert np.allclose(evaluate({'stable': {'f': 0.8, 'm': 0.5}}, {1: [0], 2: [0]}, one, [1, 2], female),
+                       [0.8, 0.5])
+
+    # Mixing scalar and per-sex specs raises
+    try:
+        sti.pn_rates({'stable': {'f': 0.8, 'm': 0.5}, 'casual': 0.1})
+        raise AssertionError('Expected ValueError for mixed scalar/dict spec')
+    except ValueError:
+        pass
+    return
+
+
+def test_pn_rates_sim():
+    """ pn_rates through PartnerNotification.step() across one and two networks """
+    sc.heading('Testing pn_rates in a running sim...')
+
+    def newly_diagnosed(sim):
+        hiv = sim.diseases.hiv
+        return (hiv.ti_diagnosed == hiv.ti).uids
+
+    def make_sim(current_rates, use_prior=False):
+        # Notify/attend probs are deterministic (matched edge -> 1, else 0),
+        # so current notifications reflect exactly which partners matched.
+        hiv_test = sti.HIVTest(name='hiv_test', test_prob_data=0.3)
+        pn = sti.PartnerNotification(
+            eligibility=newly_diagnosed, test=hiv_test,
+            p_notify_current=ss.bernoulli(p=sti.pn_rates(current_rates)),
+            p_attends_current=ss.bernoulli(p=1.0),
+            p_notify_previous=ss.bernoulli(p=0.5 if use_prior else 0.0),
+            p_attends_previous=ss.bernoulli(p=1.0),
+            name='pn',
+        )
+        networks = [sti.StructuredSexual(recall_prior=use_prior)]
+        if use_prior:
+            networks.append(sti.PriorPartners(dur_recall=ss.years(0.5)))
+        return hivsim.demo('simple', run=False, plot=False, n_agents=n_agents,
+                           dur=5, rand_seed=1, verbose=-1,
+                           networks=networks, interventions=[hiv_test, pn])
+
+    edge_types = sti.StructuredSexual().edge_types
+
+    # Single network: matching rates notify partners; an unmatched edge type notifies none
+    match = make_sim({k: 1.0 for k in edge_types}); match.run()
+    none  = make_sim({'no_such_edge_type': 1.0});   none.run()
+    n_match = int(match.results.pn.new_notified_current.sum())
+    assert n_match > 0, f'Expected current notifications with matching rates, got {n_match}'
+    assert int(none.results.pn.new_notified_current.sum()) == 0, 'Unmatched edge type should notify nobody'
+
+    # Two networks: with a prior network also configured, the current channel
+    # still notifies via pn_rates. The prior channel is current-channel-blind:
+    # pn_rates returns 0 there (covered deterministically in test_pn_rates).
+    both = make_sim({k: 1.0 for k in edge_types}, use_prior=True); both.run()
+    assert int(both.results.pn.new_notified_current.sum()) > 0, 'Expected current-channel notifications'
+    return n_match
+
+
 if __name__ == '__main__':
     do_plot = True
     sc.options(interactive=do_plot)
@@ -573,6 +660,8 @@ if __name__ == '__main__':
     r10 = test_art_parameter_sensitivity(do_plot=do_plot)
     r11 = test_art_duration(do_plot=do_plot)
     r12 = test_pn()
+    r13 = test_pn_rates()
+    r14 = test_pn_rates_sim()
 
     T.toc()
 


### PR DESCRIPTION
Adds optional edge-type / partner-sex stratification to `PartnerNotification`, independent of the syph (#500) and MSM (#502) work — touches only `base_interventions.py`.

## What

- `PartnerNotification.step()` walks current-channel edges preserving edge type and exposes `current_partner_edges` (`{partner_uid: [edge_type, ...]}`).
- New `pn_rates(rates)` helper builds a per-UID probability callable for `p_notify_current` / `p_attends_current`, stratified by edge type and (optionally) partner sex:
  - `pn_rates({'stable': 0.20, 'casual': 0.10})`
  - `pn_rates({'stable': {'f': 0.80, 'm': 0.50}, 'casual': {'f': 0.50, 'm': 0.25}})`

  Partners reachable via multiple current-channel edges have per-edge probabilities summed and capped at 1.

## Compatibility

- Scalar `p_notify_current` / `p_attends_current` bernoullis are unchanged — `test_pn` passes as-is.
- Edge-type stratification is current-channel only; the prior channel returns 0 (documented in `step()` / `pn_rates`).

## Notes

- This is the cycle-prevention-free PN contribution (the cycle-prevention variant in the closed #501 was not adopted).
- `pn_rates` has no automated test coverage yet (`test_pn` covers the scalar path); smoke-tested manually (both shapes notify as expected).
