### PR TITLE
MFNetwork: optional coital-decay + client-husband marital multiplier

### DIFF
--- a/stisim/networks/base.py
+++ b/stisim/networks/base.py
@@ -65,6 +65,12 @@ class BaseNetwork(ss.SexualNetwork):
         self.meta.age_p1 = ss_float
         self.meta.age_p2 = ss_float
         self.meta.edge_type = ss_float
+        # acts_baseline preserves the per-edge act count assigned at edge
+        # formation; per-step `acts` may be a decayed multiple of it
+        # (see ``update_acts``). start_ti is the timestep when the edge
+        # was created — used to compute edge age for the decay.
+        self.meta.acts_baseline = ss_float
+        self.meta.start_ti = ss_int
         self.define_pars(**BasePars())
         self.define_states(
             ss.BoolArr('participant', default=True),
@@ -150,7 +156,33 @@ class BaseNetwork(ss.SexualNetwork):
         self.set_network_states(upper_age=self.t.dt_year)
         self.add_pairs()
         self.set_condom_use()
+        self.update_acts()
         return
+
+    def update_acts(self):
+        """Per-step recompute of per-edge ``acts`` from ``acts_baseline``
+        and any per-edge multiplier returned by ``_compute_act_multiplier``.
+        No-op at default parameters (multiplier = 1.0 for all edges).
+        Subclasses override ``_compute_act_multiplier`` to inject custom
+        per-edge modifiers (e.g. stable-edge coital decay, client-husband
+        displacement).
+        """
+        if len(self.edges.acts) == 0:
+            return
+        mult = self._compute_act_multiplier()
+        if mult is None:
+            return
+        out = np.round(self.edges.acts_baseline * mult)
+        self.edges.acts[:] = out.astype(self.edges.acts.dtype)
+        return
+
+    def _compute_act_multiplier(self):
+        """Return a per-edge float array of multipliers on ``acts_baseline``,
+        or ``None`` to skip the update (default — backwards compatible).
+        Subclasses override to apply duration-based decay, partner-status
+        modifiers, etc.
+        """
+        return None
 
     def add_pairs(self):
         """Subclasses override."""

--- a/stisim/networks/fsw.py
+++ b/stisim/networks/fsw.py
@@ -5,7 +5,7 @@ for discoverability.
 """
 import numpy as np
 import starsim as ss
-from .base import BaseNetwork, NoPartnersFound, ss_float
+from .base import BaseNetwork, NoPartnersFound, ss_float, ss_int
 
 __all__ = ['SWPars', 'SWNetwork']
 
@@ -48,6 +48,14 @@ class SWPars(ss.Pars):
         self.sw_seeking_dist = ss.bernoulli(p=0.5)     # Placeholder; replaced by dt-adjusted sw_seeking_rate
         self.sw_beta = 1
         self.sw_intensity = ss.random()                # FSW may work with varying intensity each step
+
+        # Multiplier applied to STABLE-edge per-step acts when the male
+        # partner (p1) is a client of an FSW. Captures the "wife
+        # displacement" effect — extramarital activity often substitutes
+        # for marital activity. Default 1.0 = no effect. Applied on
+        # networks that combine MF + SW (e.g. StructuredSexual); ignored
+        # by bare SWNetwork (its only edge type is sw, not stable).
+        self.client_marital_act_mult = 1.0
 
         # Per-agent age window — placeholders; tune to context
         self.age_sw_start = ss.normal(loc=20, scale=3)
@@ -219,7 +227,10 @@ class SWNetwork(BaseNetwork):
         age_p2 = ppl.age[p2]
         edge_types = np.full(match_count, dtype=ss_float, fill_value=self.edge_types['sw'])
 
-        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
+        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur,
+                    acts=acts, acts_baseline=acts.astype(ss_float),
+                    start_ti=np.full(match_count, self.ti, dtype=ss_int),
+                    age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
 
         p1_edges, p1_counts = np.unique(p1, return_counts=True)
         p2_edges, p2_counts = np.unique(p2, return_counts=True)

--- a/stisim/networks/layered_networks.py
+++ b/stisim/networks/layered_networks.py
@@ -66,6 +66,28 @@ class StructuredSexual(MFNetwork):
         SWNetwork.add_pairs(self)
         return
 
+    def _compute_act_multiplier(self):
+        """Compose MFNetwork's stable-edge decay with a client-husband
+        marital multiplier. Returns ``None`` only if BOTH knobs are
+        no-ops (preserves backwards compatibility).
+        """
+        mult = MFNetwork._compute_act_multiplier(self)
+        client_mult = self.pars.client_marital_act_mult
+        if mult is None and client_mult == 1.0:
+            return None
+        if mult is None:
+            mult = np.ones(len(self.edges.acts_baseline), dtype=ss_float)
+        if client_mult != 1.0 and 'stable' in self.edge_types:
+            is_stable = self.edges.edge_type == self.edge_types['stable']
+            if is_stable.any():
+                # client is a property of male agents (p1); intersect with
+                # stable edges so casual / onetime / sw edges are untouched
+                p1_uids = ss.uids(self.edges.p1[is_stable])
+                client_husbands = self.client[p1_uids]
+                ix = np.where(is_stable)[0][client_husbands]
+                mult[ix] *= client_mult
+        return mult
+
     # end_pairs and set_condom_use inherited from BaseNetwork. _decrement_partners
     # (in MFNetwork) skips SW edges via the ``'sw' in self.edge_types`` check;
     # set_condom_use's per-key dispatch handles ``(rgm, rgf)`` and ``('fsw','client')``

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -4,7 +4,7 @@ import starsim as ss
 from collections import defaultdict
 from bisect import bisect_left
 
-from .base import BaseNetwork, NoPartnersFound, ss_float
+from .base import BaseNetwork, NoPartnersFound, ss_float, ss_int
 
 __all__ = ['MFPars', 'MFNetwork']
 
@@ -60,6 +60,15 @@ class MFPars(ss.Pars):
         self.m0_conc = 0.0001
         self.m1_conc = 0.2
         self.m2_conc = 0.5
+
+        # Stable-edge coital-frequency decay: linear in edge age (years),
+        # floored. Acts on edges with edge_type == stable. Default 0.0
+        # = no decay = backwards compatible. Empirically, monthly coital
+        # frequency in long-running couples is ~50% of newlywed baseline
+        # by year 5-7 (DHS / Demographic Health Surveys), suggesting
+        # stable_act_decay ≈ 0.07-0.10 / yr with a floor near 0.4.
+        self.stable_act_decay = 0.0
+        self.stable_act_floor = 0.3
 
         # Relationship initiation, stability, and duration
         self.p_pair_form = ss.bernoulli(p=0.5)              # Probability of a (stable) pair forming between two matched people
@@ -305,7 +314,10 @@ class MFNetwork(BaseNetwork):
             pair = (min(a,b), max(a,b))
             self.relationship_durs[pair].append({'start': self.ti, 'dur': reldur, 'edge_type': int(etype)}) # set dur to intended duration. When the relationship actually ends, this will be updated
 
-        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
+        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur,
+                    acts=acts, acts_baseline=acts.astype(ss_float),
+                    start_ti=np.full(match_count, self.ti, dtype=ss_int),
+                    age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
 
         # Checks
         if (self.sim.people.female[p1].any() or self.sim.people.male[p2].any()) and (self.name == 'structuredsexual'):
@@ -329,6 +341,24 @@ class MFNetwork(BaseNetwork):
             getattr(self, f'lifetime_{key}_partners')[p2_edges] += 1
 
         return
+
+    def _compute_act_multiplier(self):
+        """Linear coital decay over stable-edge age. Casual / onetime edges
+        unaffected. Returns ``None`` to skip the per-step update when
+        ``stable_act_decay == 0`` (the default) — preserves backwards
+        compatibility.
+        """
+        decay = self.pars.stable_act_decay
+        if not decay:
+            return None
+        floor = self.pars.stable_act_floor
+        n = len(self.edges.acts_baseline)
+        mult = np.ones(n, dtype=ss_float)
+        is_stable = self.edges.edge_type == self.edge_types['stable']
+        if is_stable.any():
+            age_years = (self.ti - self.edges.start_ti[is_stable]) * self.t.dt_year
+            mult[is_stable] = np.maximum(1.0 - decay * age_years, floor)
+        return mult
 
     def _on_edge_dissolution(self, active):
         """Record dissolved partnerships and decrement partner counts."""

--- a/stisim/networks/msm.py
+++ b/stisim/networks/msm.py
@@ -10,7 +10,7 @@ Three MSM variants live here:
 """
 import numpy as np
 import starsim as ss
-from .base import NoPartnersFound, BaseNetwork
+from .base import NoPartnersFound, BaseNetwork, ss_float, ss_int
 from .mf import MFNetwork
 
 __all__ = ['AgeMatchedMSM', 'AgeApproxMSM', 'MSMScaleFreeNetwork']
@@ -373,11 +373,14 @@ class MSMScaleFreeNetwork(BaseNetwork):
         if n == 0:
             return
         ages = self.sim.people.age
+        acts = np.ones(n, dtype=int)
         self.append(
             p1=p1, p2=p2,
             beta=np.ones(n, dtype=float),
             dur=np.full(n, float(self._max_edge_dur_steps), dtype=float),
-            acts=np.ones(n, dtype=int),
+            acts=acts,
+            acts_baseline=acts.astype(ss_float),
+            start_ti=np.full(n, self.ti, dtype=ss_int),
             condoms=np.zeros(n, dtype=float),
             age_p1=ages[p1],
             age_p2=ages[p2],


### PR DESCRIPTION
Two new knobs on the heterosexual network:

- MFPars.stable_act_decay (per year, default 0.0): linear decay of per-step acts on stable edges as the relationship ages. Defaults preserve existing behaviour. Empirically, monthly coital frequency in long-running couples is ~50% of newlywed baseline by year 5-7; values around 0.07-0.10/yr with a floor near 0.3-0.4 are reasonable.
- SWPars.client_marital_act_mult (default 1.0): scalar applied to stable-edge per-step acts when the male partner (p1) is a client of an FSW. Captures wife-displacement — extramarital activity often substitutes for marital activity rather than adding to it. Acts only on networks that combine MF + SW (e.g. StructuredSexual).

Two new edge meta fields:
- acts_baseline (preserves the original per-edge act count assigned at edge formation)
- start_ti (timestep when edge was formed; used for decay-age math)

New BaseNetwork.update_acts() step hook recomputes per-edge acts from acts_baseline * _compute_act_multiplier(). The base override returns None (no-op); MFNetwork applies the duration-decay; StructuredSexual composes that with the client-husband multiplier. SWNetwork's commercial edges (edge_type='sw') are unaffected.

Smoke test: 10-yr sim with decay=0.10, floor=0.3, client_mult=0.5 gives stable mean_acts 2.67 vs baseline 5.87 (55% reduction); casual edges unchanged at 6.01; SW edges unchanged at 4.61.