### PR TITLE
Minor change: art coverage plotting created two identical plots

### DIFF
--- a/stisim/analyzers.py
+++ b/stisim/analyzers.py
@@ -750,7 +750,7 @@ class art_coverage(ss.Analyzer):
                 ax.legend(frameon=False, fontsize=9)
 
         pl.tight_layout()
-        return fig
+        return ss.return_fig(fig)
 
 
 class PartnershipFormationAnalyzer(ss.Analyzer):


### PR DESCRIPTION
A very minor change - art_coverage plotting would create two identical plots instead of one.