### PR TITLE
fix: SyphTest crashes with default eligibility; document stratified test_prob_data

### DIFF
--- a/docs/user_guide/interventions/interventions.md
+++ b/docs/user_guide/interventions/interventions.md
@@ -66,6 +66,40 @@ syndromic = sti.SymptomaticTesting(
 )
 ```
 
+### SyphTest
+
+Base class for syphilis testing (`ANCSyphTest` and `NewbornSyphTest` subclass it). In addition to the scalar/array/`TimeSeries` forms `test_prob_data` accepts everywhere else, `SyphTest` also accepts a long-format `DataFrame` stratified by risk group, sex, and sex-work status -- one row per `(year, risk_group, sex, sw)` combination:
+
+```python
+import pandas as pd
+
+test_prob_data = pd.DataFrame([
+    {'year': 2000, 'risk_group': 0, 'sex': 'female', 'sw': 0, 'symp_test_prob': 0.15},
+    {'year': 2000, 'risk_group': 1, 'sex': 'female', 'sw': 0, 'symp_test_prob': 0.15},
+    {'year': 2000, 'risk_group': 2, 'sex': 'female', 'sw': 0, 'symp_test_prob': 0.38},
+    {'year': 2000, 'risk_group': 0, 'sex': 'female', 'sw': 1, 'symp_test_prob': 0.45},
+    {'year': 2000, 'risk_group': 0, 'sex': 'male',   'sw': 0, 'symp_test_prob': 0.10},
+    {'year': 2024, 'risk_group': 0, 'sex': 'female', 'sw': 0, 'symp_test_prob': 0.20},
+    # ... one row per (year, risk_group, sex, sw) stratum
+])
+
+symp_test = sti.SyphTest(
+    product=syph_dx,
+    test_prob_data=test_prob_data,
+    start=2000,
+)
+```
+
+| Column | Description |
+|--------|-------------|
+| `year` | Calendar year; strata are interpolated onto the sim's timestep grid. |
+| `risk_group` | Integer risk-group index, `0` .. `n_risk_groups - 1` (set by the sexual network, default 3). |
+| `sex` | `'female'` or `'male'`. |
+| `sw` | `1` for sex workers and their clients, `0` otherwise. |
+| `symp_test_prob` | Testing probability for that stratum-year (annualized, then scaled per-timestep like `STITest`). |
+
+Every `(risk_group, sex, sw)` combination present in the sim must have a row for every `year`, or the missing strata will have no scheduled tests.
+
 ## Treatment
 
 ### STITreatment

--- a/stisim/interventions/base_interventions.py
+++ b/stisim/interventions/base_interventions.py
@@ -205,8 +205,8 @@ class STITest(ss.Intervention):
         """
         # Select UIDs for testing based on eligibility and test_prob
         accept_uids = ss.uids()
-        if callable(self.eligibility):
-            eligible_uids = self.check_eligibility()  # Apply eligiblity - uses base class from ss.Intervention
+        if self.eligibility is None or callable(self.eligibility):
+            eligible_uids = self.check_eligibility()  # Apply eligiblity - uses base class from ss.Intervention; None -> everyone
         else:
             eligible_uids = self.eligibility
         if len(eligible_uids):

--- a/tests/test_sti_interventions.py
+++ b/tests/test_sti_interventions.py
@@ -1,0 +1,62 @@
+"""
+Test STI testing interventions: STITest/SyphTest eligibility and coverage input formats
+
+Tests cover:
+    - STITest.get_testers works with the default eligibility (None -> everyone), not just
+      an explicit eligibility function (regression test for GH #537)
+    - SyphTest accepts a DataFrame of test probabilities stratified by
+      risk group/sex/sex-work status, as documented in the interventions user guide
+"""
+
+import pandas as pd
+import sciris as sc
+import starsim as ss
+import stisim as sti
+
+n_agents = 500
+
+
+def make_syph_dx():
+    df = pd.DataFrame({'state': ['primary', 'secondary', 'latent'], 'p_positive': [0.85, 0.98, 0.7]})
+    return sti.SyphDx(df)
+
+
+def test_stitest_default_eligibility():
+    """ STITest/SyphTest must not crash when eligibility is left at its default (None) """
+    sc.heading('Testing STITest with default eligibility...')
+
+    test = sti.SyphTest(product=make_syph_dx(), test_prob_data=0.2, start=2000)
+    sim = ss.Sim(n_agents=n_agents, start=2000, stop=2005, dt=ss.months(1),
+                 diseases=sti.Syphilis(), networks=sti.StructuredSexual(),
+                 interventions=test, demographics=[ss.Births(), ss.Deaths()], verbose=0)
+    sim.run()
+
+    assert sim.results.syphtest.new_tests.sum() > 0, 'Expected some agents to be tested with default eligibility'
+    return sim
+
+
+def test_syphtest_stratified_dataframe():
+    """ SyphTest accepts a long-format DataFrame stratified by risk_group/sex/sw """
+    sc.heading('Testing SyphTest with a stratified test_prob_data DataFrame...')
+
+    test_prob_data = pd.DataFrame([
+        {'year': 2000, 'risk_group': rg, 'sex': sex, 'sw': sw, 'symp_test_prob': 0.15}
+        for rg in [0, 1, 2] for sex in ['female', 'male'] for sw in [0, 1]
+    ] + [
+        {'year': 2024, 'risk_group': rg, 'sex': sex, 'sw': sw, 'symp_test_prob': 0.30}
+        for rg in [0, 1, 2] for sex in ['female', 'male'] for sw in [0, 1]
+    ])
+
+    test = sti.SyphTest(product=make_syph_dx(), test_prob_data=test_prob_data, start=2000)
+    sim = ss.Sim(n_agents=n_agents, start=2000, stop=2010, dt=ss.months(1),
+                 diseases=sti.Syphilis(), networks=sti.StructuredSexual(),
+                 interventions=test, demographics=[ss.Births(), ss.Deaths()], verbose=0)
+    sim.run()
+
+    assert sim.results.syphtest.new_tests.sum() > 0, 'Expected some agents to be tested from the stratified DataFrame'
+    return sim
+
+
+if __name__ == '__main__':
+    test_stitest_default_eligibility()
+    test_syphtest_stratified_dataframe()


### PR DESCRIPTION
## Summary
- `STITest.get_testers` treated `eligibility=None` (the default) as a non-callable UID list instead of falling back to `check_eligibility()`, which already handles `None -> everyone`. Any `SyphTest`/`STITest` without an explicit `eligibility` function crashed on the first step.
- Documents the `risk_group`/`sex`/`sw`-stratified DataFrame format for `SyphTest.test_prob_data` in the interventions user guide.

Closes #537

## Test plan
- [x] New regression tests in `tests/test_sti_interventions.py`: default-eligibility `SyphTest` runs without crashing; stratified `test_prob_data` DataFrame produces tests
- [x] `tests/test_anc_test.py` (existing rc1.5.10 suite) still passes