### PR TITLE
Release v1.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 All notable changes to the codebase are documented in this file.
 
-## Version 1.5.7 (TBC)
+## Version 1.5.7 (2026-06-15)
+
+### Diseases
+- Syphilis: add treponemal (`trep`) and non-treponemal (`nontrep`) serology states with seroconversion/reversion dynamics (window period, ~80% lifelong trep persistence, non-trep titre decline + post-treatment reversion). New `trep_prevalence`/`nontrep_prevalence` results (overall, by sex, by age×sex) plus `sexually_transmissible`/`symptomatic`/`primary` stage prevalences. Consolidated the duplicate `active` property into `symptomatic` (removed `active_prevalence` and the `*_prevalence_15_64` results). Prevalence denominator age band is now configurable via `age_range`, exposed as a `BaseSTI` constructor argument. (#500)
+
+### Networks
+- Add `fsw_mf_conc_mult` on `StructuredSexual` to scale FSW non-sex-work concurrency (values <1 = fewer non-commercial partners). `MFNetwork.set_concurrency` is now negative-binomial-aware: it reparameterizes the target mean correctly instead of silently no-opping when `concurrency_dist` is `ss.nbinom`. (#500)
+- Fix the three MSM networks (`AgeMatchedMSM`, `AgeApproxMSM`, `MSMScaleFreeNetwork`): all now honour a participation filter and no longer crash at init. The participation parameter is renamed `msm_share` → `p_msm`. (#502)
+
+### Interventions
+- `SyndromicManagement` and `SymptomaticTesting` now take disease **names** (e.g. `diseases=['ng', 'ct']`) rather than module objects, resolved against `sim.diseases` at init. Objects passed at construction were deep-copied into orphans the sim never stepped, giving stale state and dropped result-writes. (#503)
+
+### Analyzers
+- Add `sti.PartnershipFormationAnalyzer`. Networks now record the timestep each relationship ends (`None` if still active at sim end), enabling efficient post-run partnership analysis from a shared results store. (#504)
+
+### Results
+- Remove the unimplemented `partners_12` / `n_partners_12m` references. (#473, #507)
 
 ## Version 1.5.6 (2026-06-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the codebase are documented in this file.
 
+## Version 1.5.7 (TBC)
+
 ## Version 1.5.6 (2026-06-02)
 
 ### Networks

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -106,6 +106,7 @@ website:
             - section: "Networks"
               contents:
                 - user_guide/networks/structured_sexual.md
+                - user_guide/networks/matching.md
                 - user_guide/networks/msm.md
             - section: "Interventions"
               contents:

--- a/docs/_variables.yml
+++ b/docs/_variables.yml
@@ -1,2 +1,2 @@
-version: 1.5.6
-versiondate: '2026-06-02'
+version: 1.5.7
+versiondate: '2026-06-15'

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -5,7 +5,7 @@ STIsim is built on top of [Starsim](https://docs.starsim.org). For understanding
 This user guide documents what STIsim adds on top of Starsim:
 
 - **[Diseases](diseases/index.md)** -- State diagrams and parameter tables for each STI module (HIV, syphilis, chlamydia, gonorrhea, trichomoniasis, BV, GUD).
-- **[Networks](networks/structured_sexual.md)** -- The structured sexual network: risk groups, partnership types, age mixing, sex work, and condom use. See also [MSM networks](networks/msm.md).
+- **[Networks](networks/structured_sexual.md)** -- The structured sexual network: risk groups, partnership types, age mixing, sex work, and condom use. See also [pair matching](networks/matching.md) and [MSM networks](networks/msm.md).
 - **[Interventions](interventions/interventions.md)** -- Testing, treatment, and HIV-specific interventions (ART, VMMC, PrEP).
 - **[Connectors](connectors.md)** -- Coinfection interactions between co-circulating diseases.
 - **[Calibration](calibration.md)** -- Fitting model parameters to data with Optuna.

--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -60,7 +60,7 @@ Syndromic management: test symptomatic care-seekers and route them to treatment 
 
 ```python
 syndromic = sti.SymptomaticTesting(
-    diseases=[ng, ct, tv],
+    diseases=['ng', 'ct', 'tv'],
     treatments=[ng_tx, ct_tx, metro],
     disease_treatment_map={'ng': ng_tx, 'ct': ct_tx, 'tv': metro},
 )

--- a/docs/user_guide/networks/matching.md
+++ b/docs/user_guide/networks/matching.md
@@ -1,0 +1,99 @@
+# Pair matching
+
+Each timestep, [`MFNetwork`](structured_sexual.md) forms new heterosexual partnerships by matching *looking* women to *eligible* men. The algorithm that does this is selected by the `match_method` parameter (default `'closest_age_tapered_seeking'`). All matchers share the same inputs and contract; they differ only in how they turn age preferences into pairs.
+
+## The matching problem
+
+```
+each timestep
+      │
+      ▼
+ eligible women ──► sample desired partner age ──► desired ages ┐
+ (post-debut,        (own age + gap drawn from                  │
+  under-partnered,    age_diff_pars, by age group               ├─► match_method ─► (p1, p2)
+  "looking")          × risk group)                             │        pairs
+                                                                │
+ eligible men ───────────────────────────────────► actual ages ┘
+ (post-debut, under-partnered)                                          │
+                                                                        ▼
+                                                              add_pairs assigns
+                                                              type / duration / acts
+```
+
+- **Eligible women** are post-debut, under-partnered (`partners < concurrency`), and pass the `p_pair_form` "looking" filter. Each draws a **desired** male partner age — her own age plus an age gap sampled from `age_diff_pars` (varies by her age group and risk group; see [age mixing](structured_sexual.md#age-mixing)).
+- **Eligible men** are post-debut and under-partnered, with their **actual** ages.
+- A matcher returns `(p1, p2)` — equal-length `ss.uids` arrays of male and female partners — or raises `NoPartnersFound` if it can pair no one. Relationship type (stable/casual/one-time), duration, and coital acts are assigned afterwards by `add_pairs`, not by the matcher.
+
+## Default: `closest_age_tapered_seeking`
+
+The default matcher pairs each woman with the closest-aged available man at or above her target, and damps older women's search so realized age gaps stay faithful to `age_diff_pars` even when older men are scarce. It runs in four steps.
+
+**1. Taper older women's search.** A woman's chance of looking this step falls with age, reaching zero at `f_partnership_taper_cut` (default 55):
+
+```
+P(woman looks)
+  1 ┤●●●●●●●●●●●●●●●●
+    │                ●●
+    │                  ●●●        ∝ ((cut − age) / offset) ^ 1.5
+  0 ┤────────────────────●●●●●──► age
+    0                  ↑          ↑
+              taper onset        cut  (f_partnership_taper_cut)
+            (cut − offset)
+```
+
+`offset` is `mean_gap + 3·sd`, the widest plausible age gap across age/risk groups. Without this taper, older women who draw large gaps cannot find partners, biasing realized gaps downward.
+
+**2. Sample desired ages** for the women who are looking (own age + gap), and collect eligible men's actual ages.
+
+**3. Closest-age sweep.** Sort women by desired age and men by actual age, then sweep once with a two-pointer scan: each woman takes the nearest still-available man near her target (no man is reused). A woman whose nearest free man is more than `max_deviation` (1 year) off her target is skipped — later, higher-target women may still match.
+
+```
+F desired (sorted):  24    27    33        M actual (sorted): 22  25  28  31  34
+
+   24 ─► nearest free man near 24 ─► 25     ✓  gap 1
+   27 ─► nearest free man near 27 ─► 28     ✓  gap 1
+   33 ─► nearest free man near 33 ─► 34     ✓  gap 1
+                                            22, 31 left unmatched
+```
+
+**4. Trim extremes.** Drop any pair whose realized age gap exceeds `mean_gap + 3·sd`, removing unrealistic matches the sweep may have forced.
+
+A small residual downward bias (<1 year) in the female–male age gap remains, driven mainly by debut-age limits truncating the low end of young women's preferences. Note also that in calibration `age_diff_pars` is not orthogonal to the concurrency and duration parameters, since those shape the pool of people looking each step.
+
+## Other matchers
+
+`match_method` accepts any of these registry keys (or a callable — see below):
+
+| `match_method` | How it pairs | Age-gap fidelity |
+|----------------|--------------|------------------|
+| `closest_age_tapered_seeking` *(default)* | sorted closest-age sweep + older-woman taper + extreme-gap trim | highest |
+| `kdtree_nn` | KD-tree nearest-neighbour on male age; contested men go to the closest woman | high |
+| `lsa` | globally optimal assignment over the full age-distance matrix; `O(n³)`, reference only | optimal (slow) |
+| `greedy_old_enough` | each woman (by ascending target) takes the youngest free man ≥ her target | one-sided |
+| `sort_pair` | sort both groups by age, zip, truncate to the shorter | moderate |
+| `sort_bisect` | sort + trim non-overlapping age tails + subsample (legacy production) | low (boundaries only) |
+| `desired_age_bucket` | 1-year desired-age buckets, sample a man within | coarse ⁽¹⁾ |
+| `band_match` | 5-year age bands, shuffle and zip within each band | coarse ⁽¹⁾ |
+
+⁽¹⁾ `desired_age_bucket` and `band_match` draw from their own RNG seeded per `(rand_seed, ti)` — reproducible for a fixed run, but not branching-stable under Starsim's Common Random Numbers (adding an intervention can reshuffle pairings).
+
+## Custom matchers
+
+Pass a callable as `match_method`. It receives the network and returns `(p1, p2)`. Two helpers cover the common setup:
+
+```python
+import stisim as sti
+from stisim.networks import NoPartnersFound
+
+def my_matcher(net):
+    f_looking, m_eligible = net._get_eligible()      # women: ss.uids; men: bool mask (use m_eligible.uids)
+    desired = net._sample_desired_ages(f_looking)    # target male age per looking woman
+    ...                                              # your pairing logic
+    if nothing_matched:
+        raise NoPartnersFound()
+    return p1, p2                                     # equal-length male, female ss.uids
+
+net = sti.MFNetwork(match_method=my_matcher)
+```
+
+`p1` must be male uids and `p2` female uids, of equal length. Raise `NoPartnersFound` when no pairing is possible for the timestep.

--- a/docs/user_guide/networks/msm.md
+++ b/docs/user_guide/networks/msm.md
@@ -9,10 +9,10 @@ STIsim provides two networks for modeling sexual contact between men. Both exten
 
 ## Participation
 
-Both networks expose an `msm_share` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
+Both networks expose an `p_msm` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
 
 ```python
-msm = sti.AgeMatchedMSM(msm_share=ss.bernoulli(p=0.05))  # 5% of males
+msm = sti.AgeMatchedMSM(p_msm=ss.bernoulli(p=0.05))  # 5% of males
 ```
 
 ## Combining with the heterosexual network

--- a/docs/user_guide/networks/msm.md
+++ b/docs/user_guide/networks/msm.md
@@ -1,15 +1,16 @@
 # MSM networks
 
-STIsim provides two networks for modeling sexual contact between men. Both extend [`StructuredSexual`](structured_sexual.md), inheriting risk groups, concurrency, and partnership classification, but differ in how partners are matched.
+STIsim provides three networks for modeling sexual contact between men. `AgeMatchedMSM` and `AgeApproxMSM` extend [`MFNetwork`](structured_sexual.md), inheriting risk groups, concurrency, and partnership classification, and differ only in how partners are matched. `MSMScaleFreeNetwork` extends `BaseNetwork` directly and uses a preferential-attachment kernel instead of risk groups.
 
 | Class | Matching strategy | When to use |
 |-------|------------------|-------------|
 | `sti.AgeMatchedMSM` | Sort eligible males by age and pair sequentially | Lightweight; partners always have similar ages |
-| `sti.AgeApproxMSM` | Reuses `StructuredSexual` age-difference preferences to match split groups of eligible males | More flexible age mixing |
+| `sti.AgeApproxMSM` | Reuses `MFNetwork` age-difference preferences to match split groups of eligible males | More flexible age mixing |
+| `sti.MSMScaleFreeNetwork` | Preferential-attachment (rich-get-richer) degree kernel with Markovian edge deletion | Scale-free degree distribution; concentrated transmission |
 
 ## Participation
 
-Both networks expose an `p_msm` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
+All three networks expose a `p_msm` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
 
 ```python
 msm = sti.AgeMatchedMSM(p_msm=ss.bernoulli(p=0.05))  # 5% of males
@@ -28,7 +29,26 @@ sim = sti.Sim(
 
 Each network maintains its own edges and partnership classification. Disease modules see contacts from all networks each timestep.
 
+## Scale-free network
+
+`sti.MSMScaleFreeNetwork` (Whittles-2019 S2 kernel) forms edges via a rate proportional to a degree-based pair weight, producing a scale-free degree distribution where a minority of high-degree agents drive most transmission. Edges are deleted at random subject to a hard duration cap.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `p_msm` | `ss.bernoulli(p=0.015)` | Fraction of males in the MSM pool |
+| `target_mean_degree` | 2.0 | Target mean concurrent partners per pool agent |
+| `target_mean_dur` | `ss.years(2)` | Target mean edge duration |
+| `max_edge_dur` | `ss.years(10)` | Hard cap on edge persistence |
+| `phi` | 1.0 | Turnover parameter (sets initial network density) |
+
+```python
+msm = sti.MSMScaleFreeNetwork(target_mean_degree=3.0)
+```
+
+Note: unlike the other networks, this one is not branching-stable under Common Random Numbers — adding an intervention that perturbs the population reshuffles edges from that point on. Reproducibility holds per `(rand_seed, ti)`. It also does not record edge expirations, so analyzers that depend on them (e.g. `PartnershipFormationAnalyzer`) skip it.
+
 ## API
 
 - `sti.AgeMatchedMSM` — exact-age matching; cheap and deterministic given inputs.
-- `sti.AgeApproxMSM` — distribution-based matching; reuses age preference machinery from `StructuredSexual`.
+- `sti.AgeApproxMSM` — distribution-based matching; reuses age-preference machinery from `MFNetwork`.
+- `sti.MSMScaleFreeNetwork` — preferential-attachment kernel; scale-free degree distribution.

--- a/docs/user_guide/networks/structured_sexual.md
+++ b/docs/user_guide/networks/structured_sexual.md
@@ -1,8 +1,21 @@
 # Structured sexual network
 
-**Class:** `sti.StructuredSexual` | **Base class:** `ss.SexualNetwork`
+**Class:** `sti.StructuredSexual` | **Base class:** `sti.MFNetwork`
 
-The `StructuredSexual` network is STIsim's primary sexual contact network. It is created automatically when you make a sim.
+The `StructuredSexual` network is STIsim's primary sexual contact network. It is created automatically when you make a sim, and bundles heterosexual partnerships with sex work on a single edge list.
+
+## Architecture
+
+STIsim's sexual networks are layered. Each network below extends `sti.BaseNetwork`, which provides the shared machinery: sexual debut, coital acts, condom-use data, and prior-partner recall.
+
+| Class | Models | Notes |
+|-------|--------|-------|
+| `sti.BaseNetwork` | shared infrastructure | debut, acts, condom data, `recall_prior` |
+| `sti.MFNetwork` | heterosexual partnerships | risk groups, concurrency, age mixing |
+| `sti.SWNetwork` | sex work | FSW–client edges |
+| `sti.StructuredSexual` | MF + sex work | the default; extends `MFNetwork` and adds sex-work edges |
+
+`StructuredSexual` keeps the historical API, so `sim.networks.structuredsexual` exposes `fsw`, `client`, risk groups, and concurrency directly. For modular use — heterosexual partnerships without sex work, or sex work alone — use `sti.MFNetwork` or `sti.SWNetwork` directly.
 
 ## Overview
 
@@ -16,12 +29,14 @@ Agents are assigned a **risk group** (low, medium, high) at initialization. Risk
 | 1 (medium) | Marry then divorce, or have concurrent partners | 14% | 18% |
 | 2 (high) | Never marry | 1% | 2% |
 
+Shares are set by `prop_f0`, `prop_m0` (low) and `prop_f2`, `prop_m2` (high); the medium group is the remainder.
+
 ## Partnership types
 
 How a partnership is classified depends on the risk groups of both partners:
 
-- **Stable**: Both partners in the same risk group and pass a stability check (RG0: 90%, RG1: 50%, RG2: 0%)
-- **Casual**: Mismatched risk groups, 50% chance (otherwise one-time)
+- **Stable**: Both partners in the same risk group and pass a stability check (`p_matched_stable`: RG0 90%, RG1 50%, RG2 0%)
+- **Casual**: Mismatched risk groups, 50% chance (`p_mismatched_casual`; otherwise one-time)
 - **One-time**: Single-timestep contact
 - **Sex work**: FSW-client contacts, one-time duration
 
@@ -34,7 +49,7 @@ The number of concurrent partners an agent seeks depends on their sex and risk g
 | Female | 0.0001 | 0.01 | 0.1 |
 | Male | 0.0001 | 0.2 | 0.5 |
 
-Values represent the parameter of a Poisson distribution (+1), so a male in RG2 typically seeks 1-3 concurrent partners.
+Each value is the target *mean* concurrency. By default `concurrency_dist` is a Poisson (`lam` = the value above) and the realized count is `rvs + 1`, so every active agent seeks at least one partner. Set `concurrency_dist` to `ss.nbinom` for an overdispersed alternative — it is reparameterized from the same mean automatically.
 
 ## Age mixing
 
@@ -46,22 +61,29 @@ Women sample a preferred partner age from a normal distribution. Parameters vary
 | Young (20-25) | (8, 3) | (7, 3) | (5, 2) |
 | Adult (25+) | (8, 3) | (7, 3) | (5, 2) |
 
-Values are the age difference (male minus female) in years. Partners are matched by sorting both groups by age.
+Values are the age difference (male minus female) in years.
+
+### Pair matching
+
+How sampled preferences are turned into pairs is set by `match_method`, which selects an algorithm from `sti.networks.matchers` (default `'closest_age_tapered_seeking'`). Pass any registered key, or a callable `f(net) -> (p1, p2)` for a custom matcher.
 
 ## Sex work
 
+FSW and client status are lifetime fates (`fsw_shares`, `client_shares`) gated by a per-agent active window — an entry age (`age_sw_start`) and duration (`dur_sw`) — so an agent counts as currently FSW only while inside that window.
+
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `fsw_shares` | 5% | Proportion of women who are sex workers |
-| `client_shares` | 12% | Proportion of men who are clients |
+| `fsw_shares` | 5% | Lifetime proportion of women who are sex workers |
+| `client_shares` | 12% | Lifetime proportion of men who are clients |
 | `sw_seeking_rate` | 1/month | Rate at which clients seek FSWs |
+| `fsw_mf_conc_mult` | 1.0 | Multiplier on FSW non-sex-work concurrency (values <1 mean active sex workers have fewer non-sex-work partners) |
 
 ## Coital acts and condoms
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `acts` | lognorm(80/yr, 30/yr) | Coital acts per partnership per year |
-| `condom_data` | None | Condom use probability (can be stratified by risk group) |
+| `condom_data` | None | Condom use probability (scalar, or stratified by risk-group pair / sex-work edges) |
 
 Transmission probability per partnership accounts for both condom use and number of acts:
 
@@ -71,6 +93,7 @@ P(transmission) = 1 - [1 - beta * (1 - eff_condom)]^(acts * p_condom) * [1 - bet
 
 STIsim also includes:
 
-- **`ss.MaternalNet`**: Mother-to-child transmission network (created automatically)
-- **`sti.AgeMatchedMSM`**: Men-who-have-sex-with-men network with age-based matching
-- **`sti.PriorPartners`**: Stores former partners for contact tracing (opt-in via `recall_prior=True`)
+- **`sti.MFNetwork`** / **`sti.SWNetwork`**: the heterosexual and sex-work layers, usable standalone (see [Architecture](#architecture)).
+- **`ss.MaternalNet`**: Mother-to-child transmission network (created automatically).
+- **MSM networks**: men-who-have-sex-with-men contact, with several matching strategies — see [MSM networks](msm.md).
+- **`sti.PriorPartners`**: Stores former partners for contact tracing. Add it alongside an MF network and set `recall_prior=True`.

--- a/docs/user_guide/networks/structured_sexual.md
+++ b/docs/user_guide/networks/structured_sexual.md
@@ -65,7 +65,7 @@ Values are the age difference (male minus female) in years.
 
 ### Pair matching
 
-How sampled preferences are turned into pairs is set by `match_method`, which selects an algorithm from `sti.networks.matchers` (default `'closest_age_tapered_seeking'`). Pass any registered key, or a callable `f(net) -> (p1, p2)` for a custom matcher.
+How sampled preferences are turned into pairs is set by `match_method` (default `'closest_age_tapered_seeking'`). See [Pair matching](matching.md) for the algorithms and how to supply your own.
 
 ## Sex work
 

--- a/stisim/analyzers.py
+++ b/stisim/analyzers.py
@@ -1,6 +1,7 @@
 """
 Common analyzers for STI analyses
 """
+import warnings
 
 # %% Imports and settings
 import numpy as np
@@ -10,9 +11,9 @@ import pandas as pd
 
 import stisim as sti
 import pylab as pl
-from collections import defaultdict
+from collections import defaultdict, Counter
 
-__all__ = ["result_grouper", "coinfection_stats", "sw_stats", "RelationshipDurations", "NetworkDegree", "DebutAge", "partner_age_diff", "TimeBetweenRelationships", "art_coverage"]
+__all__ = ["result_grouper", "coinfection_stats", "sw_stats", "RelationshipDurations", "NetworkDegree", "DebutAge", "partner_age_diff", "TimeBetweenRelationships", "art_coverage", "PartnershipFormationAnalyzer"]
 
 class result_grouper(ss.Analyzer):
     """Base analyzer providing conditional probability utilities for grouped results.
@@ -750,4 +751,505 @@ class art_coverage(ss.Analyzer):
 
         pl.tight_layout()
         return fig
+
+
+class PartnershipFormationAnalyzer(ss.Analyzer):
+    """
+    Track partnership formation per network, gender, and age bin.
+
+    Works with any analyzer that subclasses stisim BaseNetwork (that does not have class attribute
+    records_all_expirations set to False on purpose. This attribute (when False) explicitly tells
+    PartnershipFormationAnalyzer the network is not configured to work with it (yet)).
+
+    Stores **one row per distinct edge** with its active interval, rather than
+    re-snapshotting the active edge set every timestep. Formation is detected
+    at the step where ``ti_formed == ti``; the end of the interval comes from
+    the network's ``expired_this_loop`` (populated by ``_on_edge_dissolution`` when
+    ``record_expired=True``), so ``step()`` only touches the per-step *flows*
+    (newly-formed and newly-expired edges), never the active *stock*. Each
+    partner's sex and age-at-formation are read from the edge/people directly, so
+    the analyzer makes no p1=male/p2=female assumption and works for any gender
+    combination (male-female, male-male).
+
+    Recorded state lives in ``self.results['relationships'][nw]``: a list of one mutable
+    row per distinct edge::
+
+        [p1, p2, ti_formed, ti_expired, age_p1, age_p2, female_p1, female_p2]
+
+    ``ti_expired`` is the timestep at which the edge was observed in
+    ``expired_this_loop`` (so its active interval is the half-open
+    ``[ti_formed, ti_expired)``), or ``None`` while the edge is still active
+    at the end of the run. Getters map ``None -> final_ti + 1`` so an ongoing
+    edge tests active through the last timestep.
+
+    .. warning::
+        **Single-edge-per-pair-per-timestep assumption.** Edges are keyed by
+        ``(p1, p2, ti_formed)`` (see ``_indicies_of_rels_in_table_for_nw``). If a network ever forms
+        **more than one edge between the same pair of agents at the same ti**,
+        those edges collide on this key and **expiry data is corrupted**: only
+        the last-formed colliding edge remains reachable for ``ti_expired``
+        recording, so the others keep ``ti_expired = None`` (wrongly treated as
+        active through run end) and their expiry events are dropped. Formation
+        *counts* are unaffected (every edge is still appended as its own row), so
+        only the active-interval results (``get_unique_partners_active_per_agent``
+        and any duration computed from ``ti_expired``) are affected. The bundled
+        networks do not do this; the assumption holds as long as a pair forms at
+        most one edge per network per timestep (the no-concurrent-duplicate-edge
+        invariant noted in ``BaseNetwork.add_pairs``). Forming a second edge
+        between the same pair at a *different* ti is fine (distinct key).
+
+    **Duration semantics.** ``ti_expired`` is defined as one past the last
+    timestep the edge was present and transmission-capable during the disease
+    transmission step (step 9 of the 16-step integration loop). Any duration
+    reported or computed from this analyzer is therefore::
+
+        duration = ti_expired - ti_formed
+                 = number of active transmission steps the relationship existed
+
+    where an "active transmission step" means the edge was present in the
+    network with **both partners alive at step 9** (i.e. structurally available
+    to transmit) -- not that a transmission event actually fired (that further
+    depends on beta, acts, condom use, and infection status). This count is
+    consistent regardless of when a relationship formed, when it dissolved, or
+    why it dissolved:
+
+      - duration expiry at R: active ``{F..R-1}`` -> ``duration = R - F``;
+      - partner death/removal at T: the dying agent's ``alive`` flag flips at
+        step 10 (*after* step 9), so the edge is still active at T -> active
+        ``{F..T}``, ``ti_expired = T+1``, ``duration = (T+1) - F``;
+      - formed and ended-by-death in the same timestep T: active ``{T}`` ->
+        ``duration = 1`` (never a zero/empty interval);
+      - still active at run end: active ``{F..final_ti}`` ->
+        ``duration = (final_ti+1) - F`` (right-censored at the run boundary).
+
+    Note this realized duration can be shorter than the network's drawn ``dur``
+    parameter (the *intended* duration) when a partner dies or leaves early; the
+    analyzer records the realized count, not the drawn one.
+
+    Example (``self.results`` layout, network 'mfnetwork')::
+
+        ana.results['relationships']['mfnetwork'][0]
+        # -> [9, 17, 0, 4, 27.23, 19.62, False, True]
+        #    p1=9, p2=17, ti_formed=0, ti_expired=4 (active ti 0..3),
+        #    ages at formation, female flags. ti_expired is None if still active
+        #    at run end.
+
+    Reporting is via getters (all return ``{network_name: result}``; ``female``
+    selects the subject sex):
+
+      - ``get_n_partnerships_formed(female, age_bins=None, window_months=None)``
+        -- ``{nw: {age_bin: array}}``. With ``window_months=None`` the inner
+        array is the full per-timestep series (length ``n_ti``); with an int it
+        is a single trailing-window sum (length 1).
+      - ``get_n_partnerships_formed_per_agent(female, window_months=None)`` --
+        ``{nw: array}`` of non-unique formation counts per agent over the window.
+      - ``get_unique_partners_active_per_agent(female, window_months=None)`` --
+        ``{nw: array}`` of unique partners per agent on edges active during the
+        window (half-open interval test).
+
+    Args:
+        age_bins (list[str]): Age bin strings parsable by ``ss.parse_age_range``
+            (e.g. ``['0-5', '5-10', ..., '70-75']``). Bins may overlap; a
+            partner is counted in every bin containing its age. Defaults to
+            five-year bins from ``'0-5'`` through ``'70-75'``.
+        networks (list[str] | None): Network names to track. ``None`` (default)
+            tracks every stisim ``BaseNetwork``-derived sexual network in the
+            sim. Named missing networks raise ``ValueError``; named networks that
+            are not ``BaseNetwork``-derived warn and are skipped. A network that
+            cannot record all edge expirations (``records_all_expirations`` is
+            False, e.g. ``MSMScaleFreeNetwork``) is **skipped with a warning**,
+            since its active-interval results would be incomplete. The analyzer
+            requires ``BaseNetwork`` because it reads BaseNetwork-only edge meta
+            (``ti_formed``, ``age_p1``, ``age_p2``) and the ``expired_this_loop``
+            buffer, and sets ``record_expired = True`` on each tracked network.
+    """
+
+    DEFAULT_AGE_BINS = [f'{lo}-{lo+5}' for lo in range(0, 75, 5)]
+
+    # Edge-row column indices (rows stored in self.results['relationships'][nw]).
+    _P1, _P2, _FORMATION_TI, _TI_EXPIRED, _AGE1, _AGE2, _FEM1, _FEM2 = range(8)
+
+    def __init__(self, age_bins: list[str] = None, networks: list[str] = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.age_bins = list(age_bins) if age_bins is not None else list(self.DEFAULT_AGE_BINS)
+
+        # Age-bin strings are used as result dict keys, so duplicates are not
+        # allowed (they would collide). Detect via multiset-minus-set difference:
+        # Counter(all occurrences) - Counter(one of each unique) leaves only the
+        # surplus occurrences, whose keys are exactly the duplicated values.
+        dups = sorted((Counter(self.age_bins) - Counter(set(self.age_bins))).keys())
+        if len(dups) > 0:
+            raise ValueError(f"PartnershipFormationAnalyzer: duplicate age_bins are not allowed: {dups}")
+
+        self.age_ranges = [ss.parse_age_range(b) for b in self.age_bins]
+        self.target_nw_names = networks
+        self._tracked_nw_names = []                     # populated in init_results
+        self._skipped_nw_names = []                  # networks skipped (can't record expirations)
+        self._indicies_of_rels_in_table_for_nw = {}                        # nw -> {(p1,p2,ti_formed): row_idx}, pruned on expiry
+        self._final_uids = {'f': None, 'm': None}    # surviving-agent uids by sex, set in step
+        self._final_ti = None
+        return
+
+    def init_results(self):
+        super().init_results()
+
+        # Validate passed-in network names for tracking. The analyzer requires a
+        # stisim BaseNetwork-derived sexual network (it reads BaseNetwork-only
+        # edge meta -- ti_formed, age_p1, age_p2 -- and the expired_this_loop
+        # buffer), so a plain ss.SexualNetwork is not enough.
+        all_nw_names = self.sim.networks.keys()
+        if self.target_nw_names is None:
+            # default to all BaseNetwork-derived sexual networks
+            candidates = [nw_name for nw_name in all_nw_names
+                          if isinstance(self.sim.networks[nw_name], sti.BaseNetwork)]
+        else:
+            # ensure all requested networks exist
+            missing = [nw_name for nw_name in self.target_nw_names if nw_name not in all_nw_names]
+            if len(missing) > 0:
+                missing_str = ', '.join(missing)
+                raise ValueError(f"PartnershipFormationAnalyzer: network(s) '{missing_str}' not found in sim.networks. "
+                                 f"Available: {sorted(all_nw_names)}.")
+
+            # warn for any requested network that isn't BaseNetwork-derived; it will be ignored.
+            unsupported = [nw_name for nw_name in self.target_nw_names
+                           if not isinstance(self.sim.networks[nw_name], sti.BaseNetwork)]
+            if len(unsupported) > 0:
+                unsupported_str = ', '.join(unsupported)
+                warnings.warn(f"PartnershipFormationAnalyzer: network(s) '{unsupported_str}' not a stisim "
+                              f"BaseNetwork-derived sexual network, ignoring ...")
+            candidates = [nw_name for nw_name in self.target_nw_names
+                          if nw_name not in missing and nw_name not in unsupported]
+
+        # Warn-and-skip networks that cannot record all edge expirations (e.g.
+        # MSMScaleFreeNetwork removes edges outside _on_edge_dissolution), since
+        # their active-interval results (ti_expired) would be incomplete.
+        selected = []
+        for nw_name in candidates:
+            nw = self.sim.networks[nw_name]
+            if not nw.records_all_expirations:
+                self._skipped_nw_names.append(nw_name)
+                warnings.warn(f"PartnershipFormationAnalyzer: network '{nw_name}' "
+                              f"({type(nw).__name__}) does not record all edge expirations "
+                              f"(it removes edges outside _on_edge_dissolution), so "
+                              f"active-interval results would be incomplete; skipping.")
+                continue
+            selected.append(nw_name)
+        self._tracked_nw_names = selected
+
+        # Enable expiration recording on tracked networks (pure read-side-effect;
+        # supplies ti_expired via nw.expired_this_loop each step).
+        for nw_name in self._tracked_nw_names:
+            self.sim.networks[nw_name].record_expired = True
+
+        # One mutable row per distinct edge, plus a key->row index (pruned on
+        # expiry) used only to patch ti_expired in step().
+        self.results['relationships'] = {nw_name: [] for nw_name in self._tracked_nw_names}
+        self._indicies_of_rels_in_table_for_nw = {nw_name: {} for nw_name in self._tracked_nw_names}
+        return
+
+    def _key_for_rel(self, p1, p2, ti_formed):
+        return (int(p1), int(p2), int(ti_formed))
+
+    def step(self):
+        ti = self.ti
+        ppl = self.sim.people
+
+        for nw_name in self._tracked_nw_names:
+            nw = self.sim.networks[nw_name]
+            rel_table = self.results['relationships'][nw_name]
+            rel_to_index = self._indicies_of_rels_in_table_for_nw[nw_name]
+
+            # (1) append newly formed rels this ti to the rels table with ti_expired=None, and index by key for later
+            # recording of actual ti_expired.
+            new_rel_mask = np.asarray(nw.edges.ti_formed, dtype=np.int64) == ti
+            if new_rel_mask.any():
+                p1arr = np.asarray(nw.edges.p1, dtype=np.int64)[new_rel_mask]
+                p2arr = np.asarray(nw.edges.p2, dtype=np.int64)[new_rel_mask]
+                form_ti_arr = np.asarray(nw.edges.ti_formed, dtype=np.int64)[new_rel_mask]
+                age1arr = np.asarray(nw.edges.age_p1, dtype=float)[new_rel_mask]
+                age2arr = np.asarray(nw.edges.age_p2, dtype=float)[new_rel_mask]
+                # Female sex (T/F) of agents in the relationships; not assuming p1/p2 sex for sexual network generality.
+                fem1arr = np.asarray(ppl.female[ss.uids(p1arr)], dtype=bool)
+                fem2arr = np.asarray(ppl.female[ss.uids(p2arr)], dtype=bool)
+                # insert the new edges into the relationship table, recording its table index in the lookup dict
+                # so we can find it later (to update relationship end time). None below denotes as-yet unknown end time.
+                for (p1, p2, form_ti, age1, age2, fem1, fem2) in zip(p1arr, p2arr, form_ti_arr, age1arr, age2arr, fem1arr, fem2arr):
+                    rel_key = self._key_for_rel(p1=p1, p2=p2, ti_formed=form_ti)
+                    rel_to_index[rel_key] = len(rel_table)
+                    # Ensure the order of data here matches the edge row column indicies noted at top of this analyzer
+                    rel_table.append([int(p1), int(p2), int(form_ti), None, float(age1), float(age2), bool(fem1), bool(fem2)])
+
+            # (2) Edges that expired this step (before disease transmission): record ti_expired = ti and prune
+            # the index. Read-only -- the network accumulates into the buffer and clears it itself in finish_step
+            # (step 14); see _record_expired.
+            self._record_expired(nw, rel_table, rel_to_index, ti_expired=ti)
+
+        # Cache surviving-agent uids and final ti for the getters.
+        self._final_uids = {'f': np.asarray(ppl.female.uids, dtype=np.int64),
+                            'm': np.asarray(ppl.male.uids, dtype=np.int64)}
+        self._final_ti = ti
+        return
+
+    def _record_expired(self, nw, rel_table, rel_to_index, ti_expired):
+        """Record ``ti_expired`` on each edge in ``nw.expired_this_loop``.
+
+        Edges are matched to their row by the ``(p1, p2, ti_formed)`` key and
+        the index entry is pruned. This is **read-only** with respect to the
+        network: the network accumulates expirations across ``end_pairs`` and
+        ``remove_uids`` and clears the buffer itself in ``finish_step`` (step 14),
+        so several analyzers can each read the same buffer, and recording works
+        with no analyzer present. Edges never placed in the buffer (i.e. still
+        active) are left untouched, keeping ``ti_expired = None``.
+        """
+        # grab the expired relationship info
+        expired_rels = nw.expired_this_loop
+        # if at least one relationship expired, record known end dates.
+        if len(expired_rels.get('p1', ())) > 0:
+            p1_arr = np.asarray(expired_rels['p1'], dtype=np.int64)
+            p2_arr = np.asarray(expired_rels['p2'], dtype=np.int64)
+            ti_formed_arr = np.asarray(expired_rels['ti_formed'], dtype=np.int64)
+            for p1, p2, form_ti in zip(p1_arr, p2_arr, ti_formed_arr):
+                # Removing the relationship from our rel_to_index mapping, as we only need to record the end date once.
+                rel_key = self._key_for_rel(p1=p1, p2=p2, ti_formed=form_ti)
+                row_idx = rel_to_index.pop(rel_key, None)
+                # set the end date to the specified ti
+                if row_idx is not None:
+                    rel_table[row_idx][self._TI_EXPIRED] = ti_expired
+        return
+
+    def finalize(self):
+        """
+        Resolve still-buffered relationships that expired at the end of the simulation.
+
+        After the loop, the only edges left in a network's ``self.expired_this_loop`` are those removed by death at
+        the **final** step 15 — i.e. after the last ``step()`` read. They were active through the disease phase of the
+        final ti (step 9), so they get ``ti_expired = final_ti + 1``. Relationships/edges still active at sim end were
+        never buffered for removal recording, so they keep ``ti_expired = None`` (the right-censored marker; getter
+        methods treat ``None`` as still-active relationships at simulation end).
+        """
+        ti_expired = self._final_ti + 1
+        for nw_name in self._tracked_nw_names:
+            nw = self.sim.networks[nw_name]
+            rel_table = self.results['relationships'][nw_name]
+            rel_to_index = self._indicies_of_rels_in_table_for_nw[nw_name]
+            self._record_expired(nw, rel_table, rel_to_index, ti_expired=ti_expired)
+
+        super().finalize()
+        return
+
+    def _threshold(self, window_months):
+        """First ti included by a trailing window (None => whole run)."""
+        if window_months is None:
+            return None
+        return self._final_ti - window_months + 1
+
+    def _rel_element_arrs(self, nw_name):
+        """Columnar numpy arrays for one network's edge table.
+
+        ``ti_expired`` is materialized with ``None -> final_ti + 1`` so the
+        half-open active test ``ti_formed <= ti < ti_expired`` treats an
+        ongoing edge as active through the final timestep.
+        """
+        rows = self.results['relationships'][nw_name]
+        n = len(rows)
+        sentinel = self._final_ti + 1
+        if n == 0:
+            z_int = np.empty(0, dtype=np.int64)
+            z_flt = np.empty(0, dtype=float)
+            z_bool = np.empty(0, dtype=bool)
+            return dict(p1=z_int, p2=z_int.copy(), ti_formed=z_int.copy(),
+                        ti_expired=z_int.copy(), age1=z_flt, age2=z_flt.copy(),
+                        fem1=z_bool, fem2=z_bool.copy())
+        cols = list(zip(*rows))  # tuple per column
+        ti_expired = np.fromiter((sentinel if v is None else v for v in cols[self._TI_EXPIRED]),
+                                 dtype=np.int64, count=n)
+        return dict(
+            p1=np.fromiter(cols[self._P1], dtype=np.int64, count=n),
+            p2=np.fromiter(cols[self._P2], dtype=np.int64, count=n),
+            ti_formed=np.fromiter(cols[self._FORMATION_TI], dtype=np.int64, count=n),
+            ti_expired=ti_expired,
+            age1=np.fromiter(cols[self._AGE1], dtype=float, count=n),
+            age2=np.fromiter(cols[self._AGE2], dtype=float, count=n),
+            fem1=np.fromiter(cols[self._FEM1], dtype=bool, count=n),
+            fem2=np.fromiter(cols[self._FEM2], dtype=bool, count=n),
+        )
+
+    @staticmethod
+    def _counts_for_surviving_agents(uids, surviving_agents):
+        """Count occurrences of each uid, aligned to ``surviving_agents`` order."""
+        counts = np.zeros(len(surviving_agents), dtype=np.int64)
+        if len(uids) == 0 or len(surviving_agents) == 0:
+            return counts
+        tally = Counter(int(u) for u in uids)
+        for i, u in enumerate(surviving_agents):
+            counts[i] = tally.get(int(u), 0)
+        return counts
+
+    def get_n_partnerships_formed(self, female=False, age_bins=None, window_months=None):
+        """
+        Total count of partnerships formed (non-unique pairings), per network and age bin.
+
+        When window_months is not used (None), one timeseries of partnership formation counts will be returned per
+        age bin. When window_months is an int, N, it will return single-element lists of partnership formation counts
+        during the final N months of the simulation, one single-element list per age bin.
+
+        Args:
+            female (bool): Subject sex (True=female, False=male).
+            age_bins (list[str] | None): Bins to report; ``None`` (default) uses
+                the analyzer's construction bins. A partner is counted in every
+                bin containing its age at formation (overlapping bins each count
+                it); a partner whose age is outside every bin is not counted.
+            window_months (int | None): If ``None`` (default), the inner array is
+                the full per-timestep series (length ``n_ti``, indexed by ti). If
+                an int, the inner array is a single trailing-window sum
+                (length 1).
+
+        Returns:
+            dict ``{network_name: {age_bin: ndarray}}``. The inner array is
+            length ``n_ti`` when ``window_months is None``, else length 1.
+
+        Example (per timestep, whole run)::
+
+            ana.get_n_partnerships_formed(female=False, age_bins=['15-50', '40-50'])
+            # -> {'mfnetwork': {'15-50': array([0, 2, 0, 0, 4]),   # by timestep
+            #                   '40-50': array([0, 0, 1, 0, 0])}}
+
+        Example (single trailing-window sum)::
+
+            ana.get_n_partnerships_formed(female=False, age_bins=['15-50', '40-50'],
+                                          window_months=12)
+            # -> {'mfnetwork': {'15-50': array([6]),   # sum over last 12 steps
+            #                   '40-50': array([1])}}
+        """
+        bins = self.age_bins if age_bins is None else age_bins
+        ranges = self.age_ranges if age_bins is None else [ss.parse_age_range(b) for b in bins]
+        n_ti = self._final_ti + 1
+        threshold = self._threshold(window_months)
+        lo_ti = 0 if threshold is None else max(0, threshold)
+
+        out = {}
+        for nw_name in self._tracked_nw_names:
+            arr = self._rel_element_arrs(nw_name)
+            # Each subject-sex endpoint of every relationship contributes its (ti_formed, age)
+            # Note: a same-sex relationship contributes both partners (both "formed a relationship" (double counting, but they will be sorted out to potentially different age bins).
+            subject1 = arr['fem1'] if female else ~arr['fem1']
+            subject2 = arr['fem2'] if female else ~arr['fem2']
+            ti_formeds = np.concatenate([arr['ti_formed'][subject1], arr['ti_formed'][subject2]])
+            ages = np.concatenate([arr['age1'][subject1], arr['age2'][subject2]])
+            nw_out = {}
+            for age_bin, (lo, hi) in zip(bins, ranges):
+                age_mask = (ages >= lo) & (ages < hi)
+                # Per-timestep counts: a formation at ti contributes to index ti.
+                per_ti = np.bincount(ti_formeds[age_mask], minlength=n_ti).astype(np.int64)
+                if window_months is None:
+                    # here we store the timeseries of relationship formation for return
+                    nw_out[age_bin] = per_ti
+                else:
+                    # window_months was specified, so instead sum the counts in the final window_months timesteps.
+                    nw_out[age_bin] = np.array([int(per_ti[lo_ti:].sum())])
+            out[nw_name] = nw_out
+        return out
+
+    def get_n_partnerships_formed_per_agent(self, female=False, window_months=None):
+        """
+        Partnerships formed (non-unique) per agent over a trailing window, for agents alive at simulation end.
+
+        Equivalent to asking living agents, "How many partnerships have you formed over the last X months?"
+
+        Args:
+            female (bool): Subject sex.
+            window_months (int | None): Trailing ti window length for partnership counting, None for whole simulation.
+
+        Returns:
+            dict ``{network_name: array}`` indexed like the subject-sex
+            surviving-agent uids (``ana._final_uids['f'|'m']``).
+
+        Example (whole run)::
+
+            ana.get_n_partnerships_formed_per_agent(female=False)
+            # -> {'mfnetwork': array([0, 0, 1, 0, 4, ...])}
+            #    aligned to ana._final_uids['m']; e.g. that male formed 4
+            #    partnerships over the run (non-unique: a re-formed pair counts twice).
+        """
+        threshold = self._threshold(window_months)
+        surviving_agent_uids = self._final_uids['f' if female else 'm']
+        out = {}
+        for nw_name in self._tracked_nw_names:
+            arrs = self._rel_element_arrs(nw_name)
+            # we do not presume sex of p1 and p2, so we grab the selected sex agents from both (p1 and p2 agents,
+            # independently, will be 0-matching or all-matching the female sex bool passed in).
+            sex1 = arrs['fem1'] if female else ~arrs['fem1']
+            sex2 = arrs['fem2'] if female else ~arrs['fem2']
+            uids = np.concatenate([arrs['p1'][sex1], arrs['p2'][sex2]])
+            ti_formeds = np.concatenate([arrs['ti_formed'][sex1], arrs['ti_formed'][sex2]])
+            if threshold is not None:
+                keep = ti_formeds >= threshold
+                uids = uids[keep]
+            out[nw_name] = self._counts_for_surviving_agents(uids, surviving_agent_uids)
+        return out
+
+    def get_unique_partners_active_per_agent(self, female=False, window_months=None):
+        """
+        Unique partner counts per agent over a trailing window, for agents alive at simulation end.
+
+        Equivalent to asking living agents, "How many unique partners have you had over the last X months?"
+
+        An edge counts as active in the trailing window iff it had not expired
+        before the window opened, i.e. ``ti_expired > win_start`` (its half-open
+        active interval ``[ti_formed, ti_expired)`` overlaps the window). The
+        window always ends at the final timestep, so no upper bound on
+        ``ti_formed`` is needed; an ongoing edge carries
+        ``ti_expired = final_ti + 1`` and therefore always counts. For
+        ``window_months=None`` the window is the whole run (``win_start = 0``).
+        Sex-general: the partner is the other endpoint regardless of its sex, so
+        this works for same-sex networks too. Dedups by partner uid (a network is
+        assumed not to hold concurrent duplicate edges between the same pair, so
+        unique partners == unique active partnerships).
+
+        Args:
+            female (bool): Subject sex.
+            window_months (int | None): Trailing ti window length for partner counting, None for whole simulation.
+
+        Returns:
+            dict ``{network_name: array}`` indexed like the subject-sex
+            surviving-agent uids.
+
+        Example (trailing 12 timesteps)::
+
+            ana.get_unique_partners_active_per_agent(female=False, window_months=12)
+            # -> {'mfnetwork': array([1, 0, 2, ...])}
+            #    aligned to ana._final_uids['m']; e.g. the male at index 2 had 2
+            #    distinct partners across edges active during the last 12 steps.
+        """
+        threshold = self._threshold(window_months)
+        win_start = 0 if threshold is None else threshold
+        surviving_agent_uids = self._final_uids['f' if female else 'm']
+        out = {}
+        for nw_name in self._tracked_nw_names:
+            arr = self._rel_element_arrs(nw_name)
+            # ti_expired > win_start drops edges that ended before the window opened;
+            # ongoing edges carry ti_expired = final_ti + 1 (see _rel_element_arrs) so they pass.
+            active_in_win = arr['ti_expired'] > win_start
+
+            # subject_mask1/subject_mask2 select active edges whose p1/p2 (respectively)
+            # is the requested sex (female if female=True, else male).
+            subject_mask1 = active_in_win & (arr['fem1'] if female else ~arr['fem1'])
+            subject_mask2 = active_in_win & (arr['fem2'] if female else ~arr['fem2'])
+
+            # female (bool) identifies the subject -- subjects can be in p1 and/or p2 as we do not assume sex of p1/p2
+            subjects = np.concatenate([arr['p1'][subject_mask1], arr['p2'][subject_mask2]])
+            # swapping p1/p2 identifies the partners of the subjects (in subject-order of arrays)
+            partners = np.concatenate([arr['p2'][subject_mask1], arr['p1'][subject_mask2]])
+
+            if len(subjects) > 0:
+                # Distinct (subject, partner) pairs -> count partners per subject.
+                # Create 2-element pairing arrays from aligned subjects and partners arrays ([[sub0, part0], ..., [subN, partN]]
+                pairings = np.stack([subjects, partners], axis=1)
+
+                # treats each [subI, partI] element as items to be uniquified
+                unique_pairs = np.unique(pairings, axis=0)
+                out[nw_name] = self._counts_for_surviving_agents(unique_pairs[:, 0], surviving_agent_uids)
+            else:
+                out[nw_name] = np.zeros(len(surviving_agent_uids), dtype=np.int64)
+        return out
 

--- a/stisim/connectors/gud_syph.py
+++ b/stisim/connectors/gud_syph.py
@@ -36,9 +36,9 @@ class gud_syph(ss.Connector):
         sim.diseases.syphilis.rel_trans[sim.people.gud.infected] = self.pars.rel_trans_syph_gud
 
         # People with active syphilis are more likely to acquire GUD
-        sim.diseases.gud.rel_sus[sim.diseases.syphilis.active] = self.pars.rel_sus_gud_syph
+        sim.diseases.gud.rel_sus[sim.diseases.syphilis.symptomatic] = self.pars.rel_sus_gud_syph
 
         # People with active syphilis are more likely to transmit GUD
-        sim.diseases.gud.rel_trans[sim.diseases.syphilis.active] = self.pars.rel_trans_gud_syph
+        sim.diseases.gud.rel_trans[sim.diseases.syphilis.symptomatic] = self.pars.rel_trans_gud_syph
 
         return

--- a/stisim/connectors/hiv_sti.py
+++ b/stisim/connectors/hiv_sti.py
@@ -57,7 +57,7 @@ class hiv_syph(ss.Connector):
     def step(self):
 
         # HIV changes due to syphilis
-        syphilis = self.syphilis.active
+        syphilis = self.syphilis.symptomatic
         self.hiv.rel_sus[syphilis] *= self.rel_sus_hiv_syph[syphilis]
         self.hiv.rel_trans[syphilis] *= self.rel_trans_hiv_syph[syphilis]
 

--- a/stisim/diseases/bv.py
+++ b/stisim/diseases/bv.py
@@ -50,7 +50,6 @@ class SimpleBV(ss.Disease):
             p_base=0.45,                 # Used to calculate the baseline (intercept) probability of spontaneous occurrence
             p_spontaneous=sc.objdict(
                 douching=3,             # OR of BV for douching
-                n_partners_12m=2,       # OR of BV for each additional partner in the past 12 months - not working yet
                 poor_menstrual_hygiene=2,    # OR of BV for poor menstrual hygiene
             ),
 
@@ -78,7 +77,6 @@ class SimpleBV(ss.Disease):
             ss.FloatArr('ti_symptomatic', label='Time of symptoms'),
             ss.FloatArr('dur_inf', label='Duration of infection'),
             ss.BoolArr('douching', label='Douching'),
-            ss.FloatArr('n_partners_12m', default=0, label='Number of partners in the past 12 months'),
             ss.BoolArr('poor_menstrual_hygiene', label='Poor menstrual hygiene'),
         )
         self.sex_keys = {'': 'alive', 'f': 'female', 'm': 'male'}

--- a/stisim/diseases/sti.py
+++ b/stisim/diseases/sti.py
@@ -120,7 +120,7 @@ class BaseSTI(ss.Infection):
         init_prev_data: Initial prevalence data (float or DataFrame by age/sex/risk group).
         **kwargs: Additional parameters passed to ``update_pars``.
     """
-    def __init__(self, name=None, pars=None, init_prev_data=None, **kwargs):
+    def __init__(self, name=None, pars=None, init_prev_data=None, age_range=None, **kwargs):
         super().__init__(name=name)
 
         # Handle parameters
@@ -142,7 +142,7 @@ class BaseSTI(ss.Infection):
 
 
         # Results
-        self.age_range = [15, 50]  # Age range for main results e.g. prevalence
+        self.age_range = age_range if age_range is not None else [15, 50]  # Age range for main results e.g. prevalence
         self.age_bins = np.array([0, 15, 20, 25, 30, 35, 50, 65, 100])  # Age bins for results
         self.sex_keys = {'': 'alive', 'f': 'female', 'm': 'male'}
 

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -291,7 +291,8 @@ class Syphilis(BaseSTI):
 
     @property
     def active(self):
-        """ Active infection includes primary and secondary stages """
+        """ Active infection includes primary and secondary stages. Used by
+        connectors (hiv_sti, gud_syph) for coinfection coupling. """
         return self.primary | self.secondary
 
     @property
@@ -300,13 +301,30 @@ class Syphilis(BaseSTI):
         return self.active | self.latent
 
     @property
+    def sexually_transmissible(self):
+        """ Stages during which syphilis is sexually transmissible: primary,
+        secondary, and early latent. Late latent and tertiary are not
+        normally sexually transmissible (late latent can still transmit
+        congenitally at low levels). Matches WHO 'early infectious syphilis'. """
+        return self.primary | self.secondary | self.early
+
+    @property
+    def symptomatic(self):
+        """ Symptomatic stages of syphilis: primary or secondary. Distinct from
+        ``visibly_symptomatic``, which requires that the symptom actually be
+        observable (chancre at a visible site, or rash). """
+        return self.primary | self.secondary
+
+    @property
     def ulcerative(self):
         """ Has a visible genital ulcer (chancre at a visible site during primary stage) """
         return self.chancre_visible & self.primary
 
     @property
-    def symptomatic(self):
-        """ Has noticeable symptoms: visible ulcer or visible rash """
+    def visibly_symptomatic(self):
+        """ Has clinically detectable symptoms: visible ulcer or visible rash.
+        Used by care-seeking pathways. (Formerly named ``symptomatic``; renamed
+        2026-06-08 to free that name for the disease-stage definition.) """
         return self.ulcerative | (self.rash_visible & self.secondary)
 
     def init_post(self):
@@ -344,7 +362,10 @@ class Syphilis(BaseSTI):
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
-            ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
+            ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence (primary + secondary)"),
+            ss.Result('sexually_transmissible_prevalence', dtype=float, scale=False, label="Sexually transmissible (primary + secondary + early latent)"),
+            ss.Result('symptomatic_prevalence', dtype=float, scale=False, label="Symptomatic stage prevalence (primary + secondary)"),
+            ss.Result('primary_prevalence', dtype=float, scale=False, label="Primary stage prevalence"),
             ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive — matches ZIMPHIA dual-positive 'active syph'"),
             ss.Result('nontrep_prevalence_15_64', dtype=float, scale=False, label="Non-treponemal positive, ages 15-64 (household-survey denominator)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
@@ -372,15 +393,23 @@ class Syphilis(BaseSTI):
                     ss.Result(f'trep_prevalence{skk}', scale=False, label=f"Treponemal-test positive{skl}", auto_plot=False),
                     ss.Result(f'trep_prevalence_15_64{skk}', scale=False, label=f"Treponemal-test positive, ages 15-64{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
+                    ss.Result(f'sexually_transmissible_prevalence{skk}', scale=False, label=f"Sexually transmissible prevalence{skl}", auto_plot=False),
+                    ss.Result(f'symptomatic_prevalence{skk}', scale=False, label=f"Symptomatic prevalence{skl}", auto_plot=False),
+                    ss.Result(f'primary_prevalence{skk}', scale=False, label=f"Primary stage prevalence{skl}", auto_plot=False),
                     ss.Result(f'nontrep_prevalence{skk}', scale=False, label=f"Non-treponemal positive{skl}", auto_plot=False),
                     ss.Result(f'nontrep_prevalence_15_64{skk}', scale=False, label=f"Non-treponemal positive, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
                 ask = f'{skk}_{ab1}_{ab2}'
-                asl = f' ({skl}, {ab2}-{ab2})'
+                asl = f' ({skl}, {ab1}-{ab2})'
                 results += [
                     ss.Result(f'active_prevalence{ask}', scale=False, label=f"Active prevalence{asl}", auto_plot=False),
+                    ss.Result(f'sexually_transmissible_prevalence{ask}', scale=False, label=f"Sexually transmissible prevalence{asl}", auto_plot=False),
+                    ss.Result(f'symptomatic_prevalence{ask}', scale=False, label=f"Symptomatic prevalence{asl}", auto_plot=False),
+                    ss.Result(f'primary_prevalence{ask}', scale=False, label=f"Primary stage prevalence{asl}", auto_plot=False),
+                    ss.Result(f'trep_prevalence{ask}', scale=False, label=f"Treponemal positive{asl}", auto_plot=False),
+                    ss.Result(f'nontrep_prevalence{ask}', scale=False, label=f"Non-treponemal positive{asl}", auto_plot=False),
                 ]
 
         # Add FSW and clients to results:
@@ -558,6 +587,10 @@ class Syphilis(BaseSTI):
         self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
         self.results['trep_prevalence_15_64'][ti] = cond_prob(self.trep, adults_15_64)
         self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
+        self.results['active_prevalence'][ti] = cond_prob(self.active, sexually_active_adults)
+        self.results['sexually_transmissible_prevalence'][ti] = cond_prob(self.sexually_transmissible, sexually_active_adults)
+        self.results['symptomatic_prevalence'][ti] = cond_prob(self.symptomatic, sexually_active_adults)
+        self.results['primary_prevalence'][ti] = cond_prob(self.primary, sexually_active_adults)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -601,7 +634,6 @@ class Syphilis(BaseSTI):
         for pkey, pattr in self.sex_keys.items():
             skk = '' if pkey == '' else f'_{pkey}'
 
-            n_act = self.active & ppl[pattr]
             sex_denom = sexually_active_adults & ppl[pattr]
             sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
@@ -610,10 +642,21 @@ class Syphilis(BaseSTI):
                 self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
                 self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.trep, sex_denom_15_64)
                 self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
+                self.results[f'symptomatic_prevalence{skk}'][ti] = cond_prob(self.symptomatic, sex_denom)
+                self.results[f'sexually_transmissible_prevalence{skk}'][ti] = cond_prob(self.sexually_transmissible, sex_denom)
+                self.results[f'primary_prevalence{skk}'][ti] = cond_prob(self.primary, sex_denom)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
-            # Compute age results
-            age_results = dict(active_prevalence = div(self.agehist(n_act), self.agehist(ppl[pattr])))
+            # Compute age-binned prevalences (denominator = all people of that sex in each age bin)
+            ppl_pattr_hist = self.agehist(ppl[pattr])
+            age_results = dict(
+                active_prevalence = div(self.agehist(self.active & ppl[pattr]), ppl_pattr_hist),
+                sexually_transmissible_prevalence = div(self.agehist(self.sexually_transmissible & ppl[pattr]), ppl_pattr_hist),
+                symptomatic_prevalence = div(self.agehist(self.symptomatic & ppl[pattr]), ppl_pattr_hist),
+                primary_prevalence = div(self.agehist(self.primary & ppl[pattr]), ppl_pattr_hist),
+                trep_prevalence = div(self.agehist(self.trep & ppl[pattr]), ppl_pattr_hist),
+                nontrep_prevalence = div(self.agehist(self.nontrep & ppl[pattr]), ppl_pattr_hist),
+            )
 
             # Store age results
             for akey, ares in age_results.items():

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -313,6 +313,7 @@ class Syphilis(BaseSTI):
         super().init_results()
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
+            ss.Result('serological_prevalence', dtype=float, scale=False, label="Serological prevalence (ever exposed)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
@@ -339,6 +340,7 @@ class Syphilis(BaseSTI):
             skl = '' if sk == '' else f' ({sk.upper()})'
             if skk != '':
                 results += [
+                    ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
                 ]
 
@@ -496,7 +498,7 @@ class Syphilis(BaseSTI):
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
-        # self.results['active_prevalence'][ti] = cond_prob(self.active, sexually_active_adults)
+        self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -541,7 +543,11 @@ class Syphilis(BaseSTI):
             skk = '' if pkey == '' else f'_{pkey}'
 
             n_act = self.active & ppl[pattr]
-            self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, adults & ppl[pattr])
+            sex_denom = sexually_active_adults & ppl[pattr]
+            if skk != '':
+                self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
+                self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+            self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results
             age_results = dict(active_prevalence = div(self.agehist(n_act), self.agehist(ppl[pattr])))

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -323,11 +323,13 @@ class Syphilis(BaseSTI):
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
             ss.Result('serological_prevalence', dtype=float, scale=False, label="Serological prevalence (ever exposed)"),
+            ss.Result('serological_prevalence_15_64', dtype=float, scale=False, label="Serological prevalence, ages 15-64 (household-survey denominator)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
             ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
             ss.Result('detectable_prevalence', dtype=float, scale=False, label="Detectable prevalence (non-trep RDT positive)"),
+            ss.Result('detectable_prevalence_15_64', dtype=float, scale=False, label="Detectable prevalence, ages 15-64 (household-survey denominator)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -351,8 +353,10 @@ class Syphilis(BaseSTI):
             if skk != '':
                 results += [
                     ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
+                    ss.Result(f'serological_prevalence_15_64{skk}', scale=False, label=f"Serological prevalence, ages 15-64{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
                     ss.Result(f'detectable_prevalence{skk}', scale=False, label=f"Detectable prevalence{skl}", auto_plot=False),
+                    ss.Result(f'detectable_prevalence_15_64{skk}', scale=False, label=f"Detectable prevalence, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
@@ -515,11 +519,15 @@ class Syphilis(BaseSTI):
         n_active = res['n_primary'][ti] + res['n_secondary'][ti]
         adults = (ppl.age >= 15) & (ppl.age < 50)
         sexually_active_adults = adults & self.sim.networks.structuredsexual.active(self.sim.people)
+        # Household-survey denominator (ZIMPHIA, etc.): all alive 15-64, no debut/network filter.
+        adults_15_64 = (ppl.age >= 15) & (ppl.age < 65) & ppl.alive
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
         self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
         self.results['detectable_prevalence'][ti] = cond_prob(self.detectable, sexually_active_adults)
+        self.results['serological_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
+        self.results['detectable_prevalence_15_64'][ti] = cond_prob(self.detectable, adults_15_64)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -565,10 +573,13 @@ class Syphilis(BaseSTI):
 
             n_act = self.active & ppl[pattr]
             sex_denom = sexually_active_adults & ppl[pattr]
+            sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
                 self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
                 self.results[f'detectable_prevalence{skk}'][ti] = cond_prob(self.detectable, sex_denom)
+                self.results[f'serological_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
+                self.results[f'detectable_prevalence_15_64{skk}'][ti] = cond_prob(self.detectable, sex_denom_15_64)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -642,10 +642,18 @@ class Syphilis(BaseSTI):
 
     def set_latent_trans(self, ti=None):
         if ti is None: ti = self.ti
+        # Latent rel_trans starts at the secondary-stage level and decays
+        # exponentially with half-life rel_trans_latent_half_life. Using
+        # rel_trans_secondary as the starting value ensures any increase in
+        # secondary transmissibility propagates smoothly into latent (no
+        # discontinuity at the secondary->latent boundary). The
+        # rel_trans_latent parameter is retained for backward compat as a
+        # multiplier on the secondary starting level.
         dur_latent = ti - self.ti_latent[self.latent]
         hl = self.pars.rel_trans_latent_half_life
         decay_rate = np.log(2) / hl if ~np.isnan(hl) else 0.
-        latent_trans = self.pars.rel_trans_latent * np.exp(-decay_rate * dur_latent)
+        starting = self.pars.rel_trans_secondary * self.pars.rel_trans_latent
+        latent_trans = starting * np.exp(-decay_rate * dur_latent)
         self.rel_trans[self.latent] = latent_trans
         return
 

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -31,6 +31,11 @@ class SyphilisPlaceholder(ss.Disease):
 
         return
 
+    @property
+    def symptomatic(self):
+        """ Alias for the active state, so connectors share an interface with the full Syphilis module """
+        return self.active
+
     def init_pre(self, sim):
         super().init_pre(sim)
         if not isinstance(self.pars.prevalence, sti.TimeSeries):
@@ -84,13 +89,10 @@ class SyphPars(BaseSTIPars):
         self.time_to_death = ss.lognorm_ex(ss.years(5), ss.years(5))  # Time to death
 
         # Time from late-latent onset until non-treponemal titre falls below
-        # detection threshold on serological tests (WHO 2021 fig 7: late latent
-        # described as "maybe positive but lower titres, possibly negative").
-        # Wide default prior; expected to be tuned in calibration. Expert input
-        # pending.
-        self.time_to_undetectable = ss.lognorm_ex(ss.years(5), ss.years(5))
+        # detection threshold on serological tests
+        self.time_to_undetectable = ss.lognorm_ex(ss.years(15), ss.years(5))
 
-        # Treponemal-test seroconversion + persistence (WHO report):
+        # Treponemal-test seroconversion + persistence
         #   - dur_to_trep: time from infection to trep antibody detection
         #     (window period during which the agent is infected but the
         #     trep test is still negative; ~2-3 weeks for IgM/IgG)
@@ -109,7 +111,6 @@ class SyphPars(BaseSTIPars):
         self.eff_condom = 0.0
         self.rel_trans_primary = 1
         self.rel_trans_secondary = 1
-        self.rel_trans_latent = 1  # Baseline level; this decays exponentially with duration of latent infection
         self.rel_trans_tertiary = 0.0
         self.rel_trans_latent_half_life = ss.years(1)
 
@@ -152,8 +153,8 @@ class SyphPars(BaseSTIPars):
 
 class Syphilis(BaseSTI):
 
-    def __init__(self, pars=None, name='syph', init_prev_data=None, init_prev_latent_data=None, **kwargs):
-        super().__init__(name=name)
+    def __init__(self, pars=None, name='syph', init_prev_data=None, init_prev_latent_data=None, age_range=None, **kwargs):
+        super().__init__(name=name, age_range=age_range)
 
         # Define default parameters
         default_pars = SyphPars()
@@ -180,7 +181,7 @@ class Syphilis(BaseSTI):
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
             ss.BoolState('ever_exposed'), # Biological: ever infected (lifetime); used for is_naive/sus_not_naive logic
             ss.BoolState('trep'),         # Treponemal test positive (matches what a real trep RDT would detect: 80% persist for life, 20% sero-revert eventually)
-            ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive — would be flagged dual-positive in ZIMPHIA's "active infection" category
+            ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
             # Symptom visibility — determined at infection/stage entry, reflects anatomical site
@@ -290,15 +291,9 @@ class Syphilis(BaseSTI):
         return self.exposed | self.primary | self.secondary
 
     @property
-    def active(self):
-        """ Active infection includes primary and secondary stages. Used by
-        connectors (hiv_sti, gud_syph) for coinfection coupling. """
-        return self.primary | self.secondary
-
-    @property
     def infectious(self):
         """ Infectious """
-        return self.active | self.latent
+        return self.symptomatic | self.latent
 
     @property
     def sexually_transmissible(self):
@@ -323,8 +318,7 @@ class Syphilis(BaseSTI):
     @property
     def visibly_symptomatic(self):
         """ Has clinically detectable symptoms: visible ulcer or visible rash.
-        Used by care-seeking pathways. (Formerly named ``symptomatic``; renamed
-        2026-06-08 to free that name for the disease-stage definition.) """
+        Used by care-seeking pathways. """
         return self.ulcerative | (self.rash_visible & self.secondary)
 
     def init_post(self):
@@ -357,17 +351,14 @@ class Syphilis(BaseSTI):
         super().init_results()
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
-            ss.Result('trep_prevalence', dtype=float, scale=False, label="Treponemal-test positive (ever-exposed proxy; matches ZIMPHIA total seroprev)"),
-            ss.Result('trep_prevalence_15_64', dtype=float, scale=False, label="Treponemal-test positive, ages 15-64 (household-survey denominator)"),
+            ss.Result('trep_prevalence', dtype=float, scale=False, label="Treponemal-test positive (ever-exposed proxy)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
-            ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence (primary + secondary)"),
             ss.Result('sexually_transmissible_prevalence', dtype=float, scale=False, label="Sexually transmissible (primary + secondary + early latent)"),
             ss.Result('symptomatic_prevalence', dtype=float, scale=False, label="Symptomatic stage prevalence (primary + secondary)"),
             ss.Result('primary_prevalence', dtype=float, scale=False, label="Primary stage prevalence"),
-            ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive — matches ZIMPHIA dual-positive 'active syph'"),
-            ss.Result('nontrep_prevalence_15_64', dtype=float, scale=False, label="Non-treponemal positive, ages 15-64 (household-survey denominator)"),
+            ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -391,20 +382,16 @@ class Syphilis(BaseSTI):
             if skk != '':
                 results += [
                     ss.Result(f'trep_prevalence{skk}', scale=False, label=f"Treponemal-test positive{skl}", auto_plot=False),
-                    ss.Result(f'trep_prevalence_15_64{skk}', scale=False, label=f"Treponemal-test positive, ages 15-64{skl}", auto_plot=False),
-                    ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
                     ss.Result(f'sexually_transmissible_prevalence{skk}', scale=False, label=f"Sexually transmissible prevalence{skl}", auto_plot=False),
                     ss.Result(f'symptomatic_prevalence{skk}', scale=False, label=f"Symptomatic prevalence{skl}", auto_plot=False),
                     ss.Result(f'primary_prevalence{skk}', scale=False, label=f"Primary stage prevalence{skl}", auto_plot=False),
                     ss.Result(f'nontrep_prevalence{skk}', scale=False, label=f"Non-treponemal positive{skl}", auto_plot=False),
-                    ss.Result(f'nontrep_prevalence_15_64{skk}', scale=False, label=f"Non-treponemal positive, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
                 ask = f'{skk}_{ab1}_{ab2}'
                 asl = f' ({skl}, {ab1}-{ab2})'
                 results += [
-                    ss.Result(f'active_prevalence{ask}', scale=False, label=f"Active prevalence{asl}", auto_plot=False),
                     ss.Result(f'sexually_transmissible_prevalence{ask}', scale=False, label=f"Sexually transmissible prevalence{asl}", auto_plot=False),
                     ss.Result(f'symptomatic_prevalence{ask}', scale=False, label=f"Symptomatic prevalence{asl}", auto_plot=False),
                     ss.Result(f'primary_prevalence{ask}', scale=False, label=f"Primary stage prevalence{asl}", auto_plot=False),
@@ -576,18 +563,13 @@ class Syphilis(BaseSTI):
         ppl = self.sim.people
 
         n_active = res['n_primary'][ti] + res['n_secondary'][ti]
-        adults = (ppl.age >= 15) & (ppl.age < 50)
+        adults = (ppl.age >= self.age_range[0]) & (ppl.age < self.age_range[1])
         sexually_active_adults = adults & self.sim.networks.structuredsexual.active(self.sim.people)
-        # Household-survey denominator (ZIMPHIA, etc.): all alive 15-64, no debut/network filter.
-        adults_15_64 = (ppl.age >= 15) & (ppl.age < 65) & ppl.alive
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
         self.results['trep_prevalence'][ti] = cond_prob(self.trep, sexually_active_adults)
         self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
-        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.trep, adults_15_64)
-        self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
-        self.results['active_prevalence'][ti] = cond_prob(self.active, sexually_active_adults)
         self.results['sexually_transmissible_prevalence'][ti] = cond_prob(self.sexually_transmissible, sexually_active_adults)
         self.results['symptomatic_prevalence'][ti] = cond_prob(self.symptomatic, sexually_active_adults)
         self.results['primary_prevalence'][ti] = cond_prob(self.primary, sexually_active_adults)
@@ -635,22 +617,17 @@ class Syphilis(BaseSTI):
             skk = '' if pkey == '' else f'_{pkey}'
 
             sex_denom = sexually_active_adults & ppl[pattr]
-            sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
                 self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.trep, sex_denom)
                 self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
-                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.trep, sex_denom_15_64)
-                self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
                 self.results[f'symptomatic_prevalence{skk}'][ti] = cond_prob(self.symptomatic, sex_denom)
                 self.results[f'sexually_transmissible_prevalence{skk}'][ti] = cond_prob(self.sexually_transmissible, sex_denom)
                 self.results[f'primary_prevalence{skk}'][ti] = cond_prob(self.primary, sex_denom)
-            self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age-binned prevalences (denominator = all people of that sex in each age bin)
             ppl_pattr_hist = self.agehist(ppl[pattr])
             age_results = dict(
-                active_prevalence = div(self.agehist(self.active & ppl[pattr]), ppl_pattr_hist),
                 sexually_transmissible_prevalence = div(self.agehist(self.sexually_transmissible & ppl[pattr]), ppl_pattr_hist),
                 symptomatic_prevalence = div(self.agehist(self.symptomatic & ppl[pattr]), ppl_pattr_hist),
                 primary_prevalence = div(self.agehist(self.primary & ppl[pattr]), ppl_pattr_hist),
@@ -685,17 +662,10 @@ class Syphilis(BaseSTI):
 
     def set_latent_trans(self, ti=None):
         if ti is None: ti = self.ti
-        # Latent rel_trans starts at the secondary-stage level and decays
-        # exponentially with half-life rel_trans_latent_half_life. Using
-        # rel_trans_secondary as the starting value ensures any increase in
-        # secondary transmissibility propagates smoothly into latent (no
-        # discontinuity at the secondary->latent boundary). The
-        # rel_trans_latent parameter is retained for backward compat as a
-        # multiplier on the secondary starting level.
         dur_latent = ti - self.ti_latent[self.latent]
         hl = self.pars.rel_trans_latent_half_life
         decay_rate = np.log(2) / hl if ~np.isnan(hl) else 0.
-        starting = self.pars.rel_trans_secondary * self.pars.rel_trans_latent
+        starting = self.pars.rel_trans_secondary
         latent_trans = starting * np.exp(-decay_rate * dur_latent)
         self.rel_trans[self.latent] = latent_trans
         return
@@ -763,7 +733,7 @@ class Syphilis(BaseSTI):
         dur_secondary = self.pars.dur_secondary.rvs(uids)
         self.ti_latent[uids] = self.ti_secondary[uids] + rr(dur_secondary)
         # Non-treponemal titre rises by secondary; RPR becomes positive.
-        # Also covers reactivation from late latent (titre climbs again — Fig 7).
+        # Also covers reactivation from late latent (titre climbs again).
         self.nontrep[uids] = True
         return
 

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -83,6 +83,13 @@ class SyphPars(BaseSTIPars):
         self.p_death = ss.bernoulli(p=0.05)  # probability of dying of tertiary syphilis
         self.time_to_death = ss.lognorm_ex(ss.years(5), ss.years(5))  # Time to death
 
+        # Time from late-latent onset until non-treponemal titre falls below
+        # detection threshold on serological tests (WHO 2021 fig 7: late latent
+        # described as "maybe positive but lower titres, possibly negative").
+        # Wide default prior; expected to be tuned in calibration. Expert input
+        # pending.
+        self.time_to_undetectable = ss.lognorm_ex(ss.years(5), ss.years(5))
+
         # Transmission by stage
         self.beta_m2f = 0.1
         self.eff_condom = 0.0
@@ -158,6 +165,7 @@ class Syphilis(BaseSTI):
             ss.BoolState('tertiary'),     # Includes complications (cardio/neuro/disfigurement)
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
             ss.BoolState('ever_exposed'), # Anyone ever exposed - stays true after treatment
+            ss.BoolState('detectable'),   # Non-treponemal serology positive (dual-RDT 'active syph' would detect)
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
             # Symptom visibility — determined at infection/stage entry, reflects anatomical site
@@ -175,6 +183,7 @@ class Syphilis(BaseSTI):
             ss.FloatArr('ti_latent'),
             ss.FloatArr('dur_early'),
             ss.FloatArr('ti_tertiary'),
+            ss.FloatArr('ti_detectable_end'),  # When non-trep titre drops below detection
             ss.FloatArr('ti_dead'),
             ss.FloatArr('ti_immune'),
             ss.FloatArr('ti_miscarriage'),
@@ -318,6 +327,7 @@ class Syphilis(BaseSTI):
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
             ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
+            ss.Result('detectable_prevalence', dtype=float, scale=False, label="Detectable prevalence (non-trep RDT positive)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -342,6 +352,7 @@ class Syphilis(BaseSTI):
                 results += [
                     ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
+                    ss.Result(f'detectable_prevalence{skk}', scale=False, label=f"Detectable prevalence{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
@@ -456,6 +467,14 @@ class Syphilis(BaseSTI):
             self.late[is_early] = False
             self.late[is_late] = True
 
+        # Serology detectability: non-trep titre falls below detection at
+        # the per-agent ti_detectable_end (drawn from time_to_undetectable in
+        # set_latent_prognoses). Reactivation back to secondary re-sets
+        # detectable=True in set_secondary_prognoses.
+        becomes_undetectable = self.detectable & (self.ti_detectable_end <= ti)
+        if len(becomes_undetectable.uids) > 0:
+            self.detectable[becomes_undetectable] = False
+
         return
 
     def step_die(self, uids):
@@ -473,6 +492,7 @@ class Syphilis(BaseSTI):
         self.immune[uids] = False
         self.congenital[uids] = False
         self.ever_exposed[uids] = False
+        self.detectable[uids] = False
         self.n_infections[uids] = 0
         self.chancre_visible[uids] = False
         self.rash_visible[uids] = False
@@ -499,6 +519,7 @@ class Syphilis(BaseSTI):
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
         self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
+        self.results['detectable_prevalence'][ti] = cond_prob(self.detectable, sexually_active_adults)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -547,6 +568,7 @@ class Syphilis(BaseSTI):
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
                 self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+                self.results[f'detectable_prevalence{skk}'][ti] = cond_prob(self.detectable, sex_denom)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results
@@ -636,9 +658,18 @@ class Syphilis(BaseSTI):
         """ Set prognoses for people who have just progressed to secondary infection """
         dur_secondary = self.pars.dur_secondary.rvs(uids)
         self.ti_latent[uids] = self.ti_secondary[uids] + rr(dur_secondary)
+        # Non-treponemal titre rises by secondary; serology becomes detectable.
+        # Also covers reactivation from late latent (titre climbs again — Fig 7).
+        self.detectable[uids] = True
         return
 
     def set_latent_prognoses(self, uids):
+        # Late-latent serology: draw the time at which non-trep titre is
+        # expected to fall below detection. ti_detectable_end is measured
+        # from the *start of late latent* = ti_latent + dur_early.
+        late_start = self.ti_latent[uids] + self.dur_early[uids]
+        self.ti_detectable_end[uids] = late_start + rr(self.pars.time_to_undetectable.rvs(uids))
+
         # Reactivators
         will_reactivate = self.pars.p_reactivate.rvs(uids)
         reactivate_uids = uids[will_reactivate]

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -75,7 +75,7 @@ class SyphPars(BaseSTIPars):
         self.dur_exposed = ss.normal(ss.days(50), ss.days(10))  # https://pubmed.ncbi.nlm.nih.gov/9101629/
         self.dur_primary = ss.normal(ss.weeks(6), ss.weeks(1))  # https://pubmed.ncbi.nlm.nih.gov/9101629/
         self.dur_secondary = ss.lognorm_ex(ss.months(3.6), ss.months(1.5))  # https://pubmed.ncbi.nlm.nih.gov/9101629/
-        self.dur_early = ss.uniform(ss.months(12), ss.months(14))  # Assumption
+        self.dur_early = ss.uniform(ss.months(22), ss.months(24))  # Early-latent boundary matches WHO Europe definition (≤2 years post-infection)
         self.p_reactivate = ss.bernoulli(p=0.35)  # Probability of reactivating from latent to secondary
         self.time_to_reactivate = ss.lognorm_ex(ss.years(1), ss.years(1))  # Time to reactivation
         self.p_tertiary = ss.bernoulli(p=0.35)  # https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4917057/
@@ -89,6 +89,20 @@ class SyphPars(BaseSTIPars):
         # Wide default prior; expected to be tuned in calibration. Expert input
         # pending.
         self.time_to_undetectable = ss.lognorm_ex(ss.years(5), ss.years(5))
+
+        # Treponemal-test seroconversion + persistence (WHO report):
+        #   - dur_to_trep: time from infection to trep antibody detection
+        #     (window period during which the agent is infected but the
+        #     trep test is still negative; ~2-3 weeks for IgM/IgG)
+        #   - p_trep_persists: 80% of trep-positive agents remain trep+
+        #     for life. The other 20% sero-revert eventually.
+        #   - time_to_trep_revert: timing for the 20% who do sero-revert
+        #     (slow, variable; mean ~10y post-seroconversion)
+        # Agents treated BEFORE ti_trep_start (window-period treatment)
+        # never become trep+ — SyphTx handles that case in change_states.
+        self.dur_to_trep = ss.normal(ss.weeks(3), ss.weeks(1))
+        self.p_trep_persists = ss.bernoulli(p=0.80)
+        self.time_to_trep_revert = ss.normal(ss.years(10), ss.years(5))
 
         # Transmission by stage
         self.beta_m2f = 0.1
@@ -164,7 +178,8 @@ class Syphilis(BaseSTI):
             ss.BoolState('latent'),       # Can relapse to secondary, remain in latent, or progress to tertiary,
             ss.BoolState('tertiary'),     # Includes complications (cardio/neuro/disfigurement)
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
-            ss.BoolState('ever_exposed'), # Anyone ever exposed - proxy for treponemal-test positive (antibodies persist for life)
+            ss.BoolState('ever_exposed'), # Biological: ever infected (lifetime); used for is_naive/sus_not_naive logic
+            ss.BoolState('trep'),         # Treponemal test positive (matches what a real trep RDT would detect: 80% persist for life, 20% sero-revert eventually)
             ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive — would be flagged dual-positive in ZIMPHIA's "active infection" category
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
@@ -184,6 +199,8 @@ class Syphilis(BaseSTI):
             ss.FloatArr('dur_early'),
             ss.FloatArr('ti_tertiary'),
             ss.FloatArr('ti_nontrep_end'),  # When non-trep titre drops below test threshold (sero-reversion on RPR/VDRL)
+            ss.FloatArr('ti_trep_start'),   # When trep antibodies appear (post-seroconversion); NaN if treated in window period
+            ss.FloatArr('ti_trep_end'),     # When trep test reverts to negative (NaN for the 80% who persist for life)
             ss.FloatArr('ti_dead'),
             ss.FloatArr('ti_immune'),
             ss.FloatArr('ti_miscarriage'),
@@ -479,6 +496,15 @@ class Syphilis(BaseSTI):
         if len(becomes_nontrep_neg.uids) > 0:
             self.nontrep[becomes_nontrep_neg] = False
 
+        # Treponemal seroconversion (post-window-period appearance of trep+)
+        becomes_trep_pos = (~self.trep) & (self.ti_trep_start <= ti)
+        if len(becomes_trep_pos.uids) > 0:
+            self.trep[becomes_trep_pos] = True
+        # Treponemal sero-reversion (for the 20% with ti_trep_end set)
+        becomes_trep_neg = self.trep & (self.ti_trep_end <= ti)
+        if len(becomes_trep_neg.uids) > 0:
+            self.trep[becomes_trep_neg] = False
+
         return
 
     def step_die(self, uids):
@@ -496,6 +522,7 @@ class Syphilis(BaseSTI):
         self.immune[uids] = False
         self.congenital[uids] = False
         self.ever_exposed[uids] = False
+        self.trep[uids] = False
         self.nontrep[uids] = False
         self.n_infections[uids] = 0
         self.chancre_visible[uids] = False
@@ -509,6 +536,9 @@ class Syphilis(BaseSTI):
         self.ti_latent[uids] = np.nan
         self.ti_tertiary[uids] = np.nan
         self.ti_congenital[uids] = np.nan
+        self.ti_nontrep_end[uids] = np.nan
+        self.ti_trep_start[uids] = np.nan
+        self.ti_trep_end[uids] = np.nan
 
     def update_results(self):
         super().update_results()
@@ -524,9 +554,9 @@ class Syphilis(BaseSTI):
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
-        self.results['trep_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
+        self.results['trep_prevalence'][ti] = cond_prob(self.trep, sexually_active_adults)
         self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
-        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
+        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.trep, adults_15_64)
         self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
         self.results['n_active'][ti] = n_active
 
@@ -576,9 +606,9 @@ class Syphilis(BaseSTI):
             sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
-                self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+                self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.trep, sex_denom)
                 self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
-                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
+                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.trep, sex_denom_15_64)
                 self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
@@ -645,6 +675,18 @@ class Syphilis(BaseSTI):
         self.infected[uids] = True
         self.ti_exposed[uids] = ti
         self.ti_infected[uids] = ti
+
+        # Treponemal seroconversion: trep+ appears ~3 weeks post-infection,
+        # so during the window period agents are infected but trep-negative.
+        # 80% remain trep+ for life; the other 20% sero-revert ~10y later.
+        dur_to_trep = self.pars.dur_to_trep.rvs(uids)
+        self.ti_trep_start[uids] = self.ti_exposed[uids] + rr(dur_to_trep)
+        persists = self.pars.p_trep_persists.rvs(uids)
+        reverters = uids[~persists]
+        if len(reverters) > 0:
+            revert_delay = self.pars.time_to_trep_revert.rvs(reverters)
+            self.ti_trep_end[reverters] = self.ti_trep_start[reverters] + rr(revert_delay)
+        # Persisters keep ti_trep_end at default NaN (never reverts)
 
         # Exposed to primary
         dur_exposed = self.pars.dur_exposed.rvs(uids)

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -164,8 +164,8 @@ class Syphilis(BaseSTI):
             ss.BoolState('latent'),       # Can relapse to secondary, remain in latent, or progress to tertiary,
             ss.BoolState('tertiary'),     # Includes complications (cardio/neuro/disfigurement)
             ss.BoolState('immune'),       # After effective treatment people may acquire temp immunity
-            ss.BoolState('ever_exposed'), # Anyone ever exposed - stays true after treatment
-            ss.BoolState('detectable'),   # Non-treponemal serology positive (dual-RDT 'active syph' would detect)
+            ss.BoolState('ever_exposed'), # Anyone ever exposed - proxy for treponemal-test positive (antibodies persist for life)
+            ss.BoolState('nontrep'),      # Non-treponemal (RPR/VDRL) test positive — would be flagged dual-positive in ZIMPHIA's "active infection" category
             ss.IntArr('n_infections', default=0),  # Lifetime infection count (incremented each time infected)
 
             # Symptom visibility — determined at infection/stage entry, reflects anatomical site
@@ -183,7 +183,7 @@ class Syphilis(BaseSTI):
             ss.FloatArr('ti_latent'),
             ss.FloatArr('dur_early'),
             ss.FloatArr('ti_tertiary'),
-            ss.FloatArr('ti_detectable_end'),  # When non-trep titre drops below detection
+            ss.FloatArr('ti_nontrep_end'),  # When non-trep titre drops below test threshold (sero-reversion on RPR/VDRL)
             ss.FloatArr('ti_dead'),
             ss.FloatArr('ti_immune'),
             ss.FloatArr('ti_miscarriage'),
@@ -322,14 +322,14 @@ class Syphilis(BaseSTI):
         super().init_results()
         results = [
             ss.Result('n_active', dtype=int, label="Number of active cases", auto_plot=False),
-            ss.Result('serological_prevalence', dtype=float, scale=False, label="Serological prevalence (ever exposed)"),
-            ss.Result('serological_prevalence_15_64', dtype=float, scale=False, label="Serological prevalence, ages 15-64 (household-survey denominator)"),
+            ss.Result('trep_prevalence', dtype=float, scale=False, label="Treponemal-test positive (ever-exposed proxy; matches ZIMPHIA total seroprev)"),
+            ss.Result('trep_prevalence_15_64', dtype=float, scale=False, label="Treponemal-test positive, ages 15-64 (household-survey denominator)"),
             ss.Result('pregnant_prevalence', dtype=float, scale=False, label="Pregnant prevalence", auto_plot=False),
             ss.Result('detected_pregnant_prevalence', dtype=float, scale=False, label="ANC prevalence", auto_plot=False),
             ss.Result('delivery_prevalence', dtype=float, scale=False, label="Delivery prevalence", auto_plot=False),
             ss.Result('active_prevalence', dtype=float, scale=False, label="Active prevalence"),
-            ss.Result('detectable_prevalence', dtype=float, scale=False, label="Detectable prevalence (non-trep RDT positive)"),
-            ss.Result('detectable_prevalence_15_64', dtype=float, scale=False, label="Detectable prevalence, ages 15-64 (household-survey denominator)"),
+            ss.Result('nontrep_prevalence', dtype=float, scale=False, label="Non-treponemal (RPR) positive — matches ZIMPHIA dual-positive 'active syph'"),
+            ss.Result('nontrep_prevalence_15_64', dtype=float, scale=False, label="Non-treponemal positive, ages 15-64 (household-survey denominator)"),
             ss.Result('new_nnds', dtype=int, label="Neonatal deaths", auto_plot=False),
             ss.Result('new_stillborns', dtype=int, label="Stillbirths", auto_plot=False),
             ss.Result('new_congenital', dtype=int, label="Congenital cases"),
@@ -352,11 +352,11 @@ class Syphilis(BaseSTI):
             skl = '' if sk == '' else f' ({sk.upper()})'
             if skk != '':
                 results += [
-                    ss.Result(f'serological_prevalence{skk}', scale=False, label=f"Serological prevalence{skl}", auto_plot=False),
-                    ss.Result(f'serological_prevalence_15_64{skk}', scale=False, label=f"Serological prevalence, ages 15-64{skl}", auto_plot=False),
+                    ss.Result(f'trep_prevalence{skk}', scale=False, label=f"Treponemal-test positive{skl}", auto_plot=False),
+                    ss.Result(f'trep_prevalence_15_64{skk}', scale=False, label=f"Treponemal-test positive, ages 15-64{skl}", auto_plot=False),
                     ss.Result(f'active_prevalence{skk}', scale=False, label=f"Active prevalence{skl}", auto_plot=False),
-                    ss.Result(f'detectable_prevalence{skk}', scale=False, label=f"Detectable prevalence{skl}", auto_plot=False),
-                    ss.Result(f'detectable_prevalence_15_64{skk}', scale=False, label=f"Detectable prevalence, ages 15-64{skl}", auto_plot=False),
+                    ss.Result(f'nontrep_prevalence{skk}', scale=False, label=f"Non-treponemal positive{skl}", auto_plot=False),
+                    ss.Result(f'nontrep_prevalence_15_64{skk}', scale=False, label=f"Non-treponemal positive, ages 15-64{skl}", auto_plot=False),
                 ]
 
             for ab1,ab2 in zip(self.age_bins[:-1], self.age_bins[1:]):
@@ -471,13 +471,13 @@ class Syphilis(BaseSTI):
             self.late[is_early] = False
             self.late[is_late] = True
 
-        # Serology detectability: non-trep titre falls below detection at
-        # the per-agent ti_detectable_end (drawn from time_to_undetectable in
+        # Non-trep sero-reversion: non-trep titre falls below test threshold at
+        # the per-agent ti_nontrep_end (drawn from time_to_undetectable in
         # set_latent_prognoses). Reactivation back to secondary re-sets
-        # detectable=True in set_secondary_prognoses.
-        becomes_undetectable = self.detectable & (self.ti_detectable_end <= ti)
-        if len(becomes_undetectable.uids) > 0:
-            self.detectable[becomes_undetectable] = False
+        # nontrep=True in set_secondary_prognoses.
+        becomes_nontrep_neg = self.nontrep & (self.ti_nontrep_end <= ti)
+        if len(becomes_nontrep_neg.uids) > 0:
+            self.nontrep[becomes_nontrep_neg] = False
 
         return
 
@@ -496,7 +496,7 @@ class Syphilis(BaseSTI):
         self.immune[uids] = False
         self.congenital[uids] = False
         self.ever_exposed[uids] = False
-        self.detectable[uids] = False
+        self.nontrep[uids] = False
         self.n_infections[uids] = 0
         self.chancre_visible[uids] = False
         self.rash_visible[uids] = False
@@ -524,10 +524,10 @@ class Syphilis(BaseSTI):
 
         # Overwrite prevalence so we're always storing prevalence of syphilis among sexually active adults
         self.results['prevalence'][ti] = cond_prob(self.infected, sexually_active_adults)
-        self.results['serological_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
-        self.results['detectable_prevalence'][ti] = cond_prob(self.detectable, sexually_active_adults)
-        self.results['serological_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
-        self.results['detectable_prevalence_15_64'][ti] = cond_prob(self.detectable, adults_15_64)
+        self.results['trep_prevalence'][ti] = cond_prob(self.ever_exposed, sexually_active_adults)
+        self.results['nontrep_prevalence'][ti] = cond_prob(self.nontrep, sexually_active_adults)
+        self.results['trep_prevalence_15_64'][ti] = cond_prob(self.ever_exposed, adults_15_64)
+        self.results['nontrep_prevalence_15_64'][ti] = cond_prob(self.nontrep, adults_15_64)
         self.results['n_active'][ti] = n_active
 
         # Pregnant women prevalence, if present
@@ -576,10 +576,10 @@ class Syphilis(BaseSTI):
             sex_denom_15_64 = adults_15_64 & ppl[pattr]
             if skk != '':
                 self.results[f'prevalence{skk}'][ti] = cond_prob(self.infected, sex_denom)
-                self.results[f'serological_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
-                self.results[f'detectable_prevalence{skk}'][ti] = cond_prob(self.detectable, sex_denom)
-                self.results[f'serological_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
-                self.results[f'detectable_prevalence_15_64{skk}'][ti] = cond_prob(self.detectable, sex_denom_15_64)
+                self.results[f'trep_prevalence{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom)
+                self.results[f'nontrep_prevalence{skk}'][ti] = cond_prob(self.nontrep, sex_denom)
+                self.results[f'trep_prevalence_15_64{skk}'][ti] = cond_prob(self.ever_exposed, sex_denom_15_64)
+                self.results[f'nontrep_prevalence_15_64{skk}'][ti] = cond_prob(self.nontrep, sex_denom_15_64)
             self.results[f'active_prevalence{skk}'][ti] = cond_prob(self.active, sex_denom)
 
             # Compute age results
@@ -669,17 +669,18 @@ class Syphilis(BaseSTI):
         """ Set prognoses for people who have just progressed to secondary infection """
         dur_secondary = self.pars.dur_secondary.rvs(uids)
         self.ti_latent[uids] = self.ti_secondary[uids] + rr(dur_secondary)
-        # Non-treponemal titre rises by secondary; serology becomes detectable.
+        # Non-treponemal titre rises by secondary; RPR becomes positive.
         # Also covers reactivation from late latent (titre climbs again — Fig 7).
-        self.detectable[uids] = True
+        self.nontrep[uids] = True
         return
 
     def set_latent_prognoses(self, uids):
-        # Late-latent serology: draw the time at which non-trep titre is
-        # expected to fall below detection. ti_detectable_end is measured
-        # from the *start of late latent* = ti_latent + dur_early.
+        # Late-latent non-trep sero-reversion: draw the time at which
+        # non-trep titre is expected to fall below test threshold.
+        # ti_nontrep_end is measured from the *start of late latent* =
+        # ti_latent + dur_early.
         late_start = self.ti_latent[uids] + self.dur_early[uids]
-        self.ti_detectable_end[uids] = late_start + rr(self.pars.time_to_undetectable.rvs(uids))
+        self.ti_nontrep_end[uids] = late_start + rr(self.pars.time_to_undetectable.rvs(uids))
 
         # Reactivators
         will_reactivate = self.pars.p_reactivate.rvs(uids)

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -259,6 +259,9 @@ class SymptomaticTesting(STITest):
     Unlike other test classes, this doesn't return positive/negative outcomes, since
     syndromic management doesn't involve reaching a diagnosis.
     Rather, the testing intervention itself contains a linked treatment intervention.
+
+    ``diseases`` is a list of disease names (e.g. ``['ng', 'ct', 'tv']``),
+    resolved against ``sim.diseases`` at init.
     """
 
     def __init__(self, pars=None, treatments=None, diseases=None, disease_treatment_map=None, negative_treatments=None,
@@ -282,9 +285,9 @@ class SymptomaticTesting(STITest):
         )
         self.update_pars(pars, **kwargs)
 
-        # Store treatments and diseases
+        # Store treatments and diseases (diseases are names, resolved in init_pre)
         self.treatments = sc.tolist(treatments)
-        self.diseases = diseases
+        self.diseases = sc.tolist(diseases)
         if disease_treatment_map is None:
             disease_treatment_map = {t.disease: t for t in self.treatments}
         self.disease_treatment_map = disease_treatment_map
@@ -303,6 +306,11 @@ class SymptomaticTesting(STITest):
 
     def init_pre(self, sim):
         super().init_pre(sim)
+        # diseases are passed as names; resolve to the live sim modules. Sim
+        # deep-copies modules, so constructor-passed objects would be orphans
+        # the sim never steps — state reads and result writes below would hit
+        # dead copies.
+        self.diseases = [sim.diseases[name] for name in self.diseases]
         if self.treat_prob_data is not None:
             self.treat_prob = sc.smoothinterp(sim.yearvec, self.treat_prob_data.year.values, self.treat_prob_data.treat_prob.values, smoothness=0)
         return

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -513,6 +513,7 @@ class SyndromicManagement(STITest):
         self.define_states(
             ss.FloatArr('ti_referred'),
             ss.FloatArr('ti_dismissed'),
+            ss.BoolArr('has_cerv_symp'),
         )
         self.treat_prob_data = treat_prob_data
         self.treated_by_uid = None
@@ -524,9 +525,13 @@ class SyndromicManagement(STITest):
         self.pars.tx_cerv_m.set(p=self.mvals_cerv)
         self.pars.tx_noncerv_f.set(p=self.fvals_noncerv)
         self.pars.tx_noncerv_m.set(p=self.mvals_noncerv)
-        # Resolve cervical diseases: use explicit list, else find 'ng'/'ct' in diseases
-        if not self._cervical_diseases:
-            self._cervical_diseases = [d for d in self.diseases if d.name in ('ng', 'ct')]
+        # Resolve diseases via sim.diseases so state/result references are linked
+        self.diseases = [sim.diseases[d.name] for d in self.diseases]
+        if self._cervical_diseases:
+            names = [d.name for d in self._cervical_diseases]
+        else:
+            names = [d.name for d in self.diseases if d.name in ('ng', 'ct')]
+        self._cervical_diseases = [sim.diseases[n] for n in names]
         return
 
     def init_results(self):
@@ -565,13 +570,12 @@ class SyndromicManagement(STITest):
                 m_uids = uids[ppl.male[uids]]
 
                 # Cervical symptomatic flag: OR over user-specified cervical disease modules
-                has_cerv_symp = ss.BoolArr('has_cerv_symp')
-                has_cerv_symp.initialize(sim.people)
+                self.has_cerv_symp[:] = False
                 for d in self._cervical_diseases:
-                    has_cerv_symp = has_cerv_symp | d.symptomatic
+                    self.has_cerv_symp |= d.symptomatic
 
-                f_cerv_uids    = f_uids[has_cerv_symp[f_uids]]
-                f_noncerv_uids = f_uids[~has_cerv_symp[f_uids]]
+                f_cerv_uids    = f_uids[self.has_cerv_symp[f_uids]]
+                f_noncerv_uids = f_uids[~self.has_cerv_symp[f_uids]]
 
                 ofc  = self.pars.tx_cerv_f.rvs(f_cerv_uids)
                 ofnc = self.pars.tx_noncerv_f.rvs(f_noncerv_uids)

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -448,8 +448,9 @@ class SyndromicManagement(STITest):
 
     Args:
         treatments (list):        treatment module instances
-        diseases (list):          disease modules to track accuracy for
-        cervical_diseases (list): disease modules whose symptomatic flag
+        diseases (list):          names of diseases to track accuracy for
+                                  (resolved against ``sim.diseases`` at init)
+        cervical_diseases (list): names of diseases whose symptomatic flag
                                   indicates cervical infection; defaults to
                                   any disease named 'ng' or 'ct' in ``diseases``
         outcome_tx_map (dict):    maps outcome name → list of treatment modules;
@@ -460,7 +461,7 @@ class SyndromicManagement(STITest):
     Examples::
 
         syndromic = sti.SyndromicManagement(
-            diseases=[ng, ct, tv, bv],
+            diseases=['ng', 'ct', 'tv', 'bv'],
             treatments=[ng_tx, ct_tx, metronidazole],
             eligibility=seeking_care_vds,
         )
@@ -525,13 +526,15 @@ class SyndromicManagement(STITest):
         self.pars.tx_cerv_m.set(p=self.mvals_cerv)
         self.pars.tx_noncerv_f.set(p=self.fvals_noncerv)
         self.pars.tx_noncerv_m.set(p=self.mvals_noncerv)
-        # Resolve diseases via sim.diseases so state/result references are linked
-        self.diseases = [sim.diseases[d.name] for d in self.diseases]
+        # diseases/cervical_diseases are passed as names, not module objects:
+        # Sim deep-copies modules, so a constructor-passed object would be an
+        # orphan copy the sim never steps. Resolve names to the live modules.
+        self.diseases = [sim.diseases[name] for name in self.diseases]
         if self._cervical_diseases:
-            names = [d.name for d in self._cervical_diseases]
+            cerv_names = list(self._cervical_diseases)
         else:
-            names = [d.name for d in self.diseases if d.name in ('ng', 'ct')]
-        self._cervical_diseases = [sim.diseases[n] for n in names]
+            cerv_names = [d.name for d in self.diseases if d.name in ('ng', 'ct')]
+        self._cervical_diseases = [sim.diseases[name] for name in cerv_names]
         return
 
     def init_results(self):

--- a/stisim/interventions/syphilis_interventions.py
+++ b/stisim/interventions/syphilis_interventions.py
@@ -54,12 +54,11 @@ class SyphTx(STITreatment):
             fetus_treat_eff=ss.bernoulli(p=.98),
             fetus_age_cutoff_treat_eff=-0.25,  # Reduced treatment efficacy for fetuses in the last trimester
             treat_eff_reduced=ss.bernoulli(p=.75),  # Reduced efficacy for fetuses older than cut off
-            # Non-trep sero-reversion after early-stage treatment.
-            # WHO 2021 fig 7: RPR titre drops 4-fold within ~6 months
-            # of adequate treatment of primary/secondary/early-latent
-            # syphilis, with most patients becoming RPR-negative
-            # within 6-12 months. Late-latent treatment does NOT
-            # produce reliable RPR sero-reversion and is excluded
+            # Non-trep sero-reversion after early-stage treatment: RPR titre
+            # drops 4-fold within ~6 months of adequate treatment of
+            # primary/secondary/early-latent syphilis, with most patients
+            # becoming RPR-negative within 6-12 months. Late-latent treatment
+            # does NOT produce reliable RPR sero-reversion and is excluded
             # in change_states below.
             nontrep_revert_months=ss.uniform(low=6, high=12),
         )
@@ -71,9 +70,9 @@ class SyphTx(STITreatment):
         d = self.sim.diseases[disease]
 
         # Identify early-stage treated agents BEFORE clearing stage flags.
-        # Per WHO 2021 fig 7, treatment in primary, secondary, or early
-        # latent yields RPR sero-reversion within 6-12 months; late-latent
-        # treatment does not reliably clear the non-trep test.
+        # Treatment in primary, secondary, or early latent yields RPR
+        # sero-reversion within 6-12 months; late-latent treatment does not
+        # reliably clear the non-trep test.
         early_stage_mask = (d.primary[treat_succ]
                              | d.secondary[treat_succ]
                              | d.early[treat_succ])
@@ -109,10 +108,10 @@ class SyphTx(STITreatment):
         # ti_trep_start fires (i.e. before trep antibodies appear, ~3 weeks
         # post-infection), the trep test also stays negative — they never
         # seroconvert. Clear ti_trep_start so step_state doesn't flip
-        # trep=True later. (User instruction 2026-06-07.)
+        # trep=True later.
         window_period_treated = treat_succ[
             (~d.trep[treat_succ]) &
-            (~np.isnan(d.ti_trep_start[treat_succ])) &
+            (d.ti_trep_start.notnan[treat_succ]) &
             (d.ti + 1 < d.ti_trep_start[treat_succ])
         ]
         if len(window_period_treated) > 0:

--- a/stisim/interventions/syphilis_interventions.py
+++ b/stisim/interventions/syphilis_interventions.py
@@ -53,7 +53,15 @@ class SyphTx(STITreatment):
             treat_eff=ss.bernoulli(p=.98),
             fetus_treat_eff=ss.bernoulli(p=.98),
             fetus_age_cutoff_treat_eff=-0.25,  # Reduced treatment efficacy for fetuses in the last trimester
-            treat_eff_reduced=ss.bernoulli(p=.75)  # Reduced efficacy for fetuses older than cut off
+            treat_eff_reduced=ss.bernoulli(p=.75),  # Reduced efficacy for fetuses older than cut off
+            # Non-trep sero-reversion after early-stage treatment.
+            # WHO 2021 fig 7: RPR titre drops 4-fold within ~6 months
+            # of adequate treatment of primary/secondary/early-latent
+            # syphilis, with most patients becoming RPR-negative
+            # within 6-12 months. Late-latent treatment does NOT
+            # produce reliable RPR sero-reversion and is excluded
+            # in change_states below.
+            nontrep_revert_months=ss.uniform(low=6, high=12),
         )
         self.update_pars(pars, **kwargs)
         return
@@ -61,6 +69,16 @@ class SyphTx(STITreatment):
     def change_states(self, disease, treat_succ):
         """ Change the states of people who are treated """
         d = self.sim.diseases[disease]
+
+        # Identify early-stage treated agents BEFORE clearing stage flags.
+        # Per WHO 2021 fig 7, treatment in primary, secondary, or early
+        # latent yields RPR sero-reversion within 6-12 months; late-latent
+        # treatment does not reliably clear the non-trep test.
+        early_stage_mask = (d.primary[treat_succ]
+                             | d.secondary[treat_succ]
+                             | d.early[treat_succ])
+        early_stage_treated = treat_succ[early_stage_mask]
+
         d.primary[treat_succ] = False
         d.secondary[treat_succ] = False
         d.early[treat_succ] = False
@@ -75,6 +93,30 @@ class SyphTx(STITreatment):
         d.ti_tertiary[treat_succ] = np.nan
         d.susceptible[treat_succ] = True
         d.infected[treat_succ] = False
+
+        # Schedule post-treatment non-trep sero-reversion for early-stage
+        # treated agents currently RPR-positive. Without this, treated
+        # patients stayed nontrep=True for life (ti_nontrep_end was only
+        # set when entering late latent, never for early-stage treated).
+        nontrep_treated = early_stage_treated[d.nontrep[early_stage_treated]]
+        if len(nontrep_treated) > 0:
+            months = self.pars.nontrep_revert_months.rvs(nontrep_treated)
+            steps_to_revert = np.maximum(
+                1, np.round(months / (12.0 * d.t.dt_year)).astype(int))
+            d.ti_nontrep_end[nontrep_treated] = d.ti + steps_to_revert
+
+        # Window-period treatment: if treated BEFORE the agent's
+        # ti_trep_start fires (i.e. before trep antibodies appear, ~3 weeks
+        # post-infection), the trep test also stays negative — they never
+        # seroconvert. Clear ti_trep_start so step_state doesn't flip
+        # trep=True later. (User instruction 2026-06-07.)
+        window_period_treated = treat_succ[
+            (~d.trep[treat_succ]) &
+            (~np.isnan(d.ti_trep_start[treat_succ])) &
+            (d.ti + 1 < d.ti_trep_start[treat_succ])
+        ]
+        if len(window_period_treated) > 0:
+            d.ti_trep_start[window_period_treated] = np.nan
 
     def treat_fetus(self, sim, mother_uids):
         """

--- a/stisim/networks/base.py
+++ b/stisim/networks/base.py
@@ -67,6 +67,10 @@ class BaseNetwork(ss.SexualNetwork):
         self.meta.edge_type = ss_float
         self.define_pars(**BasePars())
         self.define_states(
+            # Whether the agent takes part in this network's partnerships.
+            # Default True (all agents). Subclasses may restrict it in
+            # set_network_states — e.g. the MSM networks flag only the `p_msm`
+            # fraction of males via set_msm(), and gate the pool/matching on it.
             ss.BoolArr('participant', default=True),
             ss.FloatArr('debut', default=0),
             reset=True,

--- a/stisim/networks/base.py
+++ b/stisim/networks/base.py
@@ -59,12 +59,19 @@ class BaseNetwork(ss.SexualNetwork):
     ``MFNetwork``.
     """
 
-    def __init__(self, name=None, **kwargs):
+    # Capability flag read by analyzers (e.g. PartnershipFormationAnalyzer):
+    # True means every edge removal funnels through ``_on_edge_dissolution`` so
+    # ``expired_this_loop`` is complete. A subclass that removes edges by any other
+    # path (e.g. a custom delete inside ``add_pairs``) MUST set this to False.
+    records_all_expirations = True
+
+    def __init__(self, name=None, record_expired: bool = False, **kwargs):
         super().__init__(name=name)
         self.meta.condoms = ss_float
         self.meta.age_p1 = ss_float
         self.meta.age_p2 = ss_float
         self.meta.edge_type = ss_float
+        self.meta.ti_formed = ss_int  # timestep at which the edge was formed
         self.define_pars(**BasePars())
         self.define_states(
             # Whether the agent takes part in this network's partnerships.
@@ -75,6 +82,8 @@ class BaseNetwork(ss.SexualNetwork):
             ss.FloatArr('debut', default=0),
             reset=True,
         )
+        self.record_expired = record_expired
+        self.expired_this_loop = {}  # only utilized if self.record_expired is True
 
     @staticmethod
     def process_condom_data(condom_data):
@@ -158,6 +167,10 @@ class BaseNetwork(ss.SexualNetwork):
 
     def add_pairs(self):
         """Subclasses override."""
+        # TODO: consider rejecting a (p1, p2) pairing if that pair already has an
+        # active edge in this or any other known network, to enforce the
+        # no-concurrent-duplicate-edge invariant that partner-uniqueness
+        # reporting (e.g. PartnershipFormationAnalyzer) assumes.
         pass
 
     def set_condom_use(self):
@@ -205,7 +218,88 @@ class BaseNetwork(ss.SexualNetwork):
             self.edges[k] = self.edges[k][active]
         return
 
+    def _append_expired_relationships(self, mask):
+        """
+        Accumulate the relationship edges selected by ``mask`` into ``self.expired_this_loop``.
+
+        When ``self.record_expired`` is True, records expiring relationships (edges) by appending them
+        (concatenated), to self.expired_this_loop. This is to prevent overwrite, as multiple removal points within a
+        timestep (``end_pairs`` at loop step 7 and ``remove_uids`` at step 15) both land in the buffer. This method only
+        appends; the buffer is reset by the network in ``finish_step`` (step 14) each timestep, after any analyzer has
+        read it at step 13.
+        """
+        if not self.record_expired:
+            return
+        if np.count_nonzero(mask) == 0:
+            return
+        for k in self.meta_keys():
+            vals = self.edges[k][mask]
+            if k in self.expired_this_loop:
+                self.expired_this_loop[k] = np.concatenate([self.expired_this_loop[k], vals])
+            else:
+                self.expired_this_loop[k] = vals
+        return
+
     def _on_edge_dissolution(self, active):
-        """Subclass hook — runs after the active mask is computed and before
-        expired edges are removed. Default is a no-op."""
-        pass
+        """
+        Subclass hook — runs after the active mask is computed and before
+        expired edges are removed. Default is a no-op, but when
+        ``self.record_expired`` is True it appends the full records of the edges
+        being removed this timestep to ``self.expired_this_loop`` (a dict mirroring
+        the edge meta layout, e.g. ``expired_this_loop['p1']``, including
+        ``ti_formed``). Analyzers such as ``PartnershipFormationAnalyzer``
+        read this (read-only) to learn each edge's expiry timestep; the network
+        itself clears the buffer in ``finish_step`` (step 14) each timestep.
+
+        Extending BaseNetwork — to keep expiration tracking complete:
+          * If you override this method, call ``super()._on_edge_dissolution(active)``
+            or expired-edge recording silently stops.
+          * If you remove edges anywhere other than ``end_pairs`` (e.g. a custom
+            delete inside ``add_pairs``), route those removals through this hook
+            too, or set the class attribute ``records_all_expirations = False`` so
+            analyzers know the expiry data is incomplete and skip the network.
+        """
+        self._append_expired_relationships(~active)
+
+    def remove_uids(self, uids):
+        """Record death/removal-driven edge removals before dropping them.
+
+        ``Network.remove_uids`` (called from ``People.remove_dead`` at loop step
+        15, after analyzers have run) slices dead/removed agents' edges out of
+        ``self.edges`` directly, bypassing ``end_pairs`` / ``_on_edge_dissolution``.
+        When ``record_expired`` is True we append those edges to
+        ``expired_this_loop`` first, so analyzers capture death/removal expirations
+        (consumed on the next step, hence ``ti_expired = T+1``). Upstream
+        behavior is otherwise unchanged.
+
+        The ``super().remove_uids(uids)`` call is required and must be at the end. it performs
+        the actual edge removal (slicing the dead/removed agents out of
+        ``self.edges``). This (local) method records relationships of these uids as ending just before they will be
+        deleted in the super() version. Dropping the ``super()`` call would leave
+        dead agents' edges in the network, corrupting every downstream step, and putting it first would prevent
+        proper accounting of death-terminated relationships.
+        """
+        if self.record_expired and len(self.edges.p1) > 0:
+            removing = np.isin(self.edges.p1, uids) | np.isin(self.edges.p2, uids)
+            self._on_edge_dissolution(~removing)
+        super().remove_uids(uids)
+        return
+
+    def finish_step(self):
+        """Reset the per-step relationship expiration buffer, self.expired_this_loop (loop step 14).
+
+        When ``record_expired`` is on, ``expired_this_loop`` accumulates the edges
+        removed across ``end_pairs`` (step 7) and ``remove_uids`` (step 15). The
+        network clears it here -- *after* any analyzer has read it at step 13,
+        and *before* this step's ``remove_uids`` (step 15) appends death/removal
+        edges. This makes recording and clearing entirely network-owned: an
+        analyzer is an optional, read-only consumer (and several may read the
+        same buffer), and with no analyzer present the buffer is still reset each
+        step so nothing accumulates. Death/removal edges appended at step 15 are
+        not wiped by this clear -- it has already run -- and are read at the next
+        step's step 13.
+        """
+        super().finish_step()
+        if self.record_expired:
+            self.expired_this_loop = {}
+        return

--- a/stisim/networks/fsw.py
+++ b/stisim/networks/fsw.py
@@ -203,6 +203,10 @@ class SWNetwork(BaseNetwork):
         also inherit ``MFNetwork.match_pairs`` (e.g. :class:`StructuredSexual`)
         still pick the SW matcher here.
         """
+        # TODO: consider rejecting a (p1, p2) pairing if that pair already has an
+        # active edge in this or any other known network, to enforce the
+        # no-concurrent-duplicate-edge invariant that partner-uniqueness
+        # reporting (e.g. PartnershipFormationAnalyzer) assumes.
         ppl = self.sim.people
 
         try:
@@ -219,7 +223,8 @@ class SWNetwork(BaseNetwork):
         age_p2 = ppl.age[p2]
         edge_types = np.full(match_count, dtype=ss_float, fill_value=self.edge_types['sw'])
 
-        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
+        ti_formed = np.full(match_count, self.ti, dtype=int)
+        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types, ti_formed=ti_formed)
 
         p1_edges, p1_counts = np.unique(p1, return_counts=True)
         p2_edges, p2_counts = np.unique(p2, return_counts=True)

--- a/stisim/networks/layered_networks.py
+++ b/stisim/networks/layered_networks.py
@@ -41,6 +41,11 @@ class StructuredSexual(MFNetwork):
         super().__init__(name=name)
         # SW layer
         self.define_pars(**SWPars())
+        # Multiplier on FSW non-sex-work (MF) concurrency: values <1 mean
+        # active sex workers have fewer non-sex-work partners. Default 1.0 =
+        # no effect. Lives here rather than on MFNetwork because StructuredSexual
+        # (MF + SW combined) is the only consumer.
+        self.define_pars(fsw_mf_conc_mult=1.0)
         self.define_states(*_sw_states())
         self.edge_types['sw'] = max(self.edge_types.values()) + 1
         # Apply user pars/kwargs against the full pars dict
@@ -59,8 +64,10 @@ class StructuredSexual(MFNetwork):
     def set_network_states(self, upper_age=None):
         super().set_network_states(upper_age=upper_age)
         self.set_sex_work(upper_age=upper_age)
-        # Apply FSW-specific MF concurrency multiplier post-hoc, now that
-        # self.fsw is populated. No-op at default 1.0.
+        # Scale FSW agents' MF (non-sex-work) concurrency, now that self.fsw is
+        # populated. This affects only sex workers' non-commercial partnerships;
+        # their sex-work edges come from SWNetwork.add_pairs and are untouched.
+        # No-op at default 1.0.
         mult = self.pars.fsw_mf_conc_mult
         if mult != 1.0:
             fsw_uids = self.fsw.uids

--- a/stisim/networks/layered_networks.py
+++ b/stisim/networks/layered_networks.py
@@ -59,6 +59,14 @@ class StructuredSexual(MFNetwork):
     def set_network_states(self, upper_age=None):
         super().set_network_states(upper_age=upper_age)
         self.set_sex_work(upper_age=upper_age)
+        # Apply FSW-specific MF concurrency multiplier post-hoc, now that
+        # self.fsw is populated. No-op at default 1.0.
+        mult = self.pars.fsw_mf_conc_mult
+        if mult != 1.0:
+            fsw_uids = self.fsw.uids
+            if len(fsw_uids) > 0:
+                scaled = np.maximum(1, np.round(self.concurrency[fsw_uids] * mult)).astype(int)
+                self.concurrency[fsw_uids] = scaled
         return
 
     def add_pairs(self):

--- a/stisim/networks/layered_networks.py
+++ b/stisim/networks/layered_networks.py
@@ -77,6 +77,11 @@ class StructuredSexual(MFNetwork):
         return
 
     def add_pairs(self):
+        # TODO: consider rejecting a (p1, p2) pairing if that pair already has an
+        # active edge in this or any other known network, to enforce the
+        # no-concurrent-duplicate-edge invariant that partner-uniqueness
+        # reporting (e.g. PartnershipFormationAnalyzer) assumes. (Delegates to
+        # MFNetwork/SWNetwork below, so the check could live there instead.)
         MFNetwork.add_pairs(self)
         SWNetwork.add_pairs(self)
         return

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -60,9 +60,6 @@ class MFPars(ss.Pars):
         self.m0_conc = 0.0001
         self.m1_conc = 0.2
         self.m2_conc = 0.5
-        # Multiplier on FSW concurrency: values <1 mean that active sex workers
-        # have fewer non-sex-work partners. Default 1.0 = no effect.
-        self.fsw_mf_conc_mult = 1.0
 
         # Relationship initiation, stability, and duration
         self.p_pair_form = ss.bernoulli(p=0.5)              # Probability of a (stable) pair forming between two matched people
@@ -217,6 +214,13 @@ class MFNetwork(BaseNetwork):
         # StructuredSexual.set_network_states post-hoc, because set_sex_work
         # populates self.fsw AFTER set_concurrency runs in the MF flow.
 
+        # `mu` is the target *mean* concurrency, but the two supported dists
+        # are parameterized differently: ss.poisson takes the mean directly as
+        # `lam`, whereas ss.nbinom takes (n, p) and must be reparameterized from
+        # the mean at fixed dispersion n via p = n/(n+mu). Calling .set(lam=...)
+        # on an nbinom is silently ignored (it has no `lam` parameter), so we
+        # branch on the dist type to avoid a no-op that would leave the dist at
+        # its construction default.
         dist = self.pars.concurrency_dist
         if isinstance(dist, ss.nbinom):
             n = dist.pars['n']

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -264,6 +264,10 @@ class MFNetwork(BaseNetwork):
 
     def add_pairs(self):
         """ Match and add stable/casual/onetime partnerships for this timestep. Assigns relationship type, duration, and acts based on risk group and age, and updates partner counts. """
+        # TODO: consider rejecting a (p1, p2) pairing if that pair already has an
+        # active edge in this or any other known network, to enforce the
+        # no-concurrent-duplicate-edge invariant that partner-uniqueness
+        # reporting (e.g. PartnershipFormationAnalyzer) assumes.
         ppl = self.sim.people
 
         try:
@@ -321,7 +325,8 @@ class MFNetwork(BaseNetwork):
             pair = (min(a,b), max(a,b))
             self.relationship_durs[pair].append({'start': self.ti, 'dur': reldur, 'edge_type': int(etype)}) # set dur to intended duration. When the relationship actually ends, this will be updated
 
-        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types)
+        ti_formed = np.full(match_count, self.ti, dtype=int)
+        self.append(p1=p1, p2=p2, beta=beta, condoms=condoms, dur=dur, acts=acts, age_p1=age_p1, age_p2=age_p2, edge_type=edge_types, ti_formed=ti_formed)
 
         # Checks
         if (self.sim.people.female[p1].any() or self.sim.people.male[p2].any()) and (self.name == 'structuredsexual'):
@@ -347,7 +352,14 @@ class MFNetwork(BaseNetwork):
         return
 
     def _on_edge_dissolution(self, active):
-        """Record dissolved partnerships and decrement partner counts."""
+        """Record dissolved partnerships and decrement partner counts.
+
+        Calls ``super()`` first so BaseNetwork's expired-edge recording (used by
+        ``PartnershipFormationAnalyzer`` when ``record_expired`` is True) still
+        fires — overriding this hook without ``super()`` would silently disable
+        expiration tracking for MFNetwork and its subclasses.
+        """
+        super()._on_edge_dissolution(active)
         self._record_prior_partners(active)
         self._decrement_partners(active)
 

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -15,7 +15,6 @@ def _mf_states():
         ss.FloatArr('risk_group'),
         ss.FloatArr('concurrency'),
         ss.FloatArr('partners', default=0),
-        ss.FloatArr('partners_12', default=0),
         ss.FloatArr('lifetime_partners', default=0),
         ss.FloatArr('casual_partners', default=0),
         ss.FloatArr('stable_partners', default=0),

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -60,10 +60,8 @@ class MFPars(ss.Pars):
         self.m0_conc = 0.0001
         self.m1_conc = 0.2
         self.m2_conc = 0.5
-        # Multiplier applied to FSW's MF concurrency (non-commercial
-        # partnerships). Default 1.0 = no effect. Used on networks that
-        # combine MF + SW (e.g. StructuredSexual); ignored when the network
-        # doesn't expose a `fsw` boolean.
+        # Multiplier on FSW concurrency: values <1 mean that active sex workers
+        # have fewer non-sex-work partners. Default 1.0 = no effect.
         self.fsw_mf_conc_mult = 1.0
 
         # Relationship initiation, stability, and duration

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -199,7 +199,7 @@ class MFNetwork(BaseNetwork):
         in_age_lim = (people.age < upper_age)
         uids = in_age_lim.uids
 
-        lam = np.full(uids.shape, fill_value=np.nan, dtype=ss_float)
+        mu = np.full(uids.shape, fill_value=np.nan, dtype=ss_float)
         for rg in range(self.pars.n_risk_groups):
             f_conc = self.pars[f'f{rg}_conc']
             m_conc = self.pars[f'm{rg}_conc']
@@ -207,11 +207,17 @@ class MFNetwork(BaseNetwork):
             in_group = in_risk_group & in_age_lim
             f_in = (people.female & in_group)[uids]
             m_in = (people.male   & in_group)[uids]
-            if f_in.any(): lam[f_in] = f_conc
-            if m_in.any(): lam[m_in] = m_conc
+            if f_in.any(): mu[f_in] = f_conc
+            if m_in.any(): mu[m_in] = m_conc
 
-        self.pars.concurrency_dist.set(lam=lam)
-        self.concurrency[uids] = self.pars.concurrency_dist.rvs(uids) + 1
+        dist = self.pars.concurrency_dist
+        if isinstance(dist, ss.nbinom):
+            n = dist.pars['n']
+            p = n / (n + mu)
+            dist.set(n=n, p=p)
+        else:
+            dist.set(lam=mu)
+        self.concurrency[uids] = dist.rvs(uids) + 1
 
         return
 

--- a/stisim/networks/mf.py
+++ b/stisim/networks/mf.py
@@ -60,6 +60,11 @@ class MFPars(ss.Pars):
         self.m0_conc = 0.0001
         self.m1_conc = 0.2
         self.m2_conc = 0.5
+        # Multiplier applied to FSW's MF concurrency (non-commercial
+        # partnerships). Default 1.0 = no effect. Used on networks that
+        # combine MF + SW (e.g. StructuredSexual); ignored when the network
+        # doesn't expose a `fsw` boolean.
+        self.fsw_mf_conc_mult = 1.0
 
         # Relationship initiation, stability, and duration
         self.p_pair_form = ss.bernoulli(p=0.5)              # Probability of a (stable) pair forming between two matched people
@@ -209,6 +214,10 @@ class MFNetwork(BaseNetwork):
             m_in = (people.male   & in_group)[uids]
             if f_in.any(): mu[f_in] = f_conc
             if m_in.any(): mu[m_in] = m_conc
+
+        # Note: the FSW-specific multiplier (fsw_mf_conc_mult) is applied in
+        # StructuredSexual.set_network_states post-hoc, because set_sex_work
+        # populates self.fsw AFTER set_concurrency runs in the MF flow.
 
         dist = self.pars.concurrency_dist
         if isinstance(dist, ss.nbinom):

--- a/stisim/networks/msm.py
+++ b/stisim/networks/msm.py
@@ -19,7 +19,7 @@ __all__ = ['AgeMatchedMSM', 'AgeApproxMSM', 'MSMScaleFreeNetwork']
 class AgeMatchedMSM(MFNetwork):
     """Men-who-have-sex-with-men network using exact age-sorted matching.
 
-    Extends :class:`StructuredSexual` for MSM partnerships. Eligible males
+    Extends :class:`MFNetwork` for MSM partnerships. Eligible males
     are sorted by age and paired sequentially so that partners have similar
     ages. The ``msm_share`` parameter controls what fraction of males
     participate.
@@ -40,6 +40,7 @@ class AgeMatchedMSM(MFNetwork):
         return
 
     def set_network_states(self, upper_age=None):
+        super().set_network_states(upper_age=upper_age)  # debut, risk groups, concurrency
         self.set_msm(upper_age=upper_age)
         return
 
@@ -55,7 +56,7 @@ class AgeMatchedMSM(MFNetwork):
         # Find people eligible for a relationship
         active = self.over_debut
         underpartnered = self.partners < self.concurrency
-        m_eligible = active & ppl.male & underpartnered
+        m_eligible = active & ppl.male & underpartnered & self.participant
         m_looking = self.pars.p_pair_form.filter(m_eligible.uids)
 
         if len(m_looking) == 0:
@@ -123,6 +124,7 @@ class MSMScaleFreeNetwork(BaseNetwork):
     def __init__(self, pars=None, name=None, **kwargs):
         super().__init__(name=name)
         self.define_pars(
+            msm_share=ss.bernoulli(p=0.015),  # fraction of males in the MSM pool
             target_mean_degree=2.0,
             target_mean_dur=ss.years(2),
             max_edge_dur=ss.years(10),
@@ -162,6 +164,16 @@ class MSMScaleFreeNetwork(BaseNetwork):
             )
         return
 
+    def set_network_states(self, upper_age=None):
+        super().set_network_states(upper_age=upper_age)  # set debut
+        self.set_msm(upper_age=upper_age)
+        return
+
+    def set_msm(self, upper_age=None):
+        _, m_uids = self._get_uids(upper_age=upper_age)
+        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        return
+
     def _get_rng(self):
         """Step-local numpy Generator. Not CRN — see class docstring."""
         seed = int(self.sim.pars.rand_seed) + 2003 + int(self.ti)
@@ -169,8 +181,8 @@ class MSMScaleFreeNetwork(BaseNetwork):
 
     # ---- Subclass extension points -----------------------------------------
     def _get_pool(self):
-        """Eligible agents the kernel operates on. Default: post-debut males."""
-        return self.over_debut & self.sim.people.male
+        """Eligible agents the kernel operates on. Default: post-debut MSM males."""
+        return self.over_debut & self.sim.people.male & self.participant
 
     def _mix_node_arrays(self):
         """Per-node arrays consumed by ``_mix_weights_row``.
@@ -461,29 +473,49 @@ class MSMScaleFreeNetwork(BaseNetwork):
 class AgeApproxMSM(MFNetwork):
     """Men-who-have-sex-with-men network using approximate age-preference matching.
 
-    Extends :class:`StructuredSexual` for MSM partnerships. Unlike
+    Extends :class:`MFNetwork` for MSM partnerships. Unlike
     :class:`AgeMatchedMSM`, this variant splits eligible males into two
-    arbitrary groups and matches them using the standard age-difference
-    preference distributions rather than exact age sorting.
+    groups and matches them using the standard age-difference preference
+    distributions rather than exact age sorting.
 
     Args:
-        **kwargs: Parameter overrides forwarded to :class:`StructuredSexual`.
+        pars (dict): Parameter overrides; key parameter is ``msm_share``
+            (default ``ss.bernoulli(p=0.015)``).
+        **kwargs: Additional parameter overrides.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(name='msm', **kwargs)
+    def __init__(self, pars=None, **kwargs):
+        super().__init__(name='msm')
+        self.define_pars(
+            msm_share=ss.bernoulli(p=0.015),
+        )
+        self.update_pars(pars=pars, **kwargs)
+        return
 
-    def match_pairs(self, ppl):
+    def set_network_states(self, upper_age=None):
+        super().set_network_states(upper_age=upper_age)  # debut, risk groups, concurrency
+        self.set_msm(upper_age=upper_age)
+        return
+
+    def set_msm(self, upper_age=None):
+        _, m_uids = self._get_uids(upper_age=upper_age)
+        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        return
+
+    def match_pairs(self):
         """ Match pairs using age preferences """
+        ppl = self.sim.people
 
-        # Find people eligible for a relationship
-        active = self.over_debut()
+        # Find males eligible for a relationship
+        active = self.over_debut
         underpartnered = self.partners < self.concurrency
-        m_eligible = active & ppl.male & underpartnered
+        m_eligible = active & ppl.male & underpartnered & self.participant
         m_looking = self.pars.p_pair_form.filter(m_eligible.uids)
+        if len(m_looking) < 2:
+            raise NoPartnersFound()
 
-        # Split the total number of males looking for partners into 2 groups
-        # The first group will be matched with the second group
+        # Split the males looking for partners into two groups, then pair
+        # group1 with group2 by age preference (closest-age matching).
         group1 = m_looking[::2]
         group2 = m_looking[1::2]
         loc, scale = self.get_age_risk_pars(group1, self.pars.age_diff_pars)
@@ -491,12 +523,7 @@ class AgeApproxMSM(MFNetwork):
         age_gaps = self.pars.age_diffs.rvs(group1)
         desired_ages = ppl.age[group1] + age_gaps
         g2_ages = ppl.age[group2]
-        ind_p1 = np.argsort(g2_ages)
-        ind_p2 = np.argsort(desired_ages)
-        p1 = m_eligible.uids[ind_p1]
-        p2 = group2[ind_p2]
+        p1 = group1[np.argsort(desired_ages)]
+        p2 = group2[np.argsort(g2_ages)]
         maxlen = min(len(p1), len(p2))
-        p1 = p1[:maxlen]
-        p2 = p2[:maxlen]
-
-        return p1, p2
+        return p1[:maxlen], p2[:maxlen]

--- a/stisim/networks/msm.py
+++ b/stisim/networks/msm.py
@@ -128,6 +128,12 @@ class MSMScaleFreeNetwork(BaseNetwork):
         **kwargs: forwarded to ``update_pars``.
     """
 
+    # This network deletes edges inside ``add_pairs`` (Markov deletes) without
+    # routing them through ``_on_edge_dissolution``, so ``expired_this_loop`` is
+    # incomplete. Flag it so expiry-dependent analyzers (e.g.
+    # PartnershipFormationAnalyzer) skip it. See the TODO in ``add_pairs``.
+    records_all_expirations = False
+
     def __init__(self, pars=None, name=None, **kwargs):
         super().__init__(name=name)
         self.define_pars(
@@ -408,6 +414,7 @@ class MSMScaleFreeNetwork(BaseNetwork):
             age_p1=ages[p1],
             age_p2=ages[p2],
             edge_type=np.zeros(n, dtype=float),
+            ti_formed=np.full(n, self.ti, dtype=int),
         )
         return
 
@@ -445,6 +452,20 @@ class MSMScaleFreeNetwork(BaseNetwork):
         edge list. Both target ``mu_turnover = E* / D``, balancing the
         stationary edge stock.
         """
+        # TODO: consider rejecting a (p1, p2) pairing if that pair already has an
+        # active edge in this or any other known network, to enforce the
+        # no-concurrent-duplicate-edge invariant that partner-uniqueness
+        # reporting (e.g. PartnershipFormationAnalyzer) assumes.
+        #
+        # TODO: the Markov deletes below remove edges WITHOUT routing them
+        # through ``_on_edge_dissolution`` or ``remove_uids``, so
+        # ``expired_this_loop`` misses them and this network is currently
+        # incompatible with PartnershipFormationAnalyzer (hence
+        # ``records_all_expirations = False`` above). To support it, record the
+        # deleted edges via ``self._append_expired(<removed-mask>)`` before
+        # slicing them out (BaseNetwork now *accumulates* expiries within a step,
+        # so this composes with the dur/death expiries end_pairs records the same
+        # step -- no clobbering); then set ``records_all_expirations = True``.
         if self._kernel_sel_cdf is None:
             return
         rng = self._get_rng()

--- a/stisim/networks/msm.py
+++ b/stisim/networks/msm.py
@@ -21,11 +21,11 @@ class AgeMatchedMSM(MFNetwork):
 
     Extends :class:`MFNetwork` for MSM partnerships. Eligible males
     are sorted by age and paired sequentially so that partners have similar
-    ages. The ``msm_share`` parameter controls what fraction of males
+    ages. The ``p_msm`` parameter controls what fraction of males
     participate.
 
     Args:
-        pars (dict): Parameter overrides; key parameter is ``msm_share``
+        pars (dict): Parameter overrides; key parameter is ``p_msm``
             (default ``ss.bernoulli(p=0.015)``).
         **kwargs: Additional parameter overrides.
     """
@@ -33,7 +33,7 @@ class AgeMatchedMSM(MFNetwork):
     def __init__(self, pars=None, **kwargs):
         super().__init__(name='msm')
         self.define_pars(
-            msm_share=ss.bernoulli(p=0.015),
+            p_msm=ss.bernoulli(p=0.015),
         )
         self.update_pars(pars=pars, **kwargs)
 
@@ -45,8 +45,15 @@ class AgeMatchedMSM(MFNetwork):
         return
 
     def set_msm(self, upper_age=None):
+        """Flag the ``p_msm`` fraction of post-debut males as MSM participants.
+
+        Writes the shared ``participant`` state (True for the sampled fraction,
+        False for the rest), which gates the MSM pool/matching. Called from
+        ``set_network_states``, so it runs at init and re-samples for
+        newly-entered males each step.
+        """
         _, m_uids = self._get_uids(upper_age=upper_age)
-        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        self.participant[m_uids] = self.pars.p_msm.rvs(m_uids)
         return
 
     def match_pairs(self):
@@ -124,7 +131,7 @@ class MSMScaleFreeNetwork(BaseNetwork):
     def __init__(self, pars=None, name=None, **kwargs):
         super().__init__(name=name)
         self.define_pars(
-            msm_share=ss.bernoulli(p=0.015),  # fraction of males in the MSM pool
+            p_msm=ss.bernoulli(p=0.015),  # fraction of males in the MSM pool
             target_mean_degree=2.0,
             target_mean_dur=ss.years(2),
             max_edge_dur=ss.years(10),
@@ -170,8 +177,15 @@ class MSMScaleFreeNetwork(BaseNetwork):
         return
 
     def set_msm(self, upper_age=None):
+        """Flag the ``p_msm`` fraction of post-debut males as MSM participants.
+
+        Writes the shared ``participant`` state (True for the sampled fraction,
+        False for the rest), which gates the MSM pool/matching. Called from
+        ``set_network_states``, so it runs at init and re-samples for
+        newly-entered males each step.
+        """
         _, m_uids = self._get_uids(upper_age=upper_age)
-        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        self.participant[m_uids] = self.pars.p_msm.rvs(m_uids)
         return
 
     def _get_rng(self):
@@ -479,7 +493,7 @@ class AgeApproxMSM(MFNetwork):
     distributions rather than exact age sorting.
 
     Args:
-        pars (dict): Parameter overrides; key parameter is ``msm_share``
+        pars (dict): Parameter overrides; key parameter is ``p_msm``
             (default ``ss.bernoulli(p=0.015)``).
         **kwargs: Additional parameter overrides.
     """
@@ -487,7 +501,7 @@ class AgeApproxMSM(MFNetwork):
     def __init__(self, pars=None, **kwargs):
         super().__init__(name='msm')
         self.define_pars(
-            msm_share=ss.bernoulli(p=0.015),
+            p_msm=ss.bernoulli(p=0.015),
         )
         self.update_pars(pars=pars, **kwargs)
         return
@@ -498,8 +512,15 @@ class AgeApproxMSM(MFNetwork):
         return
 
     def set_msm(self, upper_age=None):
+        """Flag the ``p_msm`` fraction of post-debut males as MSM participants.
+
+        Writes the shared ``participant`` state (True for the sampled fraction,
+        False for the rest), which gates the MSM pool/matching. Called from
+        ``set_network_states``, so it runs at init and re-samples for
+        newly-entered males each step.
+        """
         _, m_uids = self._get_uids(upper_age=upper_age)
-        self.participant[m_uids] = self.pars.msm_share.rvs(m_uids)
+        self.participant[m_uids] = self.pars.p_msm.rvs(m_uids)
         return
 
     def match_pairs(self):

--- a/stisim/version.py
+++ b/stisim/version.py
@@ -4,6 +4,6 @@ Version and license information.
 
 __all__ = ['__version__', '__versiondate__', '__license__']
 
-__version__ = '1.5.6'
+__version__ = '1.5.7'
 __versiondate__ = '2026-06-02'
 __license__ = f'STIsim {__version__} ({__versiondate__}) — © 2024-2026 by IDM'

--- a/stisim/version.py
+++ b/stisim/version.py
@@ -5,5 +5,5 @@ Version and license information.
 __all__ = ['__version__', '__versiondate__', '__license__']
 
 __version__ = '1.5.7'
-__versiondate__ = '2026-06-02'
+__versiondate__ = '2026-06-15'
 __license__ = f'STIsim {__version__} ({__versiondate__}) — © 2024-2026 by IDM'

--- a/tests/devtests/devtest_amr.py
+++ b/tests/devtests/devtest_amr.py
@@ -48,7 +48,7 @@ def test_gon(n_agents=500, dt=1/12, start=2000, dur=40):
     ct_tx = sti.STITreatment(diseases='ct', name='ct_tx', label='ct_tx')
     metro = sti.STITreatment(diseases=['tv', 'bv'], name='metro', label='metro')
     syndromic = sti.SymptomaticTesting(
-        diseases=[ng, tv, ct, vd],
+        diseases=['ng', 'tv', 'ct', 'bv'],
         eligibility=seeking_care_discharge,
         treatments=[ng_tx, ct_tx, metro],
         disease_treatment_map={'ng': ng_tx, 'ct': ct_tx, 'tv': metro, 'bv': metro}

--- a/tests/devtests/devtest_network_diagnostics.py
+++ b/tests/devtests/devtest_network_diagnostics.py
@@ -6,16 +6,38 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 import sciris as sc
+import shutil
 import starsim as ss
 import stisim as sti
 import sys
 import time
 
-from collections import defaultdict
+from stisim.analyzers import PartnershipFormationAnalyzer
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from stisim.networks.matchers import MATCHERS
+
+# All output files written by these diagnostics go in this single directory.
+OUTPUT_DIR = sc.thisdir(__file__, 'devtest_network_diagnostics')
+
+
+def reset_output_dir():
+    """Delete OUTPUT_DIR if it exists and recreate it empty."""
+    if os.path.exists(OUTPUT_DIR):
+        shutil.rmtree(OUTPUT_DIR)
+    os.makedirs(OUTPUT_DIR)
+    return
+
+
+def _output_path(filename):
+    """Return the full path for an output file inside OUTPUT_DIR."""
+    return os.path.join(OUTPUT_DIR, filename)
+
+
+# Reset the output directory once when the module is imported, so a clean
+# directory is guaranteed whether tests run via pytest or via __main__.
+reset_output_dir()
 
 @sc.timer()
 def test_age_differences(n_agents=25000, target_age_gap=8, sd=3, matching_algo=MATCHERS['closest_age_tapered_seeking']):
@@ -73,7 +95,7 @@ def test_age_differences(n_agents=25000, target_age_gap=8, sd=3, matching_algo=M
     ax.legend()
     ax.grid(True, alpha=0.3)
     plt.tight_layout()
-    outfile = sc.thisdir(__file__, 'relationship_age_differences.png')
+    outfile = _output_path('relationship_age_differences.png')
     plt.savefig(outfile, dpi=100)
     plt.close(fig)
     print(f"Scatterplot saved to {outfile}")
@@ -204,58 +226,6 @@ def test_algorithm_comparison(n_agents=25000):
     return {'stats': all_results}
 
 
-class NPartnersAnalyzer(ss.Analyzer):
-    """Track unique female partners per male over a trailing month window.
-
-    Walks the active MFNetwork edges each step and remembers, per male, the
-    most recent timestep on which each female partner appeared. After the sim
-    finishes, ``get_partner_counts`` returns the number of unique female
-    partners each male saw in the trailing ``window_months`` months.
-
-    Args:
-        network (str): Network name to inspect (default ``'mfnetwork'``).
-        window_months (int): Trailing window in months; assumes monthly dt
-            (one ti per month) so this is also the number of trailing steps.
-    """
-
-    def __init__(self, network='mfnetwork', window_months=12, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.network = network
-        self.window_months = window_months
-        self._records = []  # list of (ti, male_uids_array, female_uids_array)
-        self._final_male_uids = None
-        self._final_ti = None
-        return
-
-    def step(self):
-        sim = self.sim
-        nw = sim.networks[self.network]
-        p1 = np.asarray(nw.edges.p1, dtype=np.int64)
-        p2 = np.asarray(nw.edges.p2, dtype=np.int64)
-        if len(p1):
-            self._records.append((self.ti, p1, p2))
-        # Cache so we can compute counts even after sim is finalized/shrunk
-        self._final_male_uids = np.asarray(sim.people.male.uids, dtype=np.int64)
-        self._final_ti = self.ti
-        return
-
-    def get_partner_counts(self):
-        """Return per-male unique-partner counts over the trailing window."""
-        threshold = self._final_ti - self.window_months + 1
-        partner_sets = defaultdict(set)
-        for ti, males, females in self._records:
-            if ti < threshold:
-                continue
-            for m, f in zip(males, females):
-                partner_sets[int(m)].add(int(f))
-
-        male_uids = self._final_male_uids
-        counts = np.zeros(len(male_uids), dtype=np.int64)
-        for i, uid in enumerate(male_uids):
-            counts[i] = len(partner_sets.get(int(uid), ()))
-        return counts
-
-
 @sc.timer()
 def test_n_partners_distribution(n_agents=25000, n_runs=5, dur=25, window_months=12, target_age_gap=8,
                                  matching_algo=MATCHERS['closest_age_tapered_seeking']):
@@ -294,13 +264,13 @@ def test_n_partners_distribution(n_agents=25000, n_runs=5, dur=25, window_months
 
     for i, seed in enumerate(seeds):
         network = sti.MFNetwork(age_diff_pars=age_diff_pars, match_method=matching_algo)
-        analyzer = NPartnersAnalyzer(network='mfnetwork', window_months=window_months)
+        analyzer = PartnershipFormationAnalyzer(networks=['mfnetwork'])
         sim = sti.Sim(n_agents=n_agents, networks=[network], analyzers=[analyzer],
                       dur=dur, rand_seed=seed)
         sim.run()
         # sti.Sim copies the analyzer during init, so retrieve the live instance
-        sim_analyzer = sim.analyzers.npartnersanalyzer
-        counts = sim_analyzer.get_partner_counts()
+        sim_analyzer = sim.analyzers.partnershipformationanalyzer
+        counts = sim_analyzer.get_unique_partners_active_per_agent(female=False, window_months=window_months)['mfnetwork']
         binned, _ = np.histogram(counts, bins=bin_edges)
         per_run_counts[i] = binned
         per_run_n_males[i] = counts.size
@@ -339,7 +309,7 @@ def test_n_partners_distribution(n_agents=25000, n_runs=5, dur=25, window_months
                  f'({n_runs} runs, {n_agents} agents, {dur} yr)')
     ax.grid(True, axis='y', alpha=0.3)
     plt.tight_layout()
-    outfile = sc.thisdir(__file__, 'n_partners_distribution.png')
+    outfile = _output_path('n_partners_distribution.png')
     plt.savefig(outfile, dpi=100)
     plt.close(fig)
     print(f"Histogram saved to {outfile}")
@@ -354,6 +324,124 @@ def test_n_partners_distribution(n_agents=25000, n_runs=5, dur=25, window_months
             'mean_counts': mean_counts, 'std_counts': std_counts,
             'bin_labels': bin_labels,
             'per_run_counts': per_run_counts, 'per_run_fractions': per_run_fractions}
+
+
+@sc.timer()
+def test_n_partners_pyramid(n_agents=25000, n_runs=5, dur=25, window_months=12, target_age_gap=8,
+                            matching_algo=MATCHERS['closest_age_tapered_seeking']):
+    """
+    Population-pyramid of partnerships formed (non-unique) by age and sex.
+
+    Sweeps over ``n_runs`` seeds and, for each, uses ``PartnershipFormationAnalyzer``
+    to count the number of partnerships *formed* (not unique-partner counts) in the
+    trailing ``window_months``, binned by each subject's age at formation. The
+    per-bin counts are averaged across seeds and drawn as a population pyramid:
+    a central vertical line at x=0 with male counts extending left and female
+    counts extending right, age bins stacked bottom (youngest) to top (oldest).
+    Each bar is labelled with its raw (mean) count.
+
+    Args:
+        n_agents (int): Number of agents per simulation.
+        n_runs (int): Number of seeds to sweep over.
+        dur (float): Simulation duration in years.
+        window_months (int): Trailing formation window in months.
+        target_age_gap (float): Mean male-female age gap for partner matching.
+        matching_algo: Partner-matching algorithm (from ``MATCHERS``).
+    """
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+
+    sdA = 3
+    age_diff_pars = {'teens': [(target_age_gap, sdA), (target_age_gap, sdA), (target_age_gap, sdA)],
+                     'young': [(target_age_gap, sdA), (target_age_gap, sdA), (target_age_gap, sdA)],
+                     'adult': [(target_age_gap, sdA), (target_age_gap, sdA), (target_age_gap, sdA)]}
+
+    # 5-year age bins, low -> high (bottom -> top of the pyramid).
+    age_bins = [f'{lo}-{lo + 5}' for lo in range(0, 80, 5)]  # '0-5' .. '75-80'
+    n_bins = len(age_bins)
+
+    seeds = list(range(n_runs))
+    male_per_run = np.zeros((n_runs, n_bins), dtype=float)
+    female_per_run = np.zeros((n_runs, n_bins), dtype=float)
+
+    for i, seed in enumerate(seeds):
+        network = sti.MFNetwork(age_diff_pars=age_diff_pars, match_method=matching_algo)
+        analyzer = PartnershipFormationAnalyzer(networks=['mfnetwork'])
+        sim = sti.Sim(n_agents=n_agents, networks=[network], analyzers=[analyzer],
+                      dur=dur, rand_seed=seed)
+        sim.run()
+        # sti.Sim copies the analyzer during init, so retrieve the live instance
+        sim_analyzer = sim.analyzers.partnershipformationanalyzer
+        # {nw: {age_bin: array([window_sum])}}; collapse each bin's length-1 array.
+        male_by_bin = sim_analyzer.get_n_partnerships_formed(
+            female=False, age_bins=age_bins, window_months=window_months)['mfnetwork']
+        female_by_bin = sim_analyzer.get_n_partnerships_formed(
+            female=True, age_bins=age_bins, window_months=window_months)['mfnetwork']
+        male_per_run[i] = [male_by_bin[b][0] for b in age_bins]
+        female_per_run[i] = [female_by_bin[b][0] for b in age_bins]
+        print(f"  seed={seed}: male_formed={int(male_per_run[i].sum())} "
+              f"female_formed={int(female_per_run[i].sum())}")
+
+    male_mean = male_per_run.mean(axis=0)
+    female_mean = female_per_run.mean(axis=0)
+    # Population std across the n_runs seeds (per age bin, per sex).
+    male_std = male_per_run.std(axis=0)
+    female_std = female_per_run.std(axis=0)
+    # Two-tailed 5%/95% whiskers under a normal approximation: mean +/- z*std,
+    # z=1.645 puts the lower cap at the 5th percentile and the upper cap at the
+    # 95th percentile (a 90% central interval). Matches test_n_partners_distribution.
+    Z_90 = 1.645
+    male_err = Z_90 * male_std
+    female_err = Z_90 * female_std
+
+    # Population pyramid: males extend left (negative), females extend right.
+    y = np.arange(n_bins)
+    fig, ax = plt.subplots(figsize=(11, 8))
+    ax.barh(y, -male_mean, color='blue', alpha=0.7, edgecolor='black', label='Male')
+    ax.barh(y, female_mean, color='red', alpha=0.7, edgecolor='black', label='Female')
+    # 5%/95% normal-approx whiskers at each bar tip (computed across seeds).
+    ax.errorbar(-male_mean, y, xerr=male_err, fmt='none', ecolor='black',
+                capsize=3, capthick=1.0, lw=1.0)
+    ax.errorbar(female_mean, y, xerr=female_err, fmt='none', ecolor='black',
+                capsize=3, capthick=1.0, lw=1.0)
+    ax.axvline(0, color='black', linewidth=1.0)
+
+    # Raw (mean) count displayed within each box.
+    for yi, (m, f) in enumerate(zip(male_mean, female_mean)):
+        if m > 0:
+            ax.text(-m / 2, yi, f'{m:.1f}', ha='center', va='center', fontsize=8, color='black')
+        if f > 0:
+            ax.text(f / 2, yi, f'{f:.1f}', ha='center', va='center', fontsize=8, color='black')
+
+    # Symmetric x-limits: abs(left edge) == right edge, large enough to contain
+    # every drawn element (bar tip + its 95% whisker) on both sides.
+    max_extent = max((male_mean + male_err).max(), (female_mean + female_err).max())
+    lim = max_extent * 1.05 if max_extent > 0 else 1.0  # 5% padding
+    ax.set_xlim(-lim, lim)
+
+    ax.set_yticks(y)
+    ax.set_yticklabels(age_bins)
+    ax.set_ylabel('Age bin at formation')
+    ax.set_xlabel('Mean partnerships formed (male ← | → female)')
+    # x tick labels as absolute magnitudes (both directions read positive).
+    ax.xaxis.set_major_formatter(plt.FuncFormatter(lambda v, pos: f'{abs(v):g}'))
+    matcher_name = getattr(matching_algo, '__name__', str(matching_algo))
+    ax.set_title(f'Partnerships formed by age & sex (population pyramid)\n'
+                 f'n_agents={n_agents}, n_runs={n_runs}, dur={dur}, '
+                 f'window_months={window_months}, target_age_gap={target_age_gap}, '
+                 f'matcher={matcher_name}')
+    ax.legend(loc='upper right')
+    ax.grid(True, axis='x', alpha=0.3)
+    plt.tight_layout()
+    outfile = _output_path('n_partners_pyramid.png')
+    plt.savefig(outfile, dpi=100)
+    plt.close(fig)
+    print(f"Pyramid saved to {outfile}")
+
+    return {'age_bins': age_bins, 'male_mean': male_mean, 'female_mean': female_mean,
+            'male_std': male_std, 'female_std': female_std,
+            'male_per_run': male_per_run, 'female_per_run': female_per_run}
 
 
 class AgeGapAnalyzer(ss.Analyzer):
@@ -512,7 +600,7 @@ def test_age_gap_distribution(n_agents=25000, n_runs=5, dur=25, window_months=12
                  f'({n_runs} runs, {n_agents} agents, {dur} yr)')
     ax.grid(True, axis='y', alpha=0.3)
     plt.tight_layout()
-    outfile = sc.thisdir(__file__, 'age_gap_distribution.png')
+    outfile = _output_path('age_gap_distribution.png')
     plt.savefig(outfile, dpi=100)
     plt.close(fig)
     print(f"Histogram saved to {outfile}")
@@ -554,6 +642,7 @@ if __name__ == '__main__':
     test_age_differences()
     test_algorithm_comparison()
     test_n_partners_distribution()
+    test_n_partners_pyramid()
     test_age_gap_distribution()
 
     sc.heading("Total:")

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -14,7 +14,7 @@ def test_msm_network(n_agents=500):
     hiv = sti.HIV(beta_m2m=0.1, init_prev=0.05)
     pregnancy = ss.Pregnancy(fertility_rate=10)
     death = ss.Deaths(death_rate=10)
-    msm = sti.AgeMatchedMSM(msm_share=ss.bernoulli(p=0.3))
+    msm = sti.AgeMatchedMSM(p_msm=ss.bernoulli(p=0.3))
     sim = sti.Sim(
         start=1990,
         dur=10,

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -14,13 +14,13 @@ def test_msm_network(n_agents=500):
     hiv = sti.HIV(beta_m2m=0.1, init_prev=0.05)
     pregnancy = ss.Pregnancy(fertility_rate=10)
     death = ss.Deaths(death_rate=10)
-    msm = sti.AgeMatchedMSM()
+    msm = sti.AgeMatchedMSM(msm_share=ss.bernoulli(p=0.3))
     sim = sti.Sim(
         start=1990,
         dur=10,
         n_agents=n_agents,
         diseases=hiv,
-        networks=msm,
+        networks=[msm],
         demographics=[pregnancy, death],
     )
     sim.run(verbose=1/12)

--- a/tests/test_partnership_formation_analyzer.py
+++ b/tests/test_partnership_formation_analyzer.py
@@ -1,0 +1,686 @@
+"""
+Tests for stisim.PartnershipFormationAnalyzer.
+
+Runs a small STI simulation, prints tabular partnership-formation counts per
+gender / age bin / timestep, and produces two plots:
+  1. Total male vs female new partnerships per timestep.
+  2. Stacked per-age-bin subplots (youngest at bottom, oldest at top), each
+     with male/female lines.
+"""
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import pandas as pd
+import pylab as pl
+import sciris as sc
+import shutil
+import starsim as ss
+import stisim as sti
+import warnings
+
+
+# Directory holding this test file. Plots are saved inside a dedicated
+# subdirectory below it, which is recreated fresh on each run.
+TEST_DIR   = os.path.dirname(os.path.abspath(__file__))
+OUTPUT_DIR = os.path.join(TEST_DIR, 'partnership_formation_analyzer')
+
+
+# Default test configuration (configurable via function arguments)
+DEFAULT_N_AGENTS  = 10000
+DEFAULT_DUR_YEARS = 5
+DEFAULT_N_SEEDS   = 3
+DEFAULT_AGE_BINS  = None  # None -> PartnershipFormationAnalyzer's own default
+
+# Plot colors per the instructions
+MALE_COLOR   = 'blue'
+FEMALE_COLOR = 'red'
+
+
+def make_sim(n_agents=DEFAULT_N_AGENTS, dur=DEFAULT_DUR_YEARS, age_bins=None, rand_seed=1):
+    """Construct a sim with an MFNetwork and the analyzer.
+
+    Returns the sim only — fetch the analyzer post-init via
+    ``sim.analyzers[ANALYZER_NAME]`` because sti.Sim deep-copies the analyzer
+    during init, leaving any pre-init reference stale.
+    """
+    sim = sti.Sim(
+        n_agents=n_agents,
+        dur=dur,
+        rand_seed=rand_seed,
+        diseases=[sti.HIV(init_prev=0.05)],
+        networks=[sti.MFNetwork()],
+        analyzers=[sti.PartnershipFormationAnalyzer(age_bins=age_bins)],
+    )
+    return sim
+
+
+def build_dataframe(sim, analyzer):
+    """Return a long-format DataFrame of (ti, year, sex, age_bin, count).
+
+    Sums the per-network per-timestep formation series so the resulting
+    DataFrame is an aggregate across every tracked network.
+    """
+    yearvec = sim.t.yearvec
+    n_ti = len(yearvec)
+
+    # {sex: {age_bin: array(n_ti)}} summed across tracked networks.
+    totals = {}
+    for sex in ['f', 'm']:
+        # {nw: {age_bin: array(n_ti)}}, full per-timestep series (window_months=None)
+        per_network = analyzer.get_n_partnerships_formed(female=(sex == 'f'))
+        agg = {bin_str: np.zeros(n_ti, dtype=int) for bin_str in analyzer.age_bins}
+        for bins_by_nw in per_network.values():
+            for bin_str, series in bins_by_nw.items():
+                agg[bin_str] += series
+        totals[sex] = agg
+
+    rows = []
+    for ti, year in enumerate(yearvec):
+        for bin_str in analyzer.age_bins:
+            for sex in ['f', 'm']:
+                rows.append({'ti': ti, 'year': float(year), 'sex': sex,
+                             'age_bin': bin_str, 'count': int(totals[sex][bin_str][ti])})
+    return pd.DataFrame(rows)
+
+
+def print_tables(df, analyzer):
+    """Print one wide table per sex: rows = age bins, columns = timesteps.
+
+    Cell values are means across seeds, formatted to 2 decimal places.
+    """
+    for sex in ('f', 'm'):
+        label = 'FEMALE' if sex == 'f' else 'MALE'
+        sub = df[df.sex == sex]
+        wide = sub.pivot(index='age_bin', columns='ti', values='count')
+        wide = wide.reindex(analyzer.age_bins)  # keep age order
+        print(f'\n=== Mean new partnerships per timestep ({label}) ===')
+        with pd.option_context('display.max_columns', None,
+                               'display.width', 200,
+                               'display.max_rows', None,
+                               'display.float_format', '{:.2f}'.format):
+            print(wide)
+
+
+def _title_suffix(dur, n_agents, n_seeds):
+    return f'dur={dur}y, n_agents={n_agents}, n_seeds={n_seeds}'
+
+
+def plot_totals(df, sim, dur, n_agents, n_seeds):
+    """Total new partnerships per timestep (mean across seeds), one line per sex."""
+    yearvec = sim.t.yearvec
+    n_ti = len(yearvec)
+    male   = (df[df.sex == 'm'].groupby('ti')['count'].sum().reindex(range(n_ti)).fillna(0).values)
+    female = (df[df.sex == 'f'].groupby('ti')['count'].sum().reindex(range(n_ti)).fillna(0).values)
+
+    # Integer year marks that fall within the simulated yearvec range; these
+    # become thin black vertical gridlines on every subplot.
+    year_marks = list(range(int(np.floor(yearvec[0])), int(np.floor(yearvec[-1])) + 1))
+
+    fig, ax = pl.subplots(figsize=(9, 5))
+    ax.plot(yearvec, male,   color=MALE_COLOR,   label='Male')
+    ax.plot(yearvec, female, color=FEMALE_COLOR, label='Female')
+    for y in year_marks:
+        ax.axvline(y, color='black', linewidth=0.5)
+    ax.set_xlabel('Year')
+    ax.set_ylabel('Mean number of partnerships formed')
+    ax.set_title(f'Total partnerships formed per timestep\n'
+                 f'({_title_suffix(dur, n_agents, n_seeds)})')
+    ax.legend()
+    pl.tight_layout()
+    return fig
+
+
+def plot_by_age_bin(df, analyzer, sim, dur, n_agents, n_seeds):
+    """Stacked subplots (one per age bin), youngest at bottom, oldest at top.
+
+    Each subplot shows the mean across seeds for male/female partner-side counts.
+    """
+    yearvec = sim.t.yearvec
+    n_bins = len(analyzer.age_bins)
+    fig, axes = pl.subplots(n_bins, 1, figsize=(9, max(1.2 * n_bins, 4)),
+                            sharex=True, sharey=True)
+    if n_bins == 1:
+        axes = [axes]
+
+    # Integer year marks that fall within the simulated yearvec range; these
+    # become thin black vertical gridlines on every subplot.
+    year_marks = list(range(int(np.floor(yearvec[0])), int(np.floor(yearvec[-1])) + 1))
+
+    for i, bin_str in enumerate(analyzer.age_bins):
+        # axes[0] is the TOP row. Youngest -> bottom -> last axis.
+        ax = axes[n_bins - 1 - i]
+        sub = df[df.age_bin == bin_str].sort_values('ti')
+        male   = sub[sub.sex == 'm']['count'].values
+        female = sub[sub.sex == 'f']['count'].values
+        ax.plot(yearvec, male,   color=MALE_COLOR,   label='Male')
+        ax.plot(yearvec, female, color=FEMALE_COLOR, label='Female')
+        for y in year_marks:
+            ax.axvline(y, color='black', linewidth=0.5)
+        ax.set_ylabel(bin_str, fontsize=9, rotation=0, ha='right', va='center')
+
+    axes[-1].set_xlabel('Year')
+    axes[0].set_title(f'Mean partnerships formed per timestep by age bin '
+                      f'(youngest at bottom)\n'
+                      f'({_title_suffix(dur, n_agents, n_seeds)})')
+    axes[0].legend(loc='upper right', fontsize=8)
+    pl.tight_layout()
+    return fig
+
+
+def test_partnership_formation_analyzer(n_agents=DEFAULT_N_AGENTS,
+                                        dur=DEFAULT_DUR_YEARS,
+                                        age_bins=DEFAULT_AGE_BINS,
+                                        n_seeds=DEFAULT_N_SEEDS):
+    """End-to-end test: run n_seeds sims in parallel, average their
+    per-(sex, age_bin, ti) counts, then print tables and produce plots."""
+    # Build one sim per seed and run them in parallel via ss.parallel (a thin
+    # wrapper around ss.MultiSim). The returned MultiSim holds the run sims.
+    sims = [make_sim(n_agents=n_agents, dur=dur, age_bins=age_bins, rand_seed=seed)
+            for seed in range(1, n_seeds + 1)]
+    msim = ss.parallel(*sims)
+    run_sims = list(msim.sims)
+
+    # Build per-seed long-format DataFrames and concat with a seed index, then
+    # average across seeds per (ti, year, sex, age_bin) cell.
+    dfs = []
+    for seed_i, sim in enumerate(run_sims, start=1):
+        analyzer = sim.analyzers['partnershipformationanalyzer']
+        df_seed = build_dataframe(sim, analyzer)
+        df_seed['seed'] = seed_i
+        dfs.append(df_seed)
+    df_all = pd.concat(dfs, ignore_index=True)
+    df_mean = (df_all
+               .groupby(['ti', 'year', 'sex', 'age_bin'], as_index=False)['count']
+               .mean())
+
+    # Use the last run sim/analyzer for shared axis info (identical structure
+    # across seeds: same yearvec, same age_bins).
+    sim_ref = run_sims[-1]
+    analyzer_ref = sim_ref.analyzers['partnershipformationanalyzer']
+
+    # ----- Sanity checks (on the mean DataFrame) -----
+    total_mean = float(df_mean['count'].sum())
+    assert total_mean > 0, 'Expected at least some new partnerships in the mean run.'
+
+    # MFNetwork is male-female only, so male and female means should
+    # match. Allow a small tolerance for partners aging above the top bin.
+    male_total_mean   = float(df_mean[df_mean.sex == 'm']['count'].sum())
+    female_total_mean = float(df_mean[df_mean.sex == 'f']['count'].sum())
+    denom = max(male_total_mean, female_total_mean, 1.0)
+    diff_share = abs(male_total_mean - female_total_mean) / denom
+    assert diff_share < 0.10, (
+        f'Male/female mean totals diverge by more than 10% '
+        f'(m={male_total_mean:.2f}, f={female_total_mean:.2f}).'
+    )
+
+    # No counts in pre-debut age bins (0-5, 5-10) — debut age is well above 10.
+    pre_debut = float(df_mean[df_mean.age_bin.isin(['0-5', '5-10'])]['count'].sum())
+    assert pre_debut == 0.0, (
+        f'Found {pre_debut} mean partnerships in pre-debut age bins (0-5, 5-10).'
+    )
+
+    # Later timesteps should accumulate counts (i.e. not all activity at ti=0).
+    per_ti_total = df_mean.groupby('ti')['count'].sum().values
+    assert per_ti_total[1:].sum() > 0, 'No new partnerships after the first timestep.'
+
+    # ----- Reporting -----
+    print(f'\nSim: n_agents={n_agents}, dur={dur}y, '
+          f'{len(sim_ref.t.yearvec)} timesteps, n_seeds={n_seeds}')
+    print(f'Mean total new partnerships across seeds: {total_mean:.2f}')
+    print(f'  Male mean contribution:   {male_total_mean:.2f}')
+    print(f'  Female mean contribution: {female_total_mean:.2f}')
+
+    # TODO: perhaps move these plots after some review into devtest for this relationships
+    print_tables(df_mean, analyzer_ref)
+    fig_totals = plot_totals(df_mean, sim_ref, dur, n_agents, n_seeds)
+    fig_by_bin = plot_by_age_bin(df_mean, analyzer_ref, sim_ref, dur, n_agents, n_seeds)
+
+    # Recreate the output subdirectory fresh, then save plots with names
+    # encoding the run's configuration.
+    if os.path.exists(OUTPUT_DIR):
+        shutil.rmtree(OUTPUT_DIR)
+    os.makedirs(OUTPUT_DIR)
+    stem = f'partnership_formation_dur{dur}y_n{n_agents}_seeds{n_seeds}'
+    totals_path = os.path.join(OUTPUT_DIR, f'{stem}_totals.png')
+    by_bin_path = os.path.join(OUTPUT_DIR, f'{stem}_by_age_bin.png')
+    fig_totals.savefig(totals_path, dpi=100, bbox_inches='tight')
+    fig_by_bin.savefig(by_bin_path, dpi=100, bbox_inches='tight')
+    print(f'Saved plots to {OUTPUT_DIR}:\n  {os.path.basename(totals_path)}\n  {os.path.basename(by_bin_path)}')
+
+    return run_sims, analyzer_ref, df_mean
+
+
+# ===========================================================================
+# Injection-based getter tests
+# ---------------------------------------------------------------------------
+# The getters (get_n_partnerships_formed, get_n_partnerships_formed_per_agent,
+# get_unique_partners_active_per_agent) are pure functions of the recorded
+# state: self.results['relationships'] (one interval row per edge), self._final_uids,
+# and self._final_ti. The helper below injects that state directly, so each
+# test asserts EXACT getter outputs for a hand-built edge history -- which a
+# real (stochastic) sim cannot give (it only supports loose aggregate checks).
+# This is where uniqueness vs non-uniqueness, the trailing-window boundary
+# (half-open [ti_formed, ti_expired)), active-vs-formed semantics,
+# per-network separation, and same-sex handling are verified to the value.
+#
+# CAVEAT: injection bypasses step() and init_results(), so these tests do NOT
+# verify that edge intervals are recorded correctly during a run (formation
+# detection + ti_expired patching from expired_this_loop). That wiring is covered
+# by the sim-level test (test_partnership_formation_analyzer) and the
+# construction/sim-level tests below (which call sim.init()/run()). The edge-row
+# layout below is the contract with step(); if it changes, update the helper.
+# ===========================================================================
+
+def _inject_analyzer(edges_by_nw, uids_by_sex, final_ti, age_bins=None):
+    """Build a PartnershipFormationAnalyzer with injected edge intervals (no sim).
+
+    ``edges_by_nw`` is a dict ``{network_name: [rows...]}`` of the tracked
+    networks' edge tables. Each row is::
+
+        [p1, p2, ti_formed, ti_expired, age_p1, age_p2, female_p1, female_p2]
+
+    ``ti_expired`` is the expiry timestep (active interval is the half-open
+    ``[ti_formed, ti_expired)``), or ``None`` if the edge is still active at
+    run end. Sex is explicit per endpoint, so same-sex edges are expressible.
+    This drives the getters directly off ``self.results['relationships']`` and the
+    cached surviving-agent uids, bypassing the simulation loop.
+    """
+    ana = sti.PartnershipFormationAnalyzer(age_bins=age_bins)
+    ana._tracked_nw_names = list(edges_by_nw.keys())
+
+    # using setattribute due to 'results' being locked by default. But we're not running anything, so its ok.
+    ana.setattribute('results',
+                     {'relationships': {nw: [list(row) for row in rows] for nw, rows in edges_by_nw.items()}})
+    # ana._indicies_of_rels_in_table_for_nw = {nw: {} for nw in edges_by_nw} # not strictly unless running a sim
+    ana._final_uids = {'f': np.asarray(uids_by_sex.get('f', []), np.int64),
+                       'm': np.asarray(uids_by_sex.get('m', []), np.int64)}
+    ana._final_ti = final_ti
+    return ana
+
+
+# Male-female scenario as edge intervals. final_ti=5; window_months=3 ->
+# threshold=3, i.e. window timesteps {3,4,5} (win_start=3, win_end=5).
+# Males 10,11 (female flag False); Females 20,21,22 (female flag True).
+#
+# Format: [p1, p2, ti_formed, ti_expired, age_p1, age_p2, female_p1, female_p2]
+# The active ti values below are known relative to usage, with "final_ti" being 5.
+_MF_EDGES = [
+    [10, 20, 2, 4,    30, 22, False, True],   # E1: active {2,3}
+    [10, 21, 3, None, 31, 18, False, True],   # E2: active {3,4,5}
+    [10, 22, 5, None, 33, 29, False, True],   # E3: active {5}
+    [11, 22, 1, None, 41, 27, False, True],   # E4: formed pre-window, active throughout
+    [10, 20, 5, None, 33, 24, False, True],   # E5: re-form of 10-20 (distinct edge)
+    [11, 21, 0, 2,    40, 17, False, True],   # E6: active {0,1}, ends before window
+]
+_MF_UIDS = {'m': [10, 11], 'f': [20, 21, 22]}
+
+
+@sc.timer()
+def test_get_unique_partners_active_per_agent():
+    """Unique partners per subject on edges ACTIVE during the window, both sexes;
+    duplicate partners collapse; an edge that ended before the window is dropped."""
+    sc.heading("get_unique_partners_active_per_agent: unique active partners per male/female")
+    ana = _inject_analyzer({'mfnetwork': _MF_EDGES}, _MF_UIDS, final_ti=5)
+
+    # window=3 (active during {3,4,5}). E1 (ti_expired=4 > win_start=3) is active
+    # (last-active ti=3); E6 (ti_expired=2) ended before the window -> dropped.
+    male = ana.get_unique_partners_active_per_agent(female=False, window_months=3)['mfnetwork']
+    female = ana.get_unique_partners_active_per_agent(female=True, window_months=3)['mfnetwork']
+    assert male.tolist()   == [3, 1],    male.tolist()         # m10->{20,21,22}; m11->{22} (E6 dropped)
+    assert female.tolist() == [1, 1, 2], female.tolist()  # f20->{10}; f21->{10}; f22->{10,11}
+
+    # whole run additionally includes E6: m11->{22,21}=2 and f21->{10,11}=2.
+    male_all = ana.get_unique_partners_active_per_agent(female=False)['mfnetwork']
+    female_all = ana.get_unique_partners_active_per_agent(female=True)['mfnetwork']
+    assert male_all.tolist()   == [3, 2],    male_all.tolist()
+    assert female_all.tolist() == [1, 2, 2], female_all.tolist()
+    print(f'test_get_unique_partners_active_per_agent: window male={male.tolist()}, '
+          f'whole-run male={male_all.tolist()}. PASSED.')
+    return
+
+
+@sc.timer()
+def test_get_n_partnerships_formed_per_agent():
+    """Non-unique formations per agent; a pair re-forming counts each time;
+    formations outside the window are excluded."""
+    sc.heading("get_n_partnerships_formed_per_agent: non-unique formations per agent")
+    ana = _inject_analyzer({'mfnetwork': _MF_EDGES}, _MF_UIDS, final_ti=5)
+
+    male = ana.get_n_partnerships_formed_per_agent(female=False, window_months=3)['mfnetwork']
+    female = ana.get_n_partnerships_formed_per_agent(female=True, window_months=3)['mfnetwork']
+    assert male.tolist()   == [3, 0],    male.tolist()         # m10: E2,E3,E5 (ft 3,5,5); m11: 0 (ft 1,0)
+    assert female.tolist() == [1, 1, 1], female.tolist()  # f20:E5; f21:E2; f22:E3
+
+    # whole run, all rels counted: m10 also gets E1(ft2) -> 4; m11 gets E4,E6 -> 2. Non-unique:
+    # m10-f20 counts twice (E1+E5), so m10 formed=4 > its unique partners=3.
+    male_all = ana.get_n_partnerships_formed_per_agent(female=False)['mfnetwork']
+    female_all = ana.get_n_partnerships_formed_per_agent(female=True)['mfnetwork']
+    assert male_all.tolist()   == [4, 2],    male_all.tolist()
+    assert female_all.tolist() == [2, 2, 2], female_all.tolist()
+    print(f'test_get_n_partnerships_formed_per_agent: window male={male.tolist()}, '
+          f'whole-run male={male_all.tolist()}. PASSED.')
+    return
+
+
+@sc.timer()
+def test_get_n_partnerships_formed_binned():
+    """Binned by age at formation: {nw:{bin:array}}; per-ti when window_months=None,
+    a single window sum otherwise. Covers disjoint, overlapping, and out-of-range bins."""
+    sc.heading("get_n_partnerships_formed (binned): per-timestep, windowed, overlapping, out-of-range")
+    ana = _inject_analyzer({'mfnetwork': _MF_EDGES}, _MF_UIDS, final_ti=5)
+
+    # In-window (ft>=3) male formation ages: E2(31),E3(33),E5(33).
+    # In-window female formation ages: E2 f21(18), E3 f22(29), E5 f20(24).
+    disjoint = ['15-30', '30-45']
+    male = ana.get_n_partnerships_formed(female=False, age_bins=disjoint, window_months=3)['mfnetwork']
+    female = ana.get_n_partnerships_formed(female=True, age_bins=disjoint, window_months=3)['mfnetwork']
+    assert male['15-30'].tolist()   == [0] and male['30-45'].tolist()   == [3], male
+    assert female['15-30'].tolist() == [3] and female['30-45'].tolist() == [0], female
+
+    # Overlapping bins each count the same formation (15-45 contains 30-45, which also contains all male ages).
+    overlapping = ['15-45', '30-45']
+    male_o = ana.get_n_partnerships_formed(female=False, age_bins=overlapping, window_months=3)['mfnetwork']
+    assert male_o['15-45'].tolist() == [3] and male_o['30-45'].tolist() == [3], male_o
+
+    # Ages outside every bin are not counted (all male ages are >= 30).
+    narrow = ana.get_n_partnerships_formed(female=False, age_bins=['15-25'], window_months=3)['mfnetwork']
+    assert narrow['15-25'].tolist() == [0], narrow
+
+    # per-timestep (window_months=None): inner arrays indexed by ti (len n_ti=6).
+    male_ts = ana.get_n_partnerships_formed(female=False, age_bins=disjoint)['mfnetwork']
+    # 30-45 male ages by ti_formed: ft0:40(E6), ft1:41(E4), ft2:30(E1), ft3:31(E2), ft5:33,33(E3,E5).
+    assert male_ts['30-45'].tolist() == [1, 1, 1, 1, 0, 2], male_ts['30-45'].tolist()
+    assert male_ts['15-30'].tolist() == [0, 0, 0, 0, 0, 0], male_ts['15-30'].tolist()
+    print(f"test_get_n_partnerships_formed_binned: window male={ {k: v.tolist() for k, v in male.items()} }; "
+          f"per-ti 30-45={male_ts['30-45'].tolist()}. PASSED.")
+    return
+
+
+@sc.timer()
+def test_active_vs_formed():
+    """A partnership formed BEFORE the window but still active during it is counted
+    by get_unique_partners_active_per_agent, but NOT by
+    get_n_partnerships_formed_per_agent."""
+    sc.heading("Active-vs-formed: pre-window partnership counts as active, not as formed")
+    # final_ti=5, window=3 (threshold=3). m10-f20 formed ti1 (pre-window), still
+    # active (ti_expired=None). m11-f21 formed ti4 (inside the window).
+    edges = [
+        [10, 20, 1, None, 31, 22, False, True],
+        [11, 21, 4, None, 41, 19, False, True],
+    ]
+    ana = _inject_analyzer({'mfnetwork': edges}, {'m': [10, 11], 'f': [20, 21]}, final_ti=5)
+    active = ana.get_unique_partners_active_per_agent(female=False, window_months=3)['mfnetwork']
+    formed = ana.get_n_partnerships_formed_per_agent(female=False, window_months=3)['mfnetwork']
+    assert active.tolist() == [1, 1], active.tolist()   # m10 active{20}; m11 active{21}
+    assert formed.tolist() == [0, 1], formed.tolist()   # m10 formed pre-window=0; m11 formed ti4=1
+    print(f'test_active_vs_formed: active={active.tolist()} vs formed={formed.tolist()}. PASSED.')
+    return
+
+
+@sc.timer()
+def test_half_open_window_boundary():
+    """Half-open active interval [ti_formed, ti_expired): an edge whose
+    ti_expired equals win_start is NOT active in the window (its last-active ti is
+    win_start-1); a single-timestep edge inside the window is counted."""
+    sc.heading("Half-open boundary: ti_expired == win_start is excluded")
+    # final_ti=5, window=3 -> win_start=3, win_end=5.
+    edges = [
+        [10, 20, 1, 3,    31, 22, False, True],   # B1: active {1,2}; ti_expired==win_start -> excluded
+        [11, 21, 1, 4,    41, 19, False, True],   # B2: active {1,2,3}; last-active 3 IS in window
+        [10, 22, 4, 5,    32, 24, False, True],   # B3: active {4} (single timestep) in window
+    ]
+    ana = _inject_analyzer({'mfnetwork': edges}, {'m': [10, 11], 'f': [20, 21, 22]}, final_ti=5)
+    win = ana.get_unique_partners_active_per_agent(female=False, window_months=3)['mfnetwork']
+    assert win.tolist() == [1, 1], win.tolist()       # m10->{22} (B1 excluded, B3 in); m11->{21}
+    allrun = ana.get_unique_partners_active_per_agent(female=False)['mfnetwork']
+    assert allrun.tolist() == [2, 1], allrun.tolist()  # whole run: m10->{20(B1),22(B3)}=2; m11->{21}
+    print(f'test_half_open_window_boundary: window={win.tolist()}, whole-run={allrun.tolist()}. PASSED.')
+    return
+
+
+@sc.timer()
+def test_same_sex_network():
+    """Male-male edges: both endpoints are classified male via the stored
+    per-endpoint sex, so unique and formed counts work with no p1/p2 assumption."""
+    sc.heading("Same-sex network: male-male edges counted for the male subject")
+    # Males 10,11,12; all edges male-male (e.g. an MSM network). final_ti=5, window=3.
+    edges = [
+        [10, 11, 3, None, 31, 29, False, False],   # m10-m11 formed ti3
+        [10, 12, 3, None, 31, 27, False, False],   # m10-m12 formed ti3
+    ]
+    ana = _inject_analyzer({'msmnet': edges}, {'m': [10, 11, 12], 'f': []}, final_ti=5)
+
+    uniq = ana.get_unique_partners_active_per_agent(female=False, window_months=3)['msmnet']
+    assert uniq.tolist() == [2, 1, 1], uniq.tolist()      # 10->{11,12}; 11->{10}; 12->{10}
+    formed = ana.get_n_partnerships_formed_per_agent(female=False, window_months=3)['msmnet']
+    assert formed.tolist() == [2, 1, 1], formed.tolist()  # both endpoints male -> 10 counts in 2 edges
+    # No females -> empty surviving-agent set.
+    f_formed = ana.get_unique_partners_active_per_agent(female=True, window_months=3)['msmnet']
+    assert len(f_formed) == 0
+    print(f'test_same_sex_network: unique={uniq.tolist()}, formed={formed.tolist()}. PASSED.')
+    return
+
+
+@sc.timer()
+def test_multiple_networks():
+    """Two tracked networks return independent per-network results; a shared
+    agent (uid=2) has independent partnerships per network."""
+    sc.heading("Multiple networks: independent per-network results; shared agent uid=2")
+    # TODO: consider adding a real MF+SW integration smoke test (a sti.Sim with
+    #  both MFNetwork and SWNetwork) to complement this injection-based check.
+    #  final_ti=5, window=3, and/or StructuredSexual as a single network.
+    edges_by_nw = {
+        'mfnetwork': [
+            [2, 20, 3, None, 31, 22, False, True],    # uid2 forms with f20 in MF
+        ],
+        'swnetwork': [
+            [2, 30, 2, 3, 31, 25, False, True],       # uid2 forms with fsw30, outside window
+            [2, 30, 3, 4, 31, 25, False, True],       # uid2 forms with fsw30
+            [2, 30, 4, None, 31, 25, False, True],    # uid2 re-forms with fsw30
+            [2, 31, 4, None, 32, 26, False, True],    # uid2 forms with fsw31
+        ],
+    }
+    uids = {'m': [2], 'f': [20, 30, 31]}
+    ana = _inject_analyzer(edges_by_nw, uids, final_ti=5)
+
+    formed = ana.get_n_partnerships_formed_per_agent(female=False, window_months=3)
+    assert set(formed.keys()) == {'mfnetwork', 'swnetwork'}, list(formed.keys())
+    assert formed['mfnetwork'].tolist() == [1], formed['mfnetwork'].tolist()   # uid2: 1 in MF
+    assert formed['swnetwork'].tolist() == [3], formed['swnetwork'].tolist()   # uid2: 2 in SW
+
+    uniq = ana.get_unique_partners_active_per_agent(female=False, window_months=3)
+    assert uniq['mfnetwork'].tolist() == [1], uniq['mfnetwork'].tolist()       # {20}
+    assert uniq['swnetwork'].tolist() == [2], uniq['swnetwork'].tolist()       # {30,31}
+
+    # Female side stays separated per network too.
+    f_formed = ana.get_n_partnerships_formed_per_agent(female=True, window_months=3)
+    assert f_formed['mfnetwork'].tolist() == [1, 0, 0], f_formed['mfnetwork'].tolist()  # f20 only
+    assert f_formed['swnetwork'].tolist() == [0, 2, 1], f_formed['swnetwork'].tolist()  # f30,f31
+    print(f"test_multiple_networks: uid2 formed MF={formed['mfnetwork'].tolist()}, "
+          f"SW={formed['swnetwork'].tolist()}. PASSED.")
+    return
+
+
+# ===========================================================================
+# Construction- and sim-level behavior tests (no injected state)
+# ---------------------------------------------------------------------------
+# Build a real analyzer (and, where needed, a real sim) to exercise __init__
+# validation and init_results() network selection / warnings / errors.
+# ===========================================================================
+
+@sc.timer()
+def test_duplicate_age_bins_rejected():
+    """Duplicate age-bin strings collide as dict keys and must be rejected at
+    construction, with every duplicated value reported."""
+    sc.heading("Duplicate age_bins raise ValueError listing all duplicates")
+    try:
+        sti.PartnershipFormationAnalyzer(age_bins=['0-5', '5-10', '0-5', '5-10', '10-15'])
+    except ValueError as e:
+        msg = str(e)
+        assert '0-5' in msg and '5-10' in msg, msg
+        assert '10-15' not in msg, msg  # non-duplicated bin must not be listed
+        print(f'test_duplicate_age_bins_rejected: raised as expected -> {msg}. PASSED.')
+        return
+    raise AssertionError('Expected ValueError for duplicate age_bins, none raised.')
+
+
+@sc.timer()
+def test_network_missing_raises():
+    """Naming a network absent from the sim raises ValueError during init."""
+    sc.heading("networks=[<missing>] raises ValueError")
+    sim = sti.Sim(n_agents=100, dur=1, diseases=[sti.HIV(init_prev=0.05)],
+                  networks=[sti.MFNetwork()],
+                  analyzers=[sti.PartnershipFormationAnalyzer(networks=['bogusnet'])])
+    try:
+        sim.init()
+    except ValueError as e:
+        assert 'bogusnet' in str(e), str(e)
+        print(f'test_network_missing_raises: raised as expected -> {e}. PASSED.')
+        return
+    raise AssertionError('Expected ValueError for a missing network, none raised.')
+
+
+@sc.timer()
+def test_network_nonsexual_warns_and_skips():
+    """A named non-sexual network warns and is skipped; the default (networks=None)
+    selects only sexual networks (the non-sexual one is excluded with no warning)."""
+    sc.heading("Non-sexual network warns + skipped; default None selects only sexual nets")
+
+    # Explicitly naming the non-sexual maternal network -> warning + skip.
+    sim = sti.Sim(n_agents=100, dur=1, diseases=[sti.HIV(init_prev=0.05)],
+                  networks=[sti.MFNetwork(), ss.MaternalNet()],
+                  analyzers=[sti.PartnershipFormationAnalyzer(networks=['maternalnet'])])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        sim.init()
+    ana = sim.analyzers['partnershipformationanalyzer']
+    assert any('maternalnet' in str(w.message) for w in caught), [str(w.message) for w in caught]
+    assert len(ana._tracked_nw_names) == 0, ana._tracked_nw_names
+
+    # Default None -> only the sexual network is tracked (no maternalnet, no warning).
+    sim2 = sti.Sim(n_agents=100, dur=1, diseases=[sti.HIV(init_prev=0.05)],
+                   networks=[sti.MFNetwork(), ss.MaternalNet()],
+                   analyzers=[sti.PartnershipFormationAnalyzer()])
+    sim2.init()
+    ana2 = sim2.analyzers['partnershipformationanalyzer']
+    assert ana2._tracked_nw_names == ['mfnetwork'], ana2._tracked_nw_names
+    print(f'test_network_nonsexual_warns_and_skips: explicit skip -> {ana._tracked_nw_names}, '
+          f'default -> {ana2._tracked_nw_names}. PASSED.')
+    return sim
+
+
+@sc.timer()
+def test_network_unsupported_expiry_warns_and_skips():
+    """A network that cannot record all expirations (records_all_expirations=False,
+    e.g. MSMScaleFreeNetwork) is skipped with a warning; other sexual networks are
+    still tracked."""
+    sc.heading("Network with records_all_expirations=False warns + skipped")
+    sim = sti.Sim(n_agents=200, dur=1, diseases=[sti.HIV(init_prev=0.05)],
+                  networks=[sti.MFNetwork(), sti.MSMScaleFreeNetwork()],
+                  analyzers=[sti.PartnershipFormationAnalyzer()])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        sim.init()
+    ana = sim.analyzers['partnershipformationanalyzer']
+    assert any('record all edge expirations' in str(w.message) for w in caught), [str(w.message) for w in caught]
+    assert ana._tracked_nw_names == ['mfnetwork'], ana._tracked_nw_names
+    assert 'msmscalefreenetwork' in ana._skipped_nw_names, ana._skipped_nw_names
+    print(f'test_network_unsupported_expiry_warns_and_skips: tracked={ana._tracked_nw_names}, '
+          f'skipped={ana._skipped_nw_names}. PASSED.')
+    return sim
+
+
+@sc.timer()
+def test_records_expired_end_to_end(deaths=False):
+    """A real run records edge expirations through the full mechanism
+    (_on_edge_dissolution append + remove_uids override + step() drain +
+    finalize): some edges get a finite ti_expired, finite intervals are valid
+    (ti_expired > ti_formed), and the still-active (None) edges exactly match
+    the network's active edges at run end."""
+    sc.heading("End-to-end: MFNetwork records expirations; intervals consistent")
+    if deaths:
+        sim = sti.Sim(n_agents=500, dur=5, rand_seed=1, diseases=[sti.HIV(init_prev=0.05)],
+                      networks=[sti.MFNetwork()], demographics=[ss.Deaths(death_rate=30)],
+                      analyzers=[sti.PartnershipFormationAnalyzer()])
+    else:
+        sim = sti.Sim(n_agents=500, dur=5, rand_seed=1, diseases=[sti.HIV(init_prev=0.05)],
+                      networks=[sti.MFNetwork()],
+                      analyzers=[sti.PartnershipFormationAnalyzer()])
+    sim.run(verbose=0)
+    ana = sim.analyzers['partnershipformationanalyzer']
+    rels = ana.results['relationships']['mfnetwork']
+    assert len(rels) > 0, 'No edges recorded.'
+    final_ti = ana._final_ti
+
+    # See _MF_EDGES, above, to understand indicies into rel records
+    finite = [rel for rel in rels if rel[3] is not None]
+    assert len(finite) > 0, 'No expirations recorded — is super()._on_edge_dissolution missing?'
+    assert all(rel[3] > rel[2] for rel in rels if rel[3] is not None), 'Found ti_expired <= ti_formed, minimum diff == 1.'
+    assert all(rel[3] > rel[2] for rel in finite), 'Found ti_expired <= ti_formed.'
+    assert all(rel[3] <= final_ti + 1 for rel in finite), 'Found ti_expired > final_ti + 1.'
+
+    # Expirations recorded *during* the run (ti_expired <= final_ti), not all
+    # deferred to the final-step sentinel. Catches normal breakups + death breakups.
+    n_during_run = sum([1 for rel in finite if rel[3] <= final_ti])
+    assert n_during_run > 0, 'No expirations recorded during the run (override or rel durs may be broken).'
+
+    # Now check to ensure that the final state of the network is equivalently represented as the non-expired
+    # network relationships, meaning, have a ti_expired == None .
+    nw = sim.networks['mfnetwork']
+    final_keys = set(zip(np.asarray(nw.edges.p1).tolist(),
+                         np.asarray(nw.edges.p2).tolist(),
+                         np.asarray(nw.edges.ti_formed).tolist()))
+    none_keys = set((rel[0], rel[1], rel[2]) for rel in rels if rel[3] is None)
+    assert len(none_keys) > 0, "There are no relationships left in network."
+    assert none_keys == final_keys, (len(none_keys), len(final_keys))
+
+    print(f'test_records_expired_end_to_end: {len(finite)}/{len(rels)} edges expired; '
+          f'{len(none_keys)} active-at-end match the network. PASSED.')
+    return sim
+
+
+@sc.timer()
+def test_deaths_intervals_consistent():
+    """With deaths enabled, every removed edge (including death-driven, via the
+    remove_uids override) is captured: no edge is left with ti_expired=None
+    unless it is genuinely still active in the network at run end. Also checks
+    intervals are valid and that expirations are actually recorded during the
+    run (not all swept to the final sentinel) -- this is what regresses if the
+    remove_uids override breaks. Guards against a removal path bypassing
+    expiration recording."""
+    sc.heading("Deaths: no edge stuck active; None-edges match the network active set")
+    return test_records_expired_end_to_end(deaths=True)
+
+
+if __name__ == '__main__':
+    do_plot = True
+    sc.options(interactive=do_plot)
+    timer = sc.timer()
+
+    # Injection-based getter tests (exact-value verification, no sim)
+    test_get_unique_partners_active_per_agent()
+    test_get_n_partnerships_formed_per_agent()
+    test_get_n_partnerships_formed_binned()
+    test_active_vs_formed()
+    test_half_open_window_boundary()
+    test_same_sex_network()
+    test_multiple_networks()
+
+    # Construction- and sim-level behavior tests
+    test_duplicate_age_bins_rejected()
+    test_network_missing_raises()
+    test_network_nonsexual_warns_and_skips()
+    test_network_unsupported_expiry_warns_and_skips()
+    test_records_expired_end_to_end()
+    test_deaths_intervals_consistent()
+
+    # End-to-end integration (real multi-seed sim + plots/tables)
+    test_partnership_formation_analyzer()
+
+    sc.heading("Total:")
+    timer.toc()
+
+    if do_plot:
+        plt.show()

--- a/tests/test_scalefree_network.py
+++ b/tests/test_scalefree_network.py
@@ -6,9 +6,16 @@ import starsim as ss
 import stisim as sti
 
 
+def _make_net(**kw):
+    """Network with full male participation, so kernel-mechanics tests see the
+    whole post-debut male pool regardless of the default ``msm_share``."""
+    kw.setdefault('msm_share', ss.bernoulli(p=1.0))
+    return sti.MSMScaleFreeNetwork(**kw)
+
+
 def _make_sim(net=None, n_agents=1_000, dur=2, rand_seed=1):
     if net is None:
-        net = sti.MSMScaleFreeNetwork()
+        net = _make_net()
     return sti.Sim(
         diseases=[sti.HIV(init_prev=0.05, beta_m2f=0.05)],
         networks=[net, ss.MaternalNet()],
@@ -20,7 +27,7 @@ def _make_sim(net=None, n_agents=1_000, dur=2, rand_seed=1):
 @sc.timer()
 def test_class_instantiates_with_defaults():
     """Bare instantiation: defaults are set; no sim required."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     assert net.pars.target_mean_degree == 2.0
     assert float(net.pars.phi) == 1.0
     assert net._target_mean_dur_steps is None  # not yet converted
@@ -29,7 +36,7 @@ def test_class_instantiates_with_defaults():
 @sc.timer()
 def test_init_pre_converts_durs_to_steps():
     """After sim init, dur params are converted to integer step counts."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -40,7 +47,7 @@ def test_init_pre_converts_durs_to_steps():
 @sc.timer()
 def test_init_pre_raises_when_max_below_target():
     """``max_edge_dur < target_mean_dur`` is rejected at init."""
-    net = sti.MSMScaleFreeNetwork(target_mean_dur=ss.years(5), max_edge_dur=ss.years(2))
+    net = _make_net(target_mean_dur=ss.years(5), max_edge_dur=ss.years(2))
     sim = _make_sim(net=net)
     with pytest.raises(ValueError, match='max_edge_dur'):
         sim.init()
@@ -49,7 +56,7 @@ def test_init_pre_raises_when_max_below_target():
 @sc.timer()
 def test_get_pool_filters_to_post_debut_males():
     """``_get_pool`` returns only post-debut male agents."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -61,9 +68,22 @@ def test_get_pool_filters_to_post_debut_males():
 
 
 @sc.timer()
+def test_msm_share_filters_pool():
+    """``msm_share`` controls the fraction of post-debut males in the pool."""
+    full = _make_sim(net=_make_net(msm_share=ss.bernoulli(p=1.0)), n_agents=2_000)
+    part = _make_sim(net=sti.MSMScaleFreeNetwork(msm_share=ss.bernoulli(p=0.2)), n_agents=2_000)
+    full.init(); part.init()
+    n_full = full.networks[0]._get_pool().count()
+    n_part = part.networks[0]._get_pool().count()
+    assert n_full > 0, 'full-participation pool is empty — fixture failure'
+    assert 0.1 < n_part / n_full < 0.35, \
+        f'msm_share=0.2 pool fraction {n_part / n_full:.2f} not near 0.2 (full={n_full}, part={n_part})'
+
+
+@sc.timer()
 def test_mix_node_arrays_log1p_deg_invariant():
     """``log1p_deg`` is ``1 + log1p(deg)`` and bounded below by 1.0."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -75,7 +95,7 @@ def test_mix_node_arrays_log1p_deg_invariant():
 @sc.timer()
 def test_mix_weights_row_returns_correct_length():
     """``_mix_weights_row(i, ...)`` returns ``n - 1 - i`` weights."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net)
     sim.init()
     sim_net = sim.networks[0]
@@ -91,7 +111,7 @@ def test_mix_weights_row_returns_correct_length():
 @sc.timer()
 def test_build_kernel_populates_artefacts():
     """``_build_kernel`` populates all the caches after init."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     sim_net = sim.networks[0]
@@ -107,7 +127,7 @@ def test_build_kernel_populates_artefacts():
 @sc.timer()
 def test_build_kernel_pair_indices_upper_triangle():
     """``pairs_i < pairs_j`` for every entry (upper triangle only)."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     sim_net = sim.networks[0]
@@ -119,7 +139,7 @@ def test_build_kernel_pair_indices_upper_triangle():
 @sc.timer()
 def test_build_kernel_degenerate_pool_returns_zero():
     """Empty pool produces zero-sized kernel artefacts and n=0."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=100)
     sim.init()
     sim_net = sim.networks[0]
@@ -132,7 +152,7 @@ def test_build_kernel_degenerate_pool_returns_zero():
 @sc.timer()
 def test_sample_pair_index_in_range_and_weighted():
     """``_sample_pair_index`` returns valid indices weighted by sel_w."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     sim_net = sim.networks[0]
@@ -147,7 +167,7 @@ def test_sample_pair_index_in_range_and_weighted():
 @sc.timer()
 def test_sample_pair_index_returns_neg_on_empty_kernel():
     """Empty kernel → sentinel -1 from ``_sample_pair_index``."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=100)
     sim.init()
     sim_net = sim.networks[0]
@@ -163,7 +183,7 @@ def test_sample_pair_index_returns_neg_on_empty_kernel():
 @sc.timer()
 def test_initial_network_q0_non_empty():
     """``init_post`` samples a non-empty initial edge set for a large pool."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=2_000)
     sim.init()
     sim_net = sim.networks[0]
@@ -173,7 +193,7 @@ def test_initial_network_q0_non_empty():
 @sc.timer()
 def test_initial_edges_post_debut_males_only():
     """Every endpoint of every initial edge is a post-debut male."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=2_000)
     sim.init()
     sim_net = sim.networks[0]
@@ -188,7 +208,7 @@ def test_initial_edges_post_debut_males_only():
 @sc.timer()
 def test_max_edge_dur_cap_respected():
     """No edge persists past ``max_edge_dur_steps``."""
-    net = sti.MSMScaleFreeNetwork(max_edge_dur=ss.years(1), target_mean_dur=ss.months(6))
+    net = _make_net(max_edge_dur=ss.years(1), target_mean_dur=ss.months(6))
     sim = _make_sim(net=net, n_agents=1_500, dur=3)
     sim.run()
     sim_net = sim.networks[0]
@@ -201,7 +221,7 @@ def test_max_edge_dur_cap_respected():
 @sc.timer()
 def test_network_initialises_and_steps():
     """End-to-end: a 2yr sim with the new network completes and forms edges."""
-    net = sti.MSMScaleFreeNetwork()
+    net = _make_net()
     sim = _make_sim(net=net, n_agents=2_000, dur=2)
     sim.run()
     sim_net = sim.networks[0]
@@ -215,7 +235,7 @@ def test_network_initialises_and_steps():
 def test_target_mean_degree_honoured():
     """After burn-in, realised mean degree is within ±30% of target."""
     target = 2.0
-    net = sti.MSMScaleFreeNetwork(target_mean_degree=target, target_mean_dur=ss.years(1))
+    net = _make_net(target_mean_degree=target, target_mean_dur=ss.years(1))
     sim = _make_sim(net=net, n_agents=2_500, dur=5)
     sim.run()
     sim_net = sim.networks[0]
@@ -234,7 +254,7 @@ def test_target_mean_dur_honoured():
     so the lower bound is half the target rather than the full target.
     """
     target_yrs = 1.0
-    net = sti.MSMScaleFreeNetwork(target_mean_dur=ss.years(target_yrs))
+    net = _make_net(target_mean_dur=ss.years(target_yrs))
     sim = _make_sim(net=net, n_agents=2_500, dur=5)
     sim.run()
     sim_net = sim.networks[0]
@@ -269,7 +289,7 @@ def test_subclass_mix_weights_override_is_used():
             # Sentinel: row i returns weights = (i+1) uniformly.
             return np.full(mix_arrays['log1p_deg'].size - 1 - i, float(i + 1))
 
-    net = SentinelMSM()
+    net = SentinelMSM(msm_share=ss.bernoulli(p=1.0))
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     assert SentinelMSM.call_count > 0, 'subclass _mix_weights_row was never called'

--- a/tests/test_scalefree_network.py
+++ b/tests/test_scalefree_network.py
@@ -8,8 +8,8 @@ import stisim as sti
 
 def _make_net(**kw):
     """Network with full male participation, so kernel-mechanics tests see the
-    whole post-debut male pool regardless of the default ``msm_share``."""
-    kw.setdefault('msm_share', ss.bernoulli(p=1.0))
+    whole post-debut male pool regardless of the default ``p_msm``."""
+    kw.setdefault('p_msm', ss.bernoulli(p=1.0))
     return sti.MSMScaleFreeNetwork(**kw)
 
 
@@ -68,16 +68,16 @@ def test_get_pool_filters_to_post_debut_males():
 
 
 @sc.timer()
-def test_msm_share_filters_pool():
-    """``msm_share`` controls the fraction of post-debut males in the pool."""
-    full = _make_sim(net=_make_net(msm_share=ss.bernoulli(p=1.0)), n_agents=2_000)
-    part = _make_sim(net=sti.MSMScaleFreeNetwork(msm_share=ss.bernoulli(p=0.2)), n_agents=2_000)
+def test_p_msm_filters_pool():
+    """``p_msm`` controls the fraction of post-debut males in the pool."""
+    full = _make_sim(net=_make_net(p_msm=ss.bernoulli(p=1.0)), n_agents=2_000)
+    part = _make_sim(net=_make_net(p_msm=ss.bernoulli(p=0.2)), n_agents=2_000)
     full.init(); part.init()
     n_full = full.networks[0]._get_pool().count()
     n_part = part.networks[0]._get_pool().count()
     assert n_full > 0, 'full-participation pool is empty — fixture failure'
     assert 0.1 < n_part / n_full < 0.35, \
-        f'msm_share=0.2 pool fraction {n_part / n_full:.2f} not near 0.2 (full={n_full}, part={n_part})'
+        f'p_msm=0.2 pool fraction {n_part / n_full:.2f} not near 0.2 (full={n_full}, part={n_part})'
 
 
 @sc.timer()
@@ -289,7 +289,7 @@ def test_subclass_mix_weights_override_is_used():
             # Sentinel: row i returns weights = (i+1) uniformly.
             return np.full(mix_arrays['log1p_deg'].size - 1 - i, float(i + 1))
 
-    net = SentinelMSM(msm_share=ss.bernoulli(p=1.0))
+    net = SentinelMSM(p_msm=ss.bernoulli(p=1.0))
     sim = _make_sim(net=net, n_agents=300)
     sim.init()
     assert SentinelMSM.call_count > 0, 'subclass _mix_weights_row was never called'


### PR DESCRIPTION
## STIsim v1.5.7 (2026-06-15)

Release of `rc1.5.7` → `main`. Version bumped to **1.5.7**; CHANGELOG + `docs/_variables.yml` updated.

### Highlights

**Diseases**
- Syphilis: treponemal (`trep`) / non-treponemal (`nontrep`) serology states with seroconversion/reversion dynamics; new `trep_prevalence`/`nontrep_prevalence` results (overall, by sex, by age×sex) plus `sexually_transmissible`/`symptomatic`/`primary` stage prevalences. Consolidated `active` → `symptomatic` (removed `active_prevalence`, `*_prevalence_15_64`). Prevalence denominator age band configurable via `age_range` on `BaseSTI`. (#500)

**Networks**
- `fsw_mf_conc_mult` on `StructuredSexual`; negative-binomial-aware `set_concurrency`. (#500)
- MSM network fixes — participation filter + init crashes across `AgeMatchedMSM`/`AgeApproxMSM`/`MSMScaleFreeNetwork`; `msm_share` → `p_msm`. (#502)

**Interventions**
- `SyndromicManagement` / `SymptomaticTesting` take disease **names** (resolved via `sim.diseases` at init) rather than deep-copied module objects. (#503)

**Analyzers**
- `PartnershipFormationAnalyzer` + relationship-end timestamps on networks. (#504)

**Results**
- Removed unimplemented `partners_12` / `n_partners_12m`. (#473, #507)

### Notes
- Deferred to a later release: #505 (`PartnerNotification` edge-type/sex stratification + `pn_rates`), still open.
- Full test suite passes locally. The docs devtest (`tests/devtests/devtest_docs.py`) skips locally without the quarto render env — relying on CI to validate tutorial/docs code.

Full details in [CHANGELOG.md](CHANGELOG.md).
