### PR TITLE
docs: sync docs.stisim.org theme with stisim.org

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -32,7 +32,7 @@ website:
       - icon: slack
         href: https://starsimhub.slack.com
       - icon: globe
-        href: https://starsim.org/
+        href: https://stisim.org/
 
   navbar:
     logo: /assets/starsim-logo.png
@@ -47,7 +47,7 @@ website:
       - icon: slack
         href: https://starsim-idm.slack.com
       - icon: globe
-        href: https://starsim.org
+        href: https://stisim.org
 
     left:
       - href: index.md
@@ -233,6 +233,11 @@ format:
       light: [cosmo, ./assets/styles-light.scss]
       dark: [cosmo, ./assets/styles-dark.scss]
     css: ./assets/styles.css
+    include-in-header:
+      text: |
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Hanken+Grotesk:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
     toc: true
     toc-expand: true
     toc-depth: 5

--- a/docs/assets/styles-dark.scss
+++ b/docs/assets/styles-dark.scss
@@ -5,10 +5,10 @@
 }
 
 .navbar {
-    background-color: rgb(52, 52, 52);
+    background-color: #121e23;
 }
 
-/*-- From https://github.com/quarto-dev/quarto-web/blob/main/theme-dark.scss --*/
+/*-- Starsim dark theme: mirrors stisim.org's dark palette for continuity --*/
 
 /*-- scss:defaults --*/
 
@@ -17,8 +17,8 @@ $red: #D44000;
 $orange: #EE6331;
 $yellow: #E7B10A;
 $green: #72994E;
-$teal: #419599;
-$cyan: #75A8D9;
+$teal: #33a7b0;
+$cyan: #6cc9cf;
 $black: #000;
 $white: #fff;
 $gray: #404041;
@@ -42,19 +42,17 @@ $danger: $red;
 
 
 
-// Base document colors
-$body-bg: $gray-900;
-$body-color: $gray-100;
-$link-color: $cyan;
+// Base document colors -- matches stisim.org tokens.css dark theme
+$body-bg: #0c1418;
+$body-color: #e9efee;
+$link-color: #33a7b0;
 
 $light: rgb(32.4,32.4,34.2);
 
 // Navigation element colors
-/*$footer-bg: shade-color($gray-800, 30%);*/
-/*$navbar-bg: shade-color($gray-800, 30%);*/
-$footer-bg: $gray-900;
-$navbar-bg: shade-color($gray-800, 10%);
- 
+$footer-bg: #0f191d;
+$navbar-bg: #121e23;
+
 
 // Code blocks
 $code-block-bg-alpha: -.9;
@@ -71,18 +69,18 @@ $dropdown-link-hover-bg: $gray-600;
 $dropdown-link-hover-color: #eee;
 $nav-tabs-link-hover-border-color: rgb(80, 80, 80);
 
-$border-color: rgba($gray-800, 0.5);
+$border-color: #223037;
 
 $mono-background-color: rgba(0,0,0,0);
-$code-color: rgb(192, 128, 216);
+$code-color: #6cc9cf;
 $nav-tabs-link-active-color: $body-color;
-$toc-inactive-border: rgba($gray-800, 0.5);
+$toc-inactive-border: #223037;
 $input-text-background-color: $gray-800;
 $input-group-addon-bg: $gray-800;
 $carousel-dark-caption-color: $body-color;
 $pagination-disabled-bg: rgb(24,24,24);
 
-$text-muted: lighten(#6a737b, 20%);
+$text-muted: #90a2a8;
 
 /*-- scss:rules --*/
 

--- a/docs/assets/styles-light.scss
+++ b/docs/assets/styles-light.scss
@@ -1,3 +1,20 @@
+/*-- scss:defaults --*/
+
+// Starsim parchment theme: mirrors stisim.org's light palette for continuity
+$body-bg: #f2e9d3;
+$body-color: #2c2313;
+$link-color: #0e7c86;
+$link-hover-color: #0a5a62;
+
+$footer-bg: #ecdfc0;
+$navbar-bg: #ecdfc0;
+
+$border-color: #ddcda1;
+$text-muted: #6b5a3d;
+
+$code-color: #0a5a62;
+$code-bg: #e8d9b3;
+
 /*-- scss:rules --*/
 
 .navbar-logo {

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,7 +1,18 @@
-/* Global font settings */
+/* Global font settings -- matches stisim.org's type system for continuity */
 body, p {
-  font-family: "Raleway", "Montserrat", "Lato", "Open Sans", sans-serif;
+  font-family: "Hanken Grotesk", system-ui, -apple-system, sans-serif;
   font-size: 1.0em;
+}
+
+h1, h2, h3, h4, h5, h6,
+.navbar-brand, .navbar-title,
+.sidebar-title, .quarto-title h1 {
+  font-family: "Space Grotesk", system-ui, sans-serif;
+  letter-spacing: -.01em;
+}
+
+code, pre, kbd, samp, .font-monospace {
+  font-family: "IBM Plex Mono", ui-monospace, Menlo, monospace;
 }
 
 /* Prevent excessive spacing in terminal output -- need a better solution for when ansi codes are present */


### PR DESCRIPTION
## Summary
- Match fonts (Space Grotesk / Hanken Grotesk / IBM Plex Mono) and light (parchment) / dark color tokens between docs.stisim.org and the new stisim.org marketing site (stisim/stisim-site) for visual continuity.
- Point the navbar/footer globe icon at stisim.org instead of starsim.org.

## Test plan
- [x] Rendered `docs/index.md` locally with `quarto render`; confirmed compiled CSS carries the new parchment (`#f2e9d3`) and dark (`#0c1418`) palette and the Google Fonts link is present.
- [ ] Spot-check a rendered page in both light and dark mode after merge.