### PR TITLE
fix(syph): clear early/late flags when mother exits latent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the codebase are documented in this file.
 
 ## Version 1.5.9 (TBC)
 
+### Diseases
+- Syphilis: clear `early` / `late` sub-flags when a mother exits the latent state (reactivation to secondary, or progression to tertiary). Previously these BoolStates persisted, so `set_congenital`'s outcome loop `for state in ['mat_active', 'early', 'late']` would overwrite the correct `mat_active` draw with the (now-stale) `early` / `late` table draw — biasing MTCT outcomes for reactivating mothers toward `normal` (the late table is 80% normal vs mat_active's 25%). Empirical impact in a hot-seed ANC screening sim: untreated-secondary MTCTs read 67% normal instead of the expected 25%.
+
 ## Version 1.5.8 (2026-06-25)
 
 ### Logistics

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -450,6 +450,11 @@ class Syphilis(BaseSTI):
         if len(secondary_from_latent.uids) > 0:
             self.secondary[secondary_from_latent] = True
             self.latent[secondary_from_latent] = False
+            # early/late are sub-flags of latent; clear them so set_congenital's
+            # outcome loop doesn't overwrite the mat_active-table draw with the
+            # (now-stale) early/late-table draw.
+            self.early[secondary_from_latent] = False
+            self.late[secondary_from_latent] = False
             self.set_secondary_prognoses(secondary_from_latent.uids)
             self._set_rash_visible(secondary_from_latent.uids)
 
@@ -465,6 +470,8 @@ class Syphilis(BaseSTI):
         tertiary = self.latent & (self.ti_tertiary <= ti)
         self.tertiary[tertiary] = True
         self.latent[tertiary] = False
+        self.early[tertiary] = False
+        self.late[tertiary] = False
 
         # Trigger deaths
         deaths = (self.ti_dead <= ti).uids


### PR DESCRIPTION
`early` and `late` are sub-flags of `latent`. Two paths in `step_state` cleared `latent` but left `early` / `late` intact:
  - secondary reactivation from latent
  - progression to tertiary

For a mother in this state (secondary or tertiary, with a residual early or late flag), `set_congenital`'s outcome loop `for state in ['mat_active', 'early', 'late']` would sample from `mat_active` correctly, then OVERWRITE with the early- and late-table draws. Since the late table is 80% normal vs mat_active's 25%, reactivating mothers' MTCT outcomes were heavily biased toward normal.

Diagnostic in a hot-seed ANC screening sim (draw 343, seeds 343000/003, 2000-2045, untreated syph+ pregnancies):
  - 12 of 18 secondary MTCTs were reactivations from latent.
  - Observed cs_outcome = normal 67% vs mat_active expected 25%.

Fix clears `early` / `late` in both transitions.