### PR TITLE
feat(hiv): expose CD4-mortality rate array and add rel_death scalars

### DIFF
--- a/stisim/diseases/hiv.py
+++ b/stisim/diseases/hiv.py
@@ -29,6 +29,12 @@ class HIVPars(BaseSTIPars):
         self.dur_latent = ss.lognorm_ex(ss.years(10), ss.years(3))  # Duration of latent, untreated HIV infection
         self.dur_falling = ss.lognorm_ex(ss.years(3), ss.years(1))  # Duration of late-stage HIV when CD4 counts fall
         self.p_hiv_death = ss.bernoulli(p=0)  # Death from HIV-related complications; set by make_p_hiv_death()
+        # CD4-stratified per-year mortality (Marston 2007, Todd 2007). Bins are
+        # upper edges of a descending CD4 ladder.
+        self.cd4_death_bins = np.array([1000, 500, 350, 200, 50, 0])
+        self.cd4_death_rates = np.array([0.003, 0.003, 0.005, 0.01, 0.05, 0.30])
+        self.rel_death = 1.0          # Scales HIV death rate for all infected agents
+        self.rel_death_on_art = 0.5   # Additional scale for on-ART agents; Marston 2007 / Kranzer 2013 African ART cohorts show ~30-50% of untreated mortality. Set to 0 to disable on-ART deaths.
         self.include_aids_deaths = True
 
         # Transmission
@@ -306,12 +312,12 @@ class HIV(BaseSTI):
         """
         Calculate per-timestep HIV death probability based on current CD4 count.
 
-        Uses CD4-stratified annual mortality rates, digitized into bins. Rates are
-        converted from per-year to per-timestep probabilities.
+        Reads the CD4 bin edges and per-year mortality rates from
+        ``self.pars.cd4_death_bins`` / ``self.pars.cd4_death_rates``, then
+        converts to per-timestep probabilities.
         """
-        cd4_bins = np.array([1000, 500, 350, 200, 50, 0])
-        p_hiv_death = ss.peryear(np.array([0.003, 0.003, 0.005, 0.01, 0.05, 0.300])).to_prob(self.dt)
-        return p_hiv_death[np.digitize(self.cd4[uids], cd4_bins)]
+        p_hiv_death = ss.peryear(self.pars.cd4_death_rates).to_prob(self.dt)
+        return p_hiv_death[np.digitize(self.cd4[uids], self.pars.cd4_death_bins)]
 
     @staticmethod
     def _interpolate(vals: list, t):
@@ -397,11 +403,15 @@ class HIV(BaseSTI):
 
         # Update deaths. We capture deaths from AIDS (i.e., when CD4 count drops to ~0) as well as deaths from
         # serious HIV-related illnesses, which can occur throughout HIV.
-        off_art = (self.infected & ~self.on_art).uids
-        p_death = self.make_p_hiv_death(uids=off_art)
+        eligible = self.infected.uids
+        p_death = self.make_p_hiv_death(uids=eligible)
+        # Scale: rel_death for everyone, additionally rel_death_on_art for on-ART agents
+        p_death = p_death * self.pars.rel_death
+        on_art_mask = self.on_art[eligible]
+        p_death[on_art_mask] = p_death[on_art_mask] * self.pars.rel_death_on_art
         self.pars.p_hiv_death.set(0)
         self.pars.p_hiv_death.set(p_death)  # Set the death probability function
-        hiv_deaths = self.pars.p_hiv_death.filter(off_art)
+        hiv_deaths = self.pars.p_hiv_death.filter(eligible)
         if len(hiv_deaths):
             self.ti_dead[hiv_deaths] = ti
             self.sim.people.request_death(hiv_deaths)

--- a/tests/test_hiv.py
+++ b/tests/test_hiv.py
@@ -765,6 +765,46 @@ def test_mtct_rates_in_range():
     return dict(p_no_art=p_no_art, p_pmtct=p_pmtct)
 
 
+@sc.timer()
+def test_rel_death_scales_hiv_mortality(n_agents=3000):
+    """rel_death and rel_death_on_art both scale HIV mortality monotonically.
+
+    Sanity check that the exposed scalars route through to the death
+    probability computed in HIV.step. Runs a small sim under three settings
+    of each scalar and checks cumulative HIV deaths are monotonic in each.
+    """
+    sc.heading("Ensuring rel_death and rel_death_on_art scale HIV deaths")
+
+    def _deaths(rel_death=1.0, rel_death_on_art=0.5):
+        test_intv = sti.HIVTest(test_prob_data=1, dt_scale=False)
+        art = sti.ART(art_initiation=1.0)
+        hiv = sti.HIV(init_prev=1.0, beta_m2f=0.0,
+                      rel_death=rel_death, rel_death_on_art=rel_death_on_art,
+                      dur_on_art=ss.constant(v=ss.years(50)))
+        sim = build_testing_sim(n_agents=n_agents, duration=15,
+                                pregnancy=None, death=None,
+                                diseases=[hiv], interventions=[test_intv, art])
+        sim.run()
+        return int(sim.diseases.hiv.results.new_deaths.sum())
+
+    # rel_death monotonically increases total deaths
+    d1 = _deaths(rel_death=0.5)
+    d2 = _deaths(rel_death=1.0)
+    d3 = _deaths(rel_death=2.0)
+    assert d1 < d2 < d3, (
+        f'rel_death should scale HIV deaths monotonically; got {d1}, {d2}, {d3}'
+    )
+
+    # rel_death_on_art monotonically increases total deaths (via the on-ART
+    # subset). rel_death=1 fixed; only the on-ART scale varies.
+    z0 = _deaths(rel_death_on_art=0.0)
+    z1 = _deaths(rel_death_on_art=1.0)
+    z2 = _deaths(rel_death_on_art=3.0)
+    assert z0 < z1 < z2, (
+        f'rel_death_on_art should scale on-ART HIV deaths monotonically; got {z0}, {z1}, {z2}'
+    )
+
+
 if __name__ == '__main__':
     do_plot = True
     sc.options(interactive=do_plot)
@@ -792,6 +832,7 @@ if __name__ == '__main__':
     test_cd4_falls_after_ART_dropout()
     test_rel_trans_rises_after_ART_dropout()
     test_rel_sus_age()
+    test_rel_death_scales_hiv_mortality()
 
     sc.heading("Total:")
     timer.toc()


### PR DESCRIPTION
The CD4-stratified HIV mortality table and its off-ART-only filter were hardcoded inside `HIV.make_p_hiv_death` and `HIV.step`. Coming out of a Zimbabwe calibration exercise where the sim under-counted AIDS deaths by 3-4x after ART scale-up, this makes both aspects tunable.

Changes to `HIVPars`:
- `cd4_death_bins`: descending CD4 bin edges (default matches old hardcoded value)
- `cd4_death_rates`: per-year mortality for each bin (default matches old hardcoded value)
- `rel_death`: scale on all HIV deaths (default 1.0)
- `rel_death_on_art`: additional scale for on-ART agents (default 0.5, from Marston 2007 / Kranzer 2013 African ART cohorts showing on-ART mortality ~30-50% of untreated at each CD4 level)

Behaviour change: on-ART agents are now included in the stochastic HIV-death channel at 0.5x their untreated CD4-bin rate, where before they were excluded entirely. Set `rel_death_on_art=0` to preserve the pre-change behaviour (on-ART agents die only via CD4=0).

Added `test_rel_death_scales_hiv_mortality` to tests/test_hiv.py.