### PR TITLE
GonorrheaTreatment: defend set_treat_eff against NaN rel_treat

### DIFF
--- a/stisim/interventions/gonorrhea_interventions.py
+++ b/stisim/interventions/gonorrhea_interventions.py
@@ -46,7 +46,9 @@ class GonorrheaTreatment(STITreatment):
         )
 
     def set_treat_eff(self, uids):
-        new_treat_eff = self.rel_treat[uids] * self.pars.base_treat_eff
+        rt = self.rel_treat[uids]
+        rt = np.where(np.isnan(rt), 1.0, rt)  # default for agents whose slot was inactive at init
+        new_treat_eff = rt * self.pars.base_treat_eff
         self.pars.treat_eff.set(new_treat_eff)
         return
 


### PR DESCRIPTION
Very uncommon but occasionally agents were gettings NaNs in their `rel_treat` arrays for gonorrhea. Fix: in set_treat_eff, replace any NaN rel_treat entries with 1 (the FloatArr's declared default) before computing treat_eff.