### PR TITLE
New model for ART adherence

### DIFF
--- a/docs/user_guide/diseases/hiv.md
+++ b/docs/user_guide/diseases/hiv.md
@@ -14,13 +14,13 @@ HIV in STIsim is modeled with CD4-based disease progression through acute, laten
                                ▼
                         ┌─────────────┐
                         │    Acute    │  CD4 declines from ~800 to ~500
-                        │  (~3 mo)   │  Transmissibility: 6x baseline
+                        │  (~3 mo)    │  Transmissibility: 6x baseline
                         └──────┬──────┘
                                │
                                ▼
                         ┌─────────────┐
                         │   Latent    │  CD4 stable at ~500
-                        │  (~10 yr)  │  Transmissibility: 1x baseline
+                        │  (~10 yr)   │  Transmissibility: 1x baseline
                         └──────┬──────┘
                                │
                     ┌──────────┴──────────┐
@@ -98,9 +98,59 @@ HIV in STIsim is modeled with CD4-based disease progression through acute, laten
      │     50–200:    1.0%/yr                  │
      │     0–50:      5.0%/yr                  │
      │     ~0:       30.0%/yr                  │
-     │   (untreated agents only)               │
+     │   (untreated agents only --             │
+     │    on-ART agents can also die here if   │
+     │    use_art_mortality_table=True, see    │
+     │    "ART mortality: two selectable       │
+     │    modes" below)                        │
      └─────────────────────────────────────────┘
 ```
+
+## ART mortality: two selectable modes
+
+This section zooms into a single box from the diagram above: **On ART**. In that diagram, "On ART" has exactly one way out — ART dropout, into Post-ART — because by default agents cannot die from HIV while `on_art = True`; only the off-ART CD4-based hazard (bottom box, "AIDS death") applies, and only once they've dropped out. `HIVPars.use_art_mortality_table` (default `False`) controls whether that's still true, i.e. whether "On ART" gains a **second** way out, straight to AIDS death, alongside the existing dropout path:
+
+```
+                        ┌─────────────────┐
+                        │     On ART      │  (from the diagram above)
+                        └───┬─────────┬───┘
+             always: ART    │         │  only if use_art_mortality_table=True:
+             dropout        │         │  ARTMortalityTable-style hazard, every timestep
+                            ▼         ▼
+                  ┌─────────────┐ ┌─────────────┐
+                  │  Post-ART   │ │ AIDS death  │
+                  └─────────────┘ └─────────────┘
+```
+
+Everything else in the diagram above (Falling, Post-ART, the AIDS-death CD4 hazard table) is unaffected by this toggle either way — it only changes whether "On ART" itself is a possible source of death, and if so, how that risk is computed:
+
+```
+                     ┌─────────────────────────┐
+                     │  On ART (on_art = True) │
+                     └───────────┬─────────────┘
+                                 │
+                      use_art_mortality_table?
+              ┌──────────────────┴──────────────────┐
+              │                                     │
+            False (default)                         True
+              │                                     │
+              ▼                                     ▼
+┌─────────────────────────────┐       ┌────────────────────────────────────┐
+│ "Simple" mode               │       │ ARTMortalityTable mode             │
+│                             │       │                                    │
+│ Mortality = 0 while on ART. │       │ get_art_mortality_hazard():        │
+│ Only the off-ART CD4-based  │       │ look up annual hazard by:          │
+│ hazard (see diagram above)  │       │   - age          (4 bins)          │
+│ ever applies.               │       │   - sex          (m / f)           │
+└─────────────────────────────┘       │   - adherence    (effective /      │
+                                      │                   non-suppressive) │
+                                      │   - duration since ti_art          │
+                                      │                   (5 bins)         │
+                                      │   - CURRENT cd4  (7 bins)          │
+                                      └────────────────────────────────────┘
+```
+
+The ARTMortalityTable-mode lookup uses the agent's **current** CD4 count (not frozen at ART initiation) — since STIsim already recomputes CD4 every timestep for the reconstitution curve, there's no reason to freeze it the way EMOD does (see `art_implementation_notes.md` section 9 for the rationale). The default table's numbers (both effective- and non-suppressive-ART variants, by sex) ship from the EMOD-HIV campaign example in `HIVSim_notes/art.md`; pass your own `art_mortality_table` dict of the same shape to use different data. EMOD's "terminal failing window" (a temporary loss of transmission suppression in the months before an ART-mortality-table-scheduled death) is not modeled in either mode.
 
 ### Notes on ART
 
@@ -109,14 +159,16 @@ HIV in STIsim is modeled with CD4-based disease progression through acute, laten
 - ART duration is drawn per-agent: `dur_on_art ~ LogNormal(3yr, 1.5yr) × rel_dur_on_art`
   - `rel_dur_on_art` is a calibrated scalar (range 1–20) that stretches mean duration
 - After dropout, `ti_zero` is redrawn based on CD4 at dropout and `cd4_potential`
-- **No age or sex dependence** anywhere in natural history, mortality, or ART effects
+- **No age or sex dependence** in natural history or ART dropout timing. Mortality *while on ART* is age/sex-dependent only if `use_art_mortality_table=True` (see above); it's otherwise zero regardless of age or sex.
 
 ### What is not modeled
 
 - Viral load / viral suppression (ART = fully suppressed, binary)
-- Age-varying progression rates or mortality
+- Age-varying progression rates (natural history is age-independent regardless of ART-mortality mode)
+- Age/sex-varying mortality while on ART, unless `use_art_mortality_table=True` (see above)
 - Sex-varying natural history
 - Re-infection or superinfection
+- EMOD's "terminal failing window" (see above)
 
 ## Parameters
 
@@ -159,6 +211,8 @@ HIV in STIsim is modeled with CD4-based disease progression through acute, laten
 | `time_to_art_efficacy` | 6 months | Time to reach full ART efficacy (linear ramp) |
 | `art_cd4_growth` | 0.1 | Logistic growth rate for CD4 reconstitution on ART |
 | `dur_on_art` | lognorm(3 yr, 1.5 yr) | Duration on ART before dropout |
+| `use_art_mortality_table` | False | If True, apply the ARTMortalityTable-style age/sex/adherence/duration-stratified hazard to on-ART agents instead of zero mortality (see "ART mortality: two selectable modes" above) |
+| `art_mortality_table` | EMOD example table | Age/sex/adherence/duration/CD4-stratified annual hazard table used when `use_art_mortality_table=True`; pass your own dict of the same shape to override |
 
 ### Care seeking
 

--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -59,8 +59,10 @@ class HIVPars(BaseSTIPars):
 
         # Treatment effects
         self.art_cd4_growth = 0.1  # Unitless parameter defining how CD4 reconstitutes after starting ART - used in a logistic growth function
-        self.art_efficacy = 0.96  # Efficacy of ART
+        self.effective_art_efficacy = 0.96  # Transmission efficacy of effective (virally-suppressive) ART
+        self.nonsupp_art_efficacy = 0.35  # Transmission efficacy of non-suppressive ART
         self.time_to_art_efficacy = ss.months(6)  # Time to reach full ART efficacy (in months) - linear increase in efficacy
+        self.p_effective_art = ss.bernoulli(p=1.0)  # Probability that a newly-initiated agent achieves viral suppression (vs. non-suppressive ART)
         self.art_cd4_pars = dict(cd4_max=1000, cd4_healthy=500)
         self.dur_on_art = ss.lognorm_ex(ss.years(3), ss.years(1.5))  # Base ART duration (scaled by rel_dur_on_art and trend)
         self.rel_dur_on_art = 1.0  # Calibratable scalar that scales ART duration
@@ -115,8 +117,11 @@ class HIV(BaseSTI):
             # Care and treatment states
             ss.FloatArr('baseline_care_seeking'),
             ss.FloatArr('care_seeking'),
-            ss.BoolState('never_art', default=True),
-            ss.BoolState('on_art'),
+            ss.BoolState('art_naive', default=True),        # Never initiated ART
+            ss.BoolState('on_art'),                          # Currently on ART (effective or non-suppressive)
+            ss.BoolState('on_effective_art'),                # Currently on ART and virally suppressed
+            ss.BoolState('on_nonsuppressive_art'),           # Currently on ART but not virally suppressed
+            ss.BoolState('art_discontinued'),                # Previously on ART, currently off
             ss.FloatArr('ti_art'),
             ss.FloatArr('ti_stop_art'),
 
@@ -362,8 +367,8 @@ class HIV(BaseSTI):
             self.cd4[art_uids] = self.cd4_increase(art_uids)
 
         # Adjust CD4 counts for people who have gone off treatment - linear decline
-        if (~self.on_art & ~self.never_art).any():
-            off_art_uids = (~self.on_art & ~self.never_art).uids
+        if self.art_discontinued.any():
+            off_art_uids = self.art_discontinued.uids
             self.cd4[off_art_uids] = self.post_art_decline(off_art_uids)
 
         # Update states for people who have never been on ART (ART removes these)
@@ -422,8 +427,11 @@ class HIV(BaseSTI):
         self.latent[uids] = False
         self.falling[uids] = False
         self.post_art[uids] = False
-        self.never_art[uids] = False
+        self.art_naive[uids] = False
         self.on_art[uids] = False
+        self.on_effective_art[uids] = False
+        self.on_nonsuppressive_art[uids] = False
+        self.art_discontinued[uids] = False
         self.diagnosed[uids] = False
 
         # Clear time states except for ti_dead
@@ -484,15 +492,16 @@ class HIV(BaseSTI):
         self.rel_trans[self.aids] *= self.pars.rel_trans_falling.rvs(self.aids.uids)
 
         # Update transmission for agents on ART
-        # When agents start ART, determine the reduction of transmission (linearly decreasing over 6 months)
+        # When agents start ART, determine the reduction of transmission (linearly decreasing over 6 months).
+        # Efficacy depends on whether the agent is virally suppressed (effective ART) or not (non-suppressive ART).
         if self.on_art.any():
-            full_eff = self.pars.art_efficacy
             time_to_full_eff = self.pars.time_to_art_efficacy
             art_uids = self.on_art.uids
+            full_eff = np.where(self.on_effective_art[art_uids], self.pars.effective_art_efficacy, self.pars.nonsupp_art_efficacy)
             timesteps_on_art = ti - self.ti_art[art_uids]
             new_on_art = timesteps_on_art < time_to_full_eff/self.dt
-            efficacy_to_date = np.full_like(art_uids, fill_value=full_eff, dtype=float)
-            efficacy_to_date[new_on_art] = timesteps_on_art[new_on_art]*full_eff/time_to_full_eff.value
+            efficacy_to_date = full_eff.copy()
+            efficacy_to_date[new_on_art] = timesteps_on_art[new_on_art]*full_eff[new_on_art]/time_to_full_eff.value
             self.rel_trans[art_uids] *= 1 - efficacy_to_date
 
         return
@@ -574,6 +583,11 @@ class HIV(BaseSTI):
         dur_falling = self.pars.dur_falling.rvs(uids)
         self.ti_zero[uids] = self.ti_falling[uids] + dur_falling.astype(int)
 
+        # Record source/target for ss.infection_log() -- HIV overrides the base
+        # Disease.set_prognoses() entirely for its natural-history setup above, so
+        # without this call the infection log's append hook never fires for HIV.
+        super().set_prognoses(uids, sources)
+
         return
 
     def set_congenital(self, uids, sources):
@@ -583,17 +597,41 @@ class HIV(BaseSTI):
         return
 
     # Treatment-related changes
-    def start_art(self, uids):
+    def start_art(self, uids, p_effective_art=None):
         """
         Check who is ready to start ART treatment and put them on ART
+
+        Args:
+            uids: agents starting ART treatment
+            p_effective_art (float/ss.Dist, optional): probability that each agent
+                achieves viral suppression (effective ART) rather than non-suppressive
+                ART. Pass a float to override `self.pars.p_effective_art`'s probability,
+                or an already-initialized `ss.Dist` (e.g. an intervention's own par) to
+                use it directly. Defaults to `self.pars.p_effective_art`
+                (default: always effective).
         """
         ti = self.ti
 
         self.on_art[uids] = True
-        newly_treated = uids[self.never_art[uids]]
-        self.never_art[newly_treated] = False
+        self.art_discontinued[uids] = False
+        newly_treated = uids[self.art_naive[uids]]
+        self.art_naive[newly_treated] = False
         self.ti_art[uids] = ti
         self.cd4_preart[uids] = self.cd4[uids]
+
+        # Determine whether each agent achieves viral suppression (effective ART) or
+        # remains non-suppressive, e.g. due to poor adherence or drug resistance
+        if isinstance(p_effective_art, ss.Dist):
+            effective_uids = p_effective_art.filter(uids)
+        else:
+            if p_effective_art is not None:
+                self.pars.p_effective_art.set(p=p_effective_art)
+            effective_uids = self.pars.p_effective_art.filter(uids)
+        nonsupp_uids = uids.remove(effective_uids)
+        self.on_effective_art[effective_uids] = True
+        self.on_nonsuppressive_art[effective_uids] = False
+        self.on_effective_art[nonsupp_uids] = False
+        self.on_nonsuppressive_art[nonsupp_uids] = True
 
         # Determine when agents goes off ART
         dur_on_art = self.pars.dur_on_art.rvs(uids)
@@ -642,6 +680,9 @@ class HIV(BaseSTI):
         # Remove agents from ART
         if uids is None: uids = self.on_art & (self.ti_stop_art <= ti)
         self.on_art[uids] = False
+        self.on_effective_art[uids] = False
+        self.on_nonsuppressive_art[uids] = False
+        self.art_discontinued[uids] = True
         self.ti_stop_art[uids] = ti
         self.cd4_postart[uids] = sc.dcp(self.cd4[uids])
 

--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -11,6 +11,117 @@ from stisim.diseases.sti import BaseSTI, BaseSTIPars
 __all__ = ['HIV', 'HIVPars']
 
 
+# Default ARTMortalityTable-style dataset: annual HIV mortality hazard for
+# agents on ART, stratified by ART duration bin x age bin x CD4 bin, separately
+# for males/females and effective/non-suppressive ART. Transcribed from the
+# EMOD-HIV campaign example in HIVSim_notes/art.md (art_implementation_notes.md
+# section 7 has a discussion of what these numbers mean). Each table has shape
+# (n_dur_bins, n_age_bins, n_cd4_bins) = (5, 4, 7), matching the bin edges below.
+_ART_MORTALITY_AGE_BINS = np.array([25, 35, 45, 125])  # years; upper edges of <25/25-35/35-45/45+
+_ART_MORTALITY_DUR_BINS = np.array([182, 365, 730, 1095, 45625])  # days since ART initiation
+_ART_MORTALITY_CD4_BINS = np.array([0, 25, 74.5, 149.5, 274.5, 424.5, 624.5])  # CD4 count
+
+_ART_MORTALITY_EFFECTIVE_MALE = np.array([
+    [[0.2015, 0.2015, 0.1128, 0.0625, 0.0312, 0.0206, 0.0162],
+     [0.2176, 0.2176, 0.1219, 0.0675, 0.0337, 0.0223, 0.0175],
+     [0.2350, 0.2350, 0.1316, 0.0729, 0.0364, 0.0240, 0.0189],
+     [0.2538, 0.2538, 0.1421, 0.0787, 0.0393, 0.0260, 0.0205]],
+    [[0.0875, 0.0875, 0.0490, 0.0271, 0.0136, 0.0062, 0.0041],
+     [0.0945, 0.0945, 0.0529, 0.0293, 0.0146, 0.0067, 0.0044],
+     [0.1021, 0.1021, 0.0572, 0.0316, 0.0158, 0.0073, 0.0047],
+     [0.1102, 0.1102, 0.0617, 0.0342, 0.0171, 0.0079, 0.0051]],
+    [[0.0255, 0.0255, 0.0181, 0.0128, 0.0085, 0.0058, 0.0038],
+     [0.0288, 0.0288, 0.0204, 0.0145, 0.0096, 0.0065, 0.0043],
+     [0.0326, 0.0326, 0.0231, 0.0164, 0.0108, 0.0074, 0.0049],
+     [0.0368, 0.0368, 0.0261, 0.0185, 0.0123, 0.0084, 0.0055]],
+    [[0.0164, 0.0164, 0.0116, 0.0083, 0.0055, 0.0037, 0.0025],
+     [0.0186, 0.0186, 0.0131, 0.0093, 0.0062, 0.0042, 0.0042],
+     [0.0210, 0.0210, 0.0148, 0.0106, 0.0070, 0.0048, 0.0048],
+     [0.0237, 0.0237, 0.0168, 0.0119, 0.0079, 0.0054, 0.0054]],
+    [[0.0119, 0.0119, 0.0081, 0.0066, 0.0033, 0.0033, 0.0033],
+     [0.0135, 0.0135, 0.0092, 0.0074, 0.0037, 0.0037, 0.0037],
+     [0.0152, 0.0152, 0.0103, 0.0084, 0.0042, 0.0042, 0.0042],
+     [0.0172, 0.0172, 0.0117, 0.0095, 0.0047, 0.0047, 0.0047]],
+])
+
+_ART_MORTALITY_NONSUPP_MALE = np.array([
+    [[0.2015, 0.2015, 0.1128, 0.0625, 0.0312, 0.0206, 0.0162],
+     [0.2176, 0.2176, 0.1219, 0.0675, 0.0337, 0.0223, 0.0175],
+     [0.2350, 0.2350, 0.1316, 0.0729, 0.0364, 0.0240, 0.0189],
+     [0.2538, 0.2538, 0.1421, 0.0787, 0.0393, 0.0260, 0.0205]],
+    [[0.1715, 0.1715, 0.5600, 0.3100, 0.1550, 0.0713, 0.0465],
+     [0.1852, 0.1852, 0.6048, 0.3348, 0.1674, 0.0770, 0.0502],
+     [0.2000, 0.2000, 0.6532, 0.3616, 0.1808, 0.0832, 0.0542],
+     [0.2160, 0.2160, 0.7054, 0.3905, 0.1953, 0.0898, 0.0586]],
+    [[0.0532, 0.0532, 0.0362, 0.0293, 0.0171, 0.0116, 0.0095],
+     [0.0601, 0.0601, 0.0409, 0.0331, 0.0193, 0.0131, 0.0107],
+     [0.0679, 0.0679, 0.0462, 0.0374, 0.0218, 0.0148, 0.0121],
+     [0.0768, 0.0768, 0.0522, 0.0422, 0.0246, 0.0168, 0.0137]],
+    [[0.0335, 0.0335, 0.0228, 0.0184, 0.0108, 0.0073, 0.0060],
+     [0.0379, 0.0379, 0.0258, 0.0208, 0.0122, 0.0083, 0.0068],
+     [0.0428, 0.0428, 0.0291, 0.0235, 0.0137, 0.0094, 0.0076],
+     [0.0484, 0.0484, 0.0329, 0.0266, 0.0155, 0.0106, 0.0086]],
+    [[0.0234, 0.0234, 0.0159, 0.0129, 0.0091, 0.0069, 0.0064],
+     [0.0265, 0.0265, 0.0180, 0.0145, 0.0103, 0.0077, 0.0073],
+     [0.0299, 0.0299, 0.0203, 0.0164, 0.0116, 0.0088, 0.0082],
+     [0.0338, 0.0338, 0.0230, 0.0186, 0.0131, 0.0099, 0.0093]],
+])
+
+_ART_MORTALITY_EFFECTIVE_FEMALE = np.array([
+    [[0.2015, 0.2015, 0.0993, 0.0518, 0.0259, 0.0171, 0.0135],
+     [0.2156, 0.2156, 0.1062, 0.0554, 0.0277, 0.0183, 0.0144],
+     [0.2307, 0.2307, 0.1137, 0.0593, 0.0296, 0.0196, 0.0154],
+     [0.2468, 0.2468, 0.1216, 0.0634, 0.0317, 0.0209, 0.0165]],
+    [[0.0875, 0.0875, 0.0431, 0.0225, 0.0112, 0.0052, 0.0034],
+     [0.0936, 0.0936, 0.0461, 0.0241, 0.0120, 0.0055, 0.0036],
+     [0.1002, 0.1002, 0.0494, 0.0257, 0.0129, 0.0059, 0.0039],
+     [0.1072, 0.1072, 0.0528, 0.0276, 0.0138, 0.0063, 0.0041]],
+    [[0.0241, 0.0241, 0.0166, 0.0135, 0.0067, 0.0044, 0.0044],
+     [0.0262, 0.0262, 0.0181, 0.0147, 0.0073, 0.0048, 0.0048],
+     [0.0286, 0.0286, 0.0197, 0.0160, 0.0080, 0.0052, 0.0052],
+     [0.0312, 0.0312, 0.0215, 0.0175, 0.0087, 0.0057, 0.0057]],
+    [[0.0149, 0.0149, 0.0103, 0.0084, 0.0042, 0.0042, 0.0042],
+     [0.0163, 0.0163, 0.0112, 0.0091, 0.0046, 0.0046, 0.0046],
+     [0.0177, 0.0177, 0.0122, 0.0099, 0.0050, 0.0050, 0.0050],
+     [0.0193, 0.0193, 0.0133, 0.0108, 0.0054, 0.0054, 0.0054]],
+    [[0.0084, 0.0084, 0.0057, 0.0046, 0.0023, 0.0023, 0.0023],
+     [0.0092, 0.0092, 0.0062, 0.0051, 0.0025, 0.0025, 0.0025],
+     [0.0100, 0.0100, 0.0068, 0.0055, 0.0028, 0.0028, 0.0028],
+     [0.0109, 0.0109, 0.0074, 0.0060, 0.0030, 0.0030, 0.0030]],
+])
+
+_ART_MORTALITY_NONSUPP_FEMALE = np.array([
+    [[0.2015, 0.2015, 0.1128, 0.0625, 0.0312, 0.0206, 0.0162],
+     [0.2176, 0.2176, 0.1219, 0.0675, 0.0337, 0.0223, 0.0175],
+     [0.2350, 0.2350, 0.1316, 0.0729, 0.0364, 0.0240, 0.0189],
+     [0.2538, 0.2538, 0.1421, 0.0787, 0.0393, 0.0260, 0.0205]],
+    [[0.1837, 0.1837, 0.0845, 0.0441, 0.0220, 0.0101, 0.0066],
+     [0.1965, 0.1965, 0.0904, 0.0472, 0.0236, 0.0108, 0.0071],
+     [0.2103, 0.2103, 0.0967, 0.0505, 0.0252, 0.0116, 0.0076],
+     [0.2250, 0.2250, 0.1035, 0.0540, 0.0270, 0.0124, 0.0081]],
+    [[0.0461, 0.0461, 0.0318, 0.0258, 0.0151, 0.0103, 0.0084],
+     [0.0502, 0.0502, 0.0346, 0.0281, 0.0164, 0.0113, 0.0091],
+     [0.0547, 0.0547, 0.0378, 0.0306, 0.0179, 0.0123, 0.0100],
+     [0.0596, 0.0596, 0.0412, 0.0334, 0.0195, 0.0134, 0.0109]],
+    [[0.0286, 0.0286, 0.0197, 0.0160, 0.0113, 0.0086, 0.0080],
+     [0.0311, 0.0311, 0.0215, 0.0174, 0.0124, 0.0094, 0.0087],
+     [0.0339, 0.0339, 0.0234, 0.0190, 0.0135, 0.0102, 0.0095],
+     [0.0370, 0.0370, 0.0255, 0.0207, 0.0147, 0.0111, 0.0104]],
+    [[0.0161, 0.0161, 0.0110, 0.0089, 0.0063, 0.0047, 0.0044],
+     [0.0176, 0.0176, 0.0119, 0.0097, 0.0068, 0.0052, 0.0048],
+     [0.0192, 0.0192, 0.0130, 0.0105, 0.0075, 0.0056, 0.0053],
+     [0.0209, 0.0209, 0.0142, 0.0115, 0.0081, 0.0061, 0.0057]],
+])
+
+_DEFAULT_ART_MORTALITY_TABLE = dict(
+    age_bins=_ART_MORTALITY_AGE_BINS,
+    dur_bins=_ART_MORTALITY_DUR_BINS,
+    cd4_bins=_ART_MORTALITY_CD4_BINS,
+    effective=dict(m=_ART_MORTALITY_EFFECTIVE_MALE, f=_ART_MORTALITY_EFFECTIVE_FEMALE),
+    nonsuppressive=dict(m=_ART_MORTALITY_NONSUPP_MALE, f=_ART_MORTALITY_NONSUPP_FEMALE),
+)
+
+
 class HIVPars(BaseSTIPars):
     """
     Parameters for the HIV disease module.
@@ -69,6 +180,18 @@ class HIVPars(BaseSTIPars):
         self.dur_on_art_trend = None  # Optional time-varying scale, e.g. sc.objdict(years=np.array([2004, 2015, 2030]), vals=np.array([0.5, 1.0, 1.5]))
         self.dur_post_art = ss.normal()  # Note defined in years!
         self.dur_post_art_scale_factor = 0.1
+
+        # ARTMortalityTable-style differential ART mortality (art.md step 4). Off by
+        # default: with use_art_mortality_table=False, on-ART agents keep the original
+        # zero-HIV-mortality-while-on-ART behavior (make_p_hiv_death only applies to
+        # off-ART agents). Setting it True looks up a nonzero, age/sex/adherence/
+        # duration-since-initiation-stratified hazard for on-ART agents instead (see
+        # HIV.get_art_mortality_hazard). art_mortality_table ships with the example
+        # values from HIVSim_notes/art.md's EMOD campaign excerpt; pass your own dict
+        # of the same shape (age_bins/dur_bins/cd4_bins + effective/nonsuppressive
+        # tables keyed by 'm'/'f') to use different data.
+        self.use_art_mortality_table = False
+        self.art_mortality_table = sc.dcp(_DEFAULT_ART_MORTALITY_TABLE)
 
         self.update(kwargs)
         return
@@ -318,6 +441,44 @@ class HIV(BaseSTI):
         p_hiv_death = ss.peryear(np.array([0.003, 0.003, 0.005, 0.01, 0.05, 0.300])).to_prob(self.dt)
         return p_hiv_death[np.digitize(self.cd4[uids], cd4_bins)]
 
+    def get_art_mortality_hazard(self, uids):
+        """
+        ARTMortalityTable-style per-timestep HIV death probability for agents
+        currently on ART (`pars.use_art_mortality_table=True` only).
+
+        Looks up an annual mortality hazard stratified by age, sex, ART
+        adherence category (effective vs. non-suppressive), and duration
+        since ART initiation, from `pars.art_mortality_table`. Unlike EMOD's
+        ARTMortalityTable, which freezes age/CD4 at the moment of initiation
+        (a simplification specific to EMOD's one-time survival-draw design),
+        this looks up the agent's CURRENT CD4 every time it's called, since
+        STIsim already recomputes CD4 continuously for other purposes (see
+        art_implementation_notes.md section 9 for the rationale).
+        """
+        table = self.pars.art_mortality_table
+        age_bins = table['age_bins']
+        dur_bins = table['dur_bins']
+        cd4_bins = table['cd4_bins']
+
+        age_idx = np.clip(np.digitize(self.sim.people.age[uids], age_bins), 0, len(age_bins) - 1)
+        dur_days = (self.ti - self.ti_art[uids]) * self.dt.days
+        dur_idx = np.clip(np.digitize(dur_days, dur_bins), 0, len(dur_bins) - 1)
+        cd4_idx = np.clip(np.digitize(self.cd4[uids], cd4_bins), 0, len(cd4_bins) - 1)
+
+        male = self.sim.people.male[uids]
+        effective = self.on_effective_art[uids]
+
+        annual_rate = np.empty(len(uids))
+        for adherence_key, adherence_mask in (('effective', effective), ('nonsuppressive', ~effective)):
+            for sex_key, sex_mask in (('m', male), ('f', ~male)):
+                mask = adherence_mask & sex_mask
+                if not mask.any():
+                    continue
+                mtable = table[adherence_key][sex_key]  # shape (n_dur, n_age, n_cd4)
+                annual_rate[mask] = mtable[dur_idx[mask], age_idx[mask], cd4_idx[mask]]
+
+        return ss.peryear(annual_rate).to_prob(self.dt)
+
     @staticmethod
     def _interpolate(vals: list, t):
         vals = sorted(vals, key=lambda x: x[0])  # Make sure values are sorted
@@ -407,6 +568,20 @@ class HIV(BaseSTI):
         self.pars.p_hiv_death.set(0)
         self.pars.p_hiv_death.set(p_death)  # Set the death probability function
         hiv_deaths = self.pars.p_hiv_death.filter(off_art)
+
+        # ARTMortalityTable-style hazard: opt-in (pars.use_art_mortality_table), gives
+        # on-ART agents a nonzero, age/sex/adherence/duration-stratified mortality risk
+        # instead of the default (off-ART-only hazard, i.e. zero mortality while on ART)
+        if self.pars.use_art_mortality_table:
+            on_art = (self.infected & self.on_art).uids
+            if len(on_art):
+                p_death_on_art = self.get_art_mortality_hazard(on_art)
+                self.pars.p_hiv_death.set(0)
+                self.pars.p_hiv_death.set(p_death_on_art)
+                on_art_deaths = self.pars.p_hiv_death.filter(on_art)
+                if len(on_art_deaths):
+                    hiv_deaths = ss.uids(np.concatenate([hiv_deaths, on_art_deaths]))
+
         if len(hiv_deaths):
             self.ti_dead[hiv_deaths] = ti
             self.sim.people.request_death(hiv_deaths)

--- a/stisim/interventions/hiv_interventions.py
+++ b/stisim/interventions/hiv_interventions.py
@@ -222,6 +222,11 @@ class ART(ss.Intervention):
                           to HIV (default 0.96). Applied to both prenatal (MaternalNet)
                           and postnatal (BreastfeedingNet) transmission. Set to 1.0 for
                           complete protection (previous default behavior).
+        p_effective_art:  probability that a newly-initiated agent achieves viral
+                          suppression (effective ART) rather than non-suppressive ART
+                          (default: ss.bernoulli(p=1.0), i.e. always effective). Forwarded
+                          to HIV.start_art(); see HIVPars.p_effective_art for the default
+                          used if ART is not present in the sim at all.
         smoothness:       interpolation smoothness (0=linear, default)
         format_priority:  when both n_art and p_art are non-NaN, prefer this format
                           ('n' or 'p', default 'n')
@@ -230,6 +235,9 @@ class ART(ss.Intervention):
 
         # Simple: 80% of infected on ART
         art = sti.ART(coverage=0.8)
+
+        # 70% of newly-initiated agents achieve viral suppression
+        art = sti.ART(coverage=0.8, p_effective_art=0.7)
 
         # Time-varying coverage
         art = sti.ART(coverage={'year': [2000, 2010, 2025], 'value': [0, 0.5, 0.9]})
@@ -255,6 +263,7 @@ class ART(ss.Intervention):
             pmtct_efficacy=0.96,  # How much maternal ART reduces infant susceptibility
                                    # to HIV via MaternalNet (prenatal) and BreastfeedingNet
                                    # (postnatal). Conceptually like infant PrEP.
+            p_effective_art=ss.bernoulli(p=1.0),  # Probability a newly-initiated agent achieves viral suppression
         )
         self.update_pars(pars, **kwargs)
 
@@ -400,7 +409,7 @@ class ART(ss.Intervention):
             choices = np.argsort(weights)[:n]
             start_uids = awaiting_art_uids[choices]
 
-        hiv.start_art(start_uids)
+        hiv.start_art(start_uids, p_effective_art=self.pars.p_effective_art)
 
         return
 

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -639,9 +639,9 @@ def test_par_ranges(n_agents=1000):
 
     # [lo, hi, result_key, dur] — higher par values should produce higher result values
     par_effects = dict(
-        beta_m2f     = [0.01,  0.2,  'cum_infections', 10],
-        init_prev    = [0.01,  0.1,  'cum_infections', 10],
-        art_efficacy = [0.96,  0.5,  'cum_deaths',     10],
+        beta_m2f              = [0.01,  0.2,  'cum_infections', 10],
+        init_prev              = [0.01,  0.1,  'cum_infections', 10],
+        effective_art_efficacy = [0.96,  0.5,  'cum_deaths',     10],
     )
 
     # Build all sims and run in one parallel call


### PR DESCRIPTION
- [x] Add EffectiveART/NonSuppressiveART tracking, to enable 90-90-90 metrics tracking
- [x] Allow transmission to vary by EffectiveART/NonSuppressiveART status
- [x] Allow mortality to vary by EffectiveART/NonSuppressiveART status, as well as age, sex, and duration on ART, following ARTMortalityTable from EMOD-HIV
- [x] Add new diagram to the docs to illustrate how the ART adherence stuff can be used to change mortality

Changes to ART adherence. EffectiveART vs NonSuppressiveART allows us to differentiate whether or not an individual adheres to ART. ART status is now one of four things: `art_naive` (replacing never_art) `on_effective_art`, `on_nonsuppressive_art`, and `art_discontinued`. When initiating we pass a new argument `p_effective_art` (defaults to 1.0) which specifies what fraction of individuals who initiate ART reach `on_effective_art status`

ART adherence affects transmission rates - When initiating, the transmission blocking efficacy is now respectively either `effective_art_efficacy=0.96` or `nonsupp_art_efficacy=0.35`. 

ART adherence affects mortality rates - we have borrowed a lookup table from EMOD-HIV, so now mortality varies by Age, Sex, ART adherence, and time since initiating ART.