### PR TITLE
Syphilis fix for ABOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the codebase are documented in this file.
 
 ## Version 1.5.9 (TBC)
 
+### Diseases
+- Syphilis: fix `new_nnds` and `new_stillborns` (and the derived `new_congenital_deaths` / `cum_congenital_deaths`) always reading 0. `step_state` cleared `ti_nnd` / `ti_stillborn` to `nan` when scheduling the deaths, so the `== ti` check in `update_results` (which runs after) never matched. Mirror the existing `_new_congenital_count` pattern: stash the counts before clearing and read from the stash in `update_results`.
+
 ## Version 1.5.8 (2026-06-25)
 
 ### Logistics

--- a/stisim/diseases/syphilis.py
+++ b/stisim/diseases/syphilis.py
@@ -474,6 +474,10 @@ class Syphilis(BaseSTI):
         # Congenital syphilis deaths
         nnd = (self.ti_nnd <= ti).uids
         stillborn = (self.ti_stillborn <= ti).uids
+        # Store counts for update_results: ti_nnd / ti_stillborn are cleared
+        # below so an `== ti` check in update_results would always read 0.
+        self._new_nnd_count = len(nnd)
+        self._new_stillborn_count = len(stillborn)
         if len(nnd):
             self.sim.people.request_death(nnd)
             self.ti_nnd[nnd] = np.nan  # Clear after firing
@@ -583,9 +587,10 @@ class Syphilis(BaseSTI):
             deliv_prev = cond_prob(self.infected, ppl.pregnancy.ti_delivery == ti)
             self.results['delivery_prevalence'][ti] = deliv_prev
 
-        # Congenital results
-        self.results['new_nnds'][ti]       = np.count_nonzero(self.ti_nnd == ti)
-        self.results['new_stillborns'][ti] = np.count_nonzero(self.ti_stillborn == ti)
+        # Congenital results: read from stashes set in step_state before
+        # ti_nnd / ti_stillborn / ti_congenital were cleared to nan.
+        self.results['new_nnds'][ti]       = getattr(self, '_new_nnd_count', 0)
+        self.results['new_stillborns'][ti] = getattr(self, '_new_stillborn_count', 0)
         self.results['new_congenital'][ti] = getattr(self, '_new_congenital_count', 0)
         self.results['new_congenital_deaths'][ti] = self.results['new_nnds'][ti] + self.results['new_stillborns'][ti]
         self.results['new_deaths'][ti] = np.count_nonzero(self.ti_dead == ti)


### PR DESCRIPTION
step_state clears self.ti_nnd / self.ti_stillborn to nan when scheduling the death; update_results runs after step_state and counted with `np.count_nonzero(self.ti_nnd == ti)`, which never matched because the slot was already nan. Result: cum_congenital_deaths was permanently 0.

Mirror the existing _new_congenital_count fix: stash the counts before clearing in step_state, read from the stash in update_results.

Verified with a Zimbabwe sim (10k agents, 1985-2040): SOC reports ~108k cumulative congenital deaths (was 0); POC reports ~100k (consistent direction).