### PR TITLE
Add rel_migration parameter to Migration

### DIFF
--- a/stisim/demographics.py
+++ b/stisim/demographics.py
@@ -22,10 +22,14 @@ class Migration(ss.Demographics):
 
     Args:
         pars (dict): Parameter overrides (e.g. ``migration_propensity``,
-            ``slot_scale``, ``min_slots``).
+            ``slot_scale``, ``min_slots``, ``rel_migration``).
         migration_data (DataFrame): Must contain ``'Time'`` and ``'Value'``
             columns giving the net number of migrants per year.
         **kwargs: Additional parameter overrides.
+
+    Pars:
+        rel_migration: constant used to scale the net number of migrants
+            (both immigration and emigration), analogous to ``rel_death``.
     """
     def __init__(self, pars=None, migration_data=None, **kwargs):
         super().__init__()
@@ -35,6 +39,7 @@ class Migration(ss.Demographics):
             migration_propensity = ss.normal(loc=1, scale=0.1),  # Propensity to emigrate
             slot_scale = 5, # Random slots will be assigned to newborn agents between min=n_agents and max=slot_scale*n_agents
             min_slots  = 100, # Minimum number of slots, useful if the population size is very small
+            rel_migration = 1, # Scale factor for net migration (both immigration and emigration)
         )
         self.update_pars(pars, **kwargs)
         self.define_states(
@@ -92,7 +97,7 @@ class Migration(ss.Demographics):
             n_migrants = mrd.loc[nearest_year].Value
         elif sc.isnumber(mrd):
             n_migrants = mrd
-        scaled_migrants = int(n_migrants*self.t.dt_year/self.sim.pars.pop_scale)
+        scaled_migrants = int(n_migrants*self.t.dt_year/self.sim.pars.pop_scale*self.pars.rel_migration)
         return scaled_migrants
 
     def make_immigrants(self, twin_uids):

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -1,0 +1,48 @@
+"""
+Tests for stisim demographics modules.
+"""
+
+import pandas as pd
+import starsim as ss
+import stisim as sti
+
+
+def _make_sim(rel_migration=1.0, n_migrants=2000, n_agents=2000, start=2000, stop=2010):
+    data = pd.DataFrame({'Time': [start, stop], 'Value': [n_migrants, n_migrants]})
+    migration = sti.Migration(migration_data=data, pars=dict(rel_migration=rel_migration))
+    sim = ss.Sim(n_agents=n_agents, start=start, stop=stop, demographics=[migration],
+                 networks=[], diseases=[], verbose=0)
+    sim.run()
+    return sim
+
+
+def test_rel_migration_scales_immigration():
+    """ rel_migration should scale up net immigration proportionally """
+    sim1 = _make_sim(rel_migration=1.0, n_migrants=2000)
+    sim2 = _make_sim(rel_migration=2.0, n_migrants=2000)
+    total1 = sim1.demographics.migration.results.new_migrants.sum()
+    total2 = sim2.demographics.migration.results.new_migrants.sum()
+    assert total1 > 0
+    assert total2 == 2 * total1
+
+
+def test_rel_migration_scales_emigration():
+    """ rel_migration should scale up net emigration (negative values) proportionally """
+    sim1 = _make_sim(rel_migration=1.0, n_migrants=-500)
+    sim2 = _make_sim(rel_migration=2.0, n_migrants=-500)
+    total1 = sim1.demographics.migration.results.new_migrants.sum()
+    total2 = sim2.demographics.migration.results.new_migrants.sum()
+    assert total1 < 0
+    assert total2 == 2 * total1
+
+
+def test_rel_migration_zero_disables_migration():
+    """ rel_migration=0 should produce no migrants """
+    sim = _make_sim(rel_migration=0.0, n_migrants=2000)
+    assert sim.demographics.migration.results.new_migrants.sum() == 0
+
+
+if __name__ == '__main__':
+    test_rel_migration_scales_immigration()
+    test_rel_migration_scales_emigration()
+    test_rel_migration_zero_disables_migration()


### PR DESCRIPTION
## Summary
- Adds `rel_migration` (default 1) to `sti.Migration`, analogous to `ss.Deaths.rel_death`: scales the net number of migrants (both immigration and emigration) computed each timestep.
- Automatically routable through `sti.Sim`/`hivsim.Sim` demographics kwargs the same way other `Migration` pars are (via the existing `sti.Migration().pars.keys()` filter in `stisim/sim.py`).

Closes #542

## Test plan
- [x] New `tests/test_demographics.py`: `rel_migration` scales immigration and emigration proportionally; `rel_migration=0` disables migration entirely.
- [x] `pytest tests/` — 179 passed