### PR TITLE
Remove stale CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,0 @@
-The uncommitted changes to CLAUDE.md are just cleanup—no new context to capture. The project memory documents the ANC screening work comprehensively: ANCTest/InfantHIVTest interventions ✓, FetalHealth connector ✓, and all gotchas (connector params, analyzer count fields).
-
-SKIP


### PR DESCRIPTION
## Summary
- Closes #549. `CLAUDE.md` had accumulated stale session-note churn ("Set session priority: anc_sti_screening", "Clean up CLAUDE.md: session end", etc. across dozens of commits) rather than real project instructions, and was confusing agents that treated it as legitimate memory content. Nothing in CI/tooling references it. Removed outright.