### PR TITLE
docs: refresh network user guide

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -106,6 +106,7 @@ website:
             - section: "Networks"
               contents:
                 - user_guide/networks/structured_sexual.md
+                - user_guide/networks/matching.md
                 - user_guide/networks/msm.md
             - section: "Interventions"
               contents:

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -5,7 +5,7 @@ STIsim is built on top of [Starsim](https://docs.starsim.org). For understanding
 This user guide documents what STIsim adds on top of Starsim:
 
 - **[Diseases](diseases/index.md)** -- State diagrams and parameter tables for each STI module (HIV, syphilis, chlamydia, gonorrhea, trichomoniasis, BV, GUD).
-- **[Networks](networks/structured_sexual.md)** -- The structured sexual network: risk groups, partnership types, age mixing, sex work, and condom use. See also [MSM networks](networks/msm.md).
+- **[Networks](networks/structured_sexual.md)** -- The structured sexual network: risk groups, partnership types, age mixing, sex work, and condom use. See also [pair matching](networks/matching.md) and [MSM networks](networks/msm.md).
 - **[Interventions](interventions/interventions.md)** -- Testing, treatment, and HIV-specific interventions (ART, VMMC, PrEP).
 - **[Connectors](connectors.md)** -- Coinfection interactions between co-circulating diseases.
 - **[Calibration](calibration.md)** -- Fitting model parameters to data with Optuna.

--- a/docs/user_guide/networks/matching.md
+++ b/docs/user_guide/networks/matching.md
@@ -1,0 +1,99 @@
+# Pair matching
+
+Each timestep, [`MFNetwork`](structured_sexual.md) forms new heterosexual partnerships by matching *looking* women to *eligible* men. The algorithm that does this is selected by the `match_method` parameter (default `'closest_age_tapered_seeking'`). All matchers share the same inputs and contract; they differ only in how they turn age preferences into pairs.
+
+## The matching problem
+
+```
+each timestep
+      │
+      ▼
+ eligible women ──► sample desired partner age ──► desired ages ┐
+ (post-debut,        (own age + gap drawn from                  │
+  under-partnered,    age_diff_pars, by age group               ├─► match_method ─► (p1, p2)
+  "looking")          × risk group)                             │        pairs
+                                                                │
+ eligible men ───────────────────────────────────► actual ages ┘
+ (post-debut, under-partnered)                                          │
+                                                                        ▼
+                                                              add_pairs assigns
+                                                              type / duration / acts
+```
+
+- **Eligible women** are post-debut, under-partnered (`partners < concurrency`), and pass the `p_pair_form` "looking" filter. Each draws a **desired** male partner age — her own age plus an age gap sampled from `age_diff_pars` (varies by her age group and risk group; see [age mixing](structured_sexual.md#age-mixing)).
+- **Eligible men** are post-debut and under-partnered, with their **actual** ages.
+- A matcher returns `(p1, p2)` — equal-length `ss.uids` arrays of male and female partners — or raises `NoPartnersFound` if it can pair no one. Relationship type (stable/casual/one-time), duration, and coital acts are assigned afterwards by `add_pairs`, not by the matcher.
+
+## Default: `closest_age_tapered_seeking`
+
+The default matcher pairs each woman with the closest-aged available man at or above her target, and damps older women's search so realized age gaps stay faithful to `age_diff_pars` even when older men are scarce. It runs in four steps.
+
+**1. Taper older women's search.** A woman's chance of looking this step falls with age, reaching zero at `f_partnership_taper_cut` (default 55):
+
+```
+P(woman looks)
+  1 ┤●●●●●●●●●●●●●●●●
+    │                ●●
+    │                  ●●●        ∝ ((cut − age) / offset) ^ 1.5
+  0 ┤────────────────────●●●●●──► age
+    0                  ↑          ↑
+              taper onset        cut  (f_partnership_taper_cut)
+            (cut − offset)
+```
+
+`offset` is `mean_gap + 3·sd`, the widest plausible age gap across age/risk groups. Without this taper, older women who draw large gaps cannot find partners, biasing realized gaps downward.
+
+**2. Sample desired ages** for the women who are looking (own age + gap), and collect eligible men's actual ages.
+
+**3. Closest-age sweep.** Sort women by desired age and men by actual age, then sweep once with a two-pointer scan: each woman takes the nearest still-available man near her target (no man is reused). A woman whose nearest free man is more than `max_deviation` (1 year) off her target is skipped — later, higher-target women may still match.
+
+```
+F desired (sorted):  24    27    33        M actual (sorted): 22  25  28  31  34
+
+   24 ─► nearest free man near 24 ─► 25     ✓  gap 1
+   27 ─► nearest free man near 27 ─► 28     ✓  gap 1
+   33 ─► nearest free man near 33 ─► 34     ✓  gap 1
+                                            22, 31 left unmatched
+```
+
+**4. Trim extremes.** Drop any pair whose realized age gap exceeds `mean_gap + 3·sd`, removing unrealistic matches the sweep may have forced.
+
+A small residual downward bias (<1 year) in the female–male age gap remains, driven mainly by debut-age limits truncating the low end of young women's preferences. Note also that in calibration `age_diff_pars` is not orthogonal to the concurrency and duration parameters, since those shape the pool of people looking each step.
+
+## Other matchers
+
+`match_method` accepts any of these registry keys (or a callable — see below):
+
+| `match_method` | How it pairs | Age-gap fidelity |
+|----------------|--------------|------------------|
+| `closest_age_tapered_seeking` *(default)* | sorted closest-age sweep + older-woman taper + extreme-gap trim | highest |
+| `kdtree_nn` | KD-tree nearest-neighbour on male age; contested men go to the closest woman | high |
+| `lsa` | globally optimal assignment over the full age-distance matrix; `O(n³)`, reference only | optimal (slow) |
+| `greedy_old_enough` | each woman (by ascending target) takes the youngest free man ≥ her target | one-sided |
+| `sort_pair` | sort both groups by age, zip, truncate to the shorter | moderate |
+| `sort_bisect` | sort + trim non-overlapping age tails + subsample (legacy production) | low (boundaries only) |
+| `desired_age_bucket` | 1-year desired-age buckets, sample a man within | coarse ⁽¹⁾ |
+| `band_match` | 5-year age bands, shuffle and zip within each band | coarse ⁽¹⁾ |
+
+⁽¹⁾ `desired_age_bucket` and `band_match` draw from their own RNG seeded per `(rand_seed, ti)` — reproducible for a fixed run, but not branching-stable under Starsim's Common Random Numbers (adding an intervention can reshuffle pairings).
+
+## Custom matchers
+
+Pass a callable as `match_method`. It receives the network and returns `(p1, p2)`. Two helpers cover the common setup:
+
+```python
+import stisim as sti
+from stisim.networks import NoPartnersFound
+
+def my_matcher(net):
+    f_looking, m_eligible = net._get_eligible()      # women: ss.uids; men: bool mask (use m_eligible.uids)
+    desired = net._sample_desired_ages(f_looking)    # target male age per looking woman
+    ...                                              # your pairing logic
+    if nothing_matched:
+        raise NoPartnersFound()
+    return p1, p2                                     # equal-length male, female ss.uids
+
+net = sti.MFNetwork(match_method=my_matcher)
+```
+
+`p1` must be male uids and `p2` female uids, of equal length. Raise `NoPartnersFound` when no pairing is possible for the timestep.

--- a/docs/user_guide/networks/msm.md
+++ b/docs/user_guide/networks/msm.md
@@ -1,15 +1,16 @@
 # MSM networks
 
-STIsim provides two networks for modeling sexual contact between men. Both extend [`StructuredSexual`](structured_sexual.md), inheriting risk groups, concurrency, and partnership classification, but differ in how partners are matched.
+STIsim provides three networks for modeling sexual contact between men. `AgeMatchedMSM` and `AgeApproxMSM` extend [`MFNetwork`](structured_sexual.md), inheriting risk groups, concurrency, and partnership classification, and differ only in how partners are matched. `MSMScaleFreeNetwork` extends `BaseNetwork` directly and uses a preferential-attachment kernel instead of risk groups.
 
 | Class | Matching strategy | When to use |
 |-------|------------------|-------------|
 | `sti.AgeMatchedMSM` | Sort eligible males by age and pair sequentially | Lightweight; partners always have similar ages |
-| `sti.AgeApproxMSM` | Reuses `StructuredSexual` age-difference preferences to match split groups of eligible males | More flexible age mixing |
+| `sti.AgeApproxMSM` | Reuses `MFNetwork` age-difference preferences to match split groups of eligible males | More flexible age mixing |
+| `sti.MSMScaleFreeNetwork` | Preferential-attachment (rich-get-richer) degree kernel with Markovian edge deletion | Scale-free degree distribution; concentrated transmission |
 
 ## Participation
 
-Both networks expose an `p_msm` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
+All three networks expose a `p_msm` parameter (default `ss.bernoulli(p=0.015)`) which sets the fraction of males that participate in MSM partnerships. Participation is assigned at sexual debut and is fixed for the lifetime of the agent.
 
 ```python
 msm = sti.AgeMatchedMSM(p_msm=ss.bernoulli(p=0.05))  # 5% of males
@@ -28,7 +29,26 @@ sim = sti.Sim(
 
 Each network maintains its own edges and partnership classification. Disease modules see contacts from all networks each timestep.
 
+## Scale-free network
+
+`sti.MSMScaleFreeNetwork` (Whittles-2019 S2 kernel) forms edges via a rate proportional to a degree-based pair weight, producing a scale-free degree distribution where a minority of high-degree agents drive most transmission. Edges are deleted at random subject to a hard duration cap.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `p_msm` | `ss.bernoulli(p=0.015)` | Fraction of males in the MSM pool |
+| `target_mean_degree` | 2.0 | Target mean concurrent partners per pool agent |
+| `target_mean_dur` | `ss.years(2)` | Target mean edge duration |
+| `max_edge_dur` | `ss.years(10)` | Hard cap on edge persistence |
+| `phi` | 1.0 | Turnover parameter (sets initial network density) |
+
+```python
+msm = sti.MSMScaleFreeNetwork(target_mean_degree=3.0)
+```
+
+Note: unlike the other networks, this one is not branching-stable under Common Random Numbers — adding an intervention that perturbs the population reshuffles edges from that point on. Reproducibility holds per `(rand_seed, ti)`. It also does not record edge expirations, so analyzers that depend on them (e.g. `PartnershipFormationAnalyzer`) skip it.
+
 ## API
 
 - `sti.AgeMatchedMSM` — exact-age matching; cheap and deterministic given inputs.
-- `sti.AgeApproxMSM` — distribution-based matching; reuses age preference machinery from `StructuredSexual`.
+- `sti.AgeApproxMSM` — distribution-based matching; reuses age-preference machinery from `MFNetwork`.
+- `sti.MSMScaleFreeNetwork` — preferential-attachment kernel; scale-free degree distribution.

--- a/docs/user_guide/networks/structured_sexual.md
+++ b/docs/user_guide/networks/structured_sexual.md
@@ -1,8 +1,21 @@
 # Structured sexual network
 
-**Class:** `sti.StructuredSexual` | **Base class:** `ss.SexualNetwork`
+**Class:** `sti.StructuredSexual` | **Base class:** `sti.MFNetwork`
 
-The `StructuredSexual` network is STIsim's primary sexual contact network. It is created automatically when you make a sim.
+The `StructuredSexual` network is STIsim's primary sexual contact network. It is created automatically when you make a sim, and bundles heterosexual partnerships with sex work on a single edge list.
+
+## Architecture
+
+STIsim's sexual networks are layered. Each network below extends `sti.BaseNetwork`, which provides the shared machinery: sexual debut, coital acts, condom-use data, and prior-partner recall.
+
+| Class | Models | Notes |
+|-------|--------|-------|
+| `sti.BaseNetwork` | shared infrastructure | debut, acts, condom data, `recall_prior` |
+| `sti.MFNetwork` | heterosexual partnerships | risk groups, concurrency, age mixing |
+| `sti.SWNetwork` | sex work | FSW–client edges |
+| `sti.StructuredSexual` | MF + sex work | the default; extends `MFNetwork` and adds sex-work edges |
+
+`StructuredSexual` keeps the historical API, so `sim.networks.structuredsexual` exposes `fsw`, `client`, risk groups, and concurrency directly. For modular use — heterosexual partnerships without sex work, or sex work alone — use `sti.MFNetwork` or `sti.SWNetwork` directly.
 
 ## Overview
 
@@ -16,12 +29,14 @@ Agents are assigned a **risk group** (low, medium, high) at initialization. Risk
 | 1 (medium) | Marry then divorce, or have concurrent partners | 14% | 18% |
 | 2 (high) | Never marry | 1% | 2% |
 
+Shares are set by `prop_f0`, `prop_m0` (low) and `prop_f2`, `prop_m2` (high); the medium group is the remainder.
+
 ## Partnership types
 
 How a partnership is classified depends on the risk groups of both partners:
 
-- **Stable**: Both partners in the same risk group and pass a stability check (RG0: 90%, RG1: 50%, RG2: 0%)
-- **Casual**: Mismatched risk groups, 50% chance (otherwise one-time)
+- **Stable**: Both partners in the same risk group and pass a stability check (`p_matched_stable`: RG0 90%, RG1 50%, RG2 0%)
+- **Casual**: Mismatched risk groups, 50% chance (`p_mismatched_casual`; otherwise one-time)
 - **One-time**: Single-timestep contact
 - **Sex work**: FSW-client contacts, one-time duration
 
@@ -34,7 +49,7 @@ The number of concurrent partners an agent seeks depends on their sex and risk g
 | Female | 0.0001 | 0.01 | 0.1 |
 | Male | 0.0001 | 0.2 | 0.5 |
 
-Values represent the parameter of a Poisson distribution (+1), so a male in RG2 typically seeks 1-3 concurrent partners.
+Each value is the target *mean* concurrency. By default `concurrency_dist` is a Poisson (`lam` = the value above) and the realized count is `rvs + 1`, so every active agent seeks at least one partner. Set `concurrency_dist` to `ss.nbinom` for an overdispersed alternative — it is reparameterized from the same mean automatically.
 
 ## Age mixing
 
@@ -46,22 +61,29 @@ Women sample a preferred partner age from a normal distribution. Parameters vary
 | Young (20-25) | (8, 3) | (7, 3) | (5, 2) |
 | Adult (25+) | (8, 3) | (7, 3) | (5, 2) |
 
-Values are the age difference (male minus female) in years. Partners are matched by sorting both groups by age.
+Values are the age difference (male minus female) in years.
+
+### Pair matching
+
+How sampled preferences are turned into pairs is set by `match_method`, which selects an algorithm from `sti.networks.matchers` (default `'closest_age_tapered_seeking'`). Pass any registered key, or a callable `f(net) -> (p1, p2)` for a custom matcher.
 
 ## Sex work
 
+FSW and client status are lifetime fates (`fsw_shares`, `client_shares`) gated by a per-agent active window — an entry age (`age_sw_start`) and duration (`dur_sw`) — so an agent counts as currently FSW only while inside that window.
+
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `fsw_shares` | 5% | Proportion of women who are sex workers |
-| `client_shares` | 12% | Proportion of men who are clients |
+| `fsw_shares` | 5% | Lifetime proportion of women who are sex workers |
+| `client_shares` | 12% | Lifetime proportion of men who are clients |
 | `sw_seeking_rate` | 1/month | Rate at which clients seek FSWs |
+| `fsw_mf_conc_mult` | 1.0 | Multiplier on FSW non-sex-work concurrency (values <1 mean active sex workers have fewer non-sex-work partners) |
 
 ## Coital acts and condoms
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `acts` | lognorm(80/yr, 30/yr) | Coital acts per partnership per year |
-| `condom_data` | None | Condom use probability (can be stratified by risk group) |
+| `condom_data` | None | Condom use probability (scalar, or stratified by risk-group pair / sex-work edges) |
 
 Transmission probability per partnership accounts for both condom use and number of acts:
 
@@ -71,6 +93,7 @@ P(transmission) = 1 - [1 - beta * (1 - eff_condom)]^(acts * p_condom) * [1 - bet
 
 STIsim also includes:
 
-- **`ss.MaternalNet`**: Mother-to-child transmission network (created automatically)
-- **`sti.AgeMatchedMSM`**: Men-who-have-sex-with-men network with age-based matching
-- **`sti.PriorPartners`**: Stores former partners for contact tracing (opt-in via `recall_prior=True`)
+- **`sti.MFNetwork`** / **`sti.SWNetwork`**: the heterosexual and sex-work layers, usable standalone (see [Architecture](#architecture)).
+- **`ss.MaternalNet`**: Mother-to-child transmission network (created automatically).
+- **MSM networks**: men-who-have-sex-with-men contact, with several matching strategies — see [MSM networks](msm.md).
+- **`sti.PriorPartners`**: Stores former partners for contact tracing. Add it alongside an MF network and set `recall_prior=True`.

--- a/docs/user_guide/networks/structured_sexual.md
+++ b/docs/user_guide/networks/structured_sexual.md
@@ -65,7 +65,7 @@ Values are the age difference (male minus female) in years.
 
 ### Pair matching
 
-How sampled preferences are turned into pairs is set by `match_method`, which selects an algorithm from `sti.networks.matchers` (default `'closest_age_tapered_seeking'`). Pass any registered key, or a callable `f(net) -> (p1, p2)` for a custom matcher.
+How sampled preferences are turned into pairs is set by `match_method` (default `'closest_age_tapered_seeking'`). See [Pair matching](matching.md) for the algorithms and how to supply your own.
 
 ## Sex work
 


### PR DESCRIPTION
Docs-only. Brings the network user guide in line with the MF/SW network refactor and the MSM additions shipping in 1.5.7, and adds a page documenting the pair-matching algorithms.

## `structured_sexual.md`
- Fix base class: `ss.SexualNetwork` → `sti.MFNetwork`.
- Add **Architecture** section documenting the layered split (`BaseNetwork` → `MFNetwork` / `SWNetwork` → `StructuredSexual`) and that MF/SW are usable standalone.
- Note Poisson-vs-nbinom concurrency, FSW lifetime-share + active-window semantics, and `fsw_mf_conc_mult`.
- Point the pair-matching subsection at the new matching page.

## `matching.md` (new)
- Documents how `match_method` turns age preferences into pairs: the matching problem (eligible women/men, desired vs actual ages, the `(p1, p2)` contract).
- Step-by-step walkthrough of the default `closest_age_tapered_seeking` (older-woman taper → desired-age sampling → closest-age two-pointer sweep → extreme-gap trim), with ASCII diagrams (matching the disease-doc convention).
- Table of all 8 registry matchers with age-gap fidelity and the CRN caveat for `desired_age_bucket` / `band_match`.
- How to supply a custom callable matcher.

## `msm.md`
- Document `sti.MSMScaleFreeNetwork` (exported but previously undocumented): params table, scale-free behavior, CRN/expiration caveats.
- Correct base-class references (`StructuredSexual` → `MFNetwork`) and "both" → "all three" networks.

Wired `matching.md` into the TOC and the user-guide index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)