### PR TITLE
docs: fix syphilis API drift breaking the docs build

### DIFF
--- a/docs/tutorials/tut_calibration.qmd
+++ b/docs/tutorials/tut_calibration.qmd
@@ -279,7 +279,7 @@ sim = make_sim(analyzers=[CoinfectionPrev()])
 
 # Your data CSV just needs a matching column:
 #
-# time, hiv.prevalence, syph.active_prevalence, coinfectionprev.coinf_prev_f_15_24
+# time, hiv.prevalence, syph.symptomatic_prevalence, coinfectionprev.coinf_prev_f_15_24
 # 2016, 0.12,           0.03,                   0.005
 # 2020, 0.11,           0.025,                  0.004
 ```
@@ -292,7 +292,7 @@ This pattern works for any custom quantity: age-specific prevalence, risk-group-
 
 The calibration expects a DataFrame (or CSV) with a `time` column (integer years) and columns matching simulation result names:
 
-| time | hiv.prevalence | syph.active_prevalence | hiv.n_on_art |
+| time | hiv.prevalence | syph.symptomatic_prevalence | hiv.n_on_art |
 |------|---------------|----------------------|-------------|
 | 2010 | 0.12 | 0.03 | 50000 |
 | 2015 | 0.11 | 0.025 | 120000 |
@@ -305,7 +305,7 @@ Not all targets are equally informative. Use `weights` to tell the calibration w
 ```{python}
 weights = {
     'hiv.prevalence': 2.0,              # Routine data -- moderate weight
-    'syph.active_prevalence': 10.0,     # PHIA survey -- high weight
+    'syph.symptomatic_prevalence': 10.0,     # PHIA survey -- high weight
     'hiv.n_on_art': 1.0,                # Program data -- default weight
 }
 ```

--- a/docs/tutorials/tut_cotransmission.qmd
+++ b/docs/tutorials/tut_cotransmission.qmd
@@ -100,7 +100,7 @@ def make_diseases():
     hiv = sti.HIV(init_prev=0.02, beta_m2f=0.03)
     syph = sti.Syphilis(
         init_prev=0.10, beta_m2f=0.25,
-        rel_trans_primary=5, rel_trans_latent=0.1,
+        rel_trans_primary=5,
         eff_condom=0.5,
         dur_primary=ss.constant(v=ss.years(2)),  # Extended for illustration
     )

--- a/docs/user_guide/diseases/syphilis.md
+++ b/docs/user_guide/diseases/syphilis.md
@@ -85,9 +85,8 @@ Syphilis in STIsim progresses through exposed, primary, secondary, latent, and t
 | `eff_condom` | 0.0 | Condom efficacy (syphilis transmits via skin contact) |
 | `rel_trans_primary` | 1 | Relative transmissibility during primary stage |
 | `rel_trans_secondary` | 1 | Relative transmissibility during secondary stage |
-| `rel_trans_latent` | 1 | Baseline latent transmissibility (decays exponentially) |
 | `rel_trans_tertiary` | 0.0 | Relative transmissibility during tertiary (non-infectious) |
-| `rel_trans_latent_half_life` | 1 yr | Half-life of latent-stage transmissibility decay |
+| `rel_trans_latent_half_life` | 1 yr | Half-life of latent-stage transmissibility decay (latent starts from the secondary value and decays) |
 
 ### Congenital syphilis
 


### PR DESCRIPTION
The `v1.5.7` docs publish failed: [run 27622542519](https://github.com/starsimhub/stisim/actions/runs/27622542519/job/81675150026). Root cause is #500 syphilis API drift that the docs examples weren't updated for (the docs devtest didn't run pre-merge).

**Build-breaker**
- `docs/tutorials/tut_cotransmission.qmd` — `sti.Syphilis(... rel_trans_latent=0.1 ...)` raised `ValueError: 1 unrecognized arguments for syph: rel_trans_latent`. `rel_trans_latent` was removed in #500; latent transmissibility now decays from `rel_trans_secondary` by `rel_trans_latent_half_life`. Dropped the kwarg — the prose ("latent... far less infectious") stays accurate under the default decay. Verified the snippet constructs + runs.

**Correctness (non-breaking, same root cause)**
- `docs/user_guide/diseases/syphilis.md` — removed the stale `rel_trans_latent` parameter row; clarified the half-life row.
- `docs/tutorials/tut_calibration.qmd` — `syph.active_prevalence` → `syph.symptomatic_prevalence` (×3; `active_prevalence` was removed in #500).

Scanned the rest of the docs for the other 1.5.7 breaking changes (`msm_share`→`p_msm`, object→string syndromic API, removed `active`/`*_prevalence_15_64`) — no other live breakages (`interventions.md` already uses the string API; remaining `active_prevalence` hits were these).

After merge: re-run **Publish STIsim docs** on `main` (`workflow_dispatch`) and forward-port to `rc1.5.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)